### PR TITLE
Rip out `OllamaLLM` from top level import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 .pytest_cache
 .ruff_cache
 .env
+import_profile.txt
 
 
 # Virtual environments

--- a/src/llm_agents_from_scratch/__init__.py
+++ b/src/llm_agents_from_scratch/__init__.py
@@ -6,11 +6,10 @@ from llm_agents_from_scratch._version import VERSION
 # ruff: noqa: F403, F401
 from .core import *
 from .core import __all__ as _core_all
-from .llms import OllamaLLM
 from .tools import *
 from .tools import __all__ as _tool_all
 
 __version__ = VERSION
 
 
-__all__ = sorted(_core_all + _tool_all + ["OllamaLLM"])  # noqa: PLE0605
+__all__ = sorted(_core_all + _tool_all)  # noqa: PLE0605


### PR DESCRIPTION
`import ollama` at top level significantly makes for a long import time. Ripping it out as a result.