### PR TITLE
Clean up `examples/ch02.ipynb`

### DIFF
--- a/examples/ch02.ipynb
+++ b/examples/ch02.ipynb
@@ -5,7 +5,7 @@
    "id": "c67463f6-e3b2-4d90-99b9-6be2013a2f44",
    "metadata": {},
    "source": [
-    "# Examples from Chapter 2"
+    "# Examples from Chapter 2 — Working with Tools"
    ]
   },
   {
@@ -15,17 +15,24 @@
    "source": [
     "## Setup Instructions\n",
     "\n",
-    "To run this notebook, you'll need to have our `llm-agents-from-scratch` library installed. There a few ways to do this, as listed below:"
+    "To ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n",
+    "\n",
+    "```sh\n",
+    "uv run --with jupyter jupyter lab\n",
+    "```\n",
+    "\n",
+    "Alternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPi by uncommenting the cell below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "06a84096-e6c3-442b-920e-a54febd8feba",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!uv pip install llm-agents-from-scratch"
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPi\n",
+    "# !pip install llm-agents-from-scratch"
    ]
   },
   {
@@ -33,7 +40,7 @@
    "id": "936a6028-6896-4be5-a77a-7fbe52ef8a05",
    "metadata": {},
    "source": [
-    "### Example 2.1: Creating a `ToolCall` object"
+    "### Example 1: Creating a `ToolCall` object"
    ]
   },
   {
@@ -55,17 +62,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "0fbcb637-e5f8-4b0b-9341-3411bd85dd59",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ToolCall(id_='280b1b51-01d5-4690-9e68-5dcb31cb6904', tool_name='web-search-tool', arguments={'query': 'Croissant bakeries in New York City and their prices.'})"
+       "ToolCall(id_='77148f15-74d5-4b38-9e9f-d39620bb7031', tool_name='web-search-tool', arguments={'query': 'Croissant bakeries in New York City and their prices.'})"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -79,7 +86,7 @@
    "id": "79f0e4f3-50a6-4f32-bd69-f902421cbf5a",
    "metadata": {},
    "source": [
-    "### Example 2.2: Creating a `ToolCallResult` object"
+    "### Example 2: Creating a `ToolCallResult` object"
    ]
   },
   {
@@ -105,17 +112,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "543e6bf2-7743-4868-9642-b23435f8b799",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ToolCallResult(tool_call_id='280b1b51-01d5-4690-9e68-5dcb31cb6904', content={'search_results': {'hits': [{'data': '...'}]}}, error=False)"
+       "ToolCallResult(tool_call_id='77148f15-74d5-4b38-9e9f-d39620bb7031', content={'search_results': {'hits': [{'data': '...'}]}}, error=False)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -129,12 +136,12 @@
    "id": "ee3c0d51-ffea-482a-bbca-65cc9ee00e10",
    "metadata": {},
    "source": [
-    "### Example 2.3: The Hailstone Tool"
+    "### Example 3: The Hailstone Tool"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "12b750fd-ed06-4e73-be09-b338e15fb1dd",
    "metadata": {},
    "outputs": [],
@@ -201,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "6bda157e-56ee-4d96-94f6-fad78da3237e",
    "metadata": {},
    "outputs": [
@@ -209,7 +216,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tool_call_id='932e5aaa-227a-4513-93a5-9902b4c786ad' content=10 error=False\n"
+      "tool_call_id='935bde41-5805-4bbe-9828-93b06625ab36' content=10 error=False\n"
      ]
     }
    ],
@@ -230,12 +237,12 @@
    "id": "02b5dece-98d2-431a-98e2-4cb66e1db425",
    "metadata": {},
    "source": [
-    "### Example 2.4: The Hailstone step function (to be used in `SimpleFunctionTool`)"
+    "### Example 4: The Hailstone step function (to be used in `SimpleFunctionTool`)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "10cdefd1-1f38-457d-bb1c-4eb5093d74c2",
    "metadata": {},
    "outputs": [],
@@ -252,12 +259,12 @@
    "id": "1865a68c-3aa3-436b-9b0b-a20e1215bcce",
    "metadata": {},
    "source": [
-    "### Example 2.5: Hailstone step function as a `SimpleFunctionTool`"
+    "### Example 5: Hailstone step function as a `SimpleFunctionTool`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "e898eb77-9b78-4321-ae78-ba539045e2a5",
    "metadata": {},
    "outputs": [
@@ -287,12 +294,12 @@
    "id": "0ffc5e16-ce50-426f-a40a-5533940812f3",
    "metadata": {},
    "source": [
-    "### Example 2.6: Running the previous `tool_call` with the alternative implementation of Hailstone tool"
+    "### Example 6: Running the previous Hailstone `tool_call` with the alternative `SimpleFunctionTool` implementation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "id": "a986c945-1939-488d-8391-1a116236ebbe",
    "metadata": {},
    "outputs": [],
@@ -309,17 +316,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "id": "90501af6-da70-4756-97f6-254fb27fe205",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ToolCallResult(tool_call_id='67439bf7-0209-4f25-84c7-ca7308133ede', content='10', error=False)"
+       "ToolCallResult(tool_call_id='b37fa814-8aa4-49a3-9037-b3c73d9817a5', content='10', error=False)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -333,12 +340,12 @@
    "id": "3ef4b891-d557-47e3-97a0-e75889bcdc35",
    "metadata": {},
    "source": [
-    "### Example 2.7: Example usage of `PydanticFunctionTool`"
+    "### Example 7: Example usage of `PydanticFunctionTool`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "id": "3a26f502-ec16-4e8c-939d-6b04a0e617b9",
    "metadata": {},
    "outputs": [],
@@ -356,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "id": "3e47b88e-79a5-4160-91a1-fe3ecf0274ac",
    "metadata": {},
    "outputs": [],
@@ -368,17 +375,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "id": "45297673-c3e5-4e65-a550-1d7ecc941c36",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<llm_agents_from_scratch.tools.pydantic_function.PydanticFunctionTool at 0x706b6c185550>"
+       "<llm_agents_from_scratch.tools.pydantic_function.PydanticFunctionTool at 0x71ba2da6c590>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -386,14 +393,6 @@
    "source": [
     "tool"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "285afcdd-6979-445d-9fae-b4a8077e3192",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds instructions for setting up .venv and simplifies numbering for examples.