### PR TITLE
feat: implement `Skill.read_body()`

### DIFF
--- a/src/llm_agents_from_scratch/skills/discovery.py
+++ b/src/llm_agents_from_scratch/skills/discovery.py
@@ -55,16 +55,17 @@ def validate_skill_dir(
         )
 
     try:
-        with open(skill_md_path, "r") as f:
+        with open(skill_md_path, "r", encoding="utf-8") as f:
             skill_md = f.read()
-
-        _, frontmatter_str, body = skill_md.split("---", 2)
-        frontmatter = yaml.safe_load(frontmatter_str)
-        info = SkillInfo.model_validate(frontmatter)
     except OSError as e:
         raise SkillValidationError(
             f"Failed to read SKILL.md at {skill_md_path}: {e}",
         ) from e
+
+    try:
+        _, frontmatter_str, body = skill_md.split("---", 2)
+        frontmatter = yaml.safe_load(frontmatter_str)
+        info = SkillInfo.model_validate(frontmatter)
     except (ValueError, ValidationError, yaml.YAMLError) as e:
         raise InvalidFrontmatterError(str(e)) from e
 

--- a/src/llm_agents_from_scratch/skills/skill.py
+++ b/src/llm_agents_from_scratch/skills/skill.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from typing import Literal
 
 from ..data_structures.skill import SkillInfo
-from ..errors import EmptySkillBodyError
+from ..errors import (
+    EmptySkillBodyError,
+    InvalidFrontmatterError,
+    SkillValidationError,
+)
 from .constants import CATALOG_SKILL_TEMPLATE
 
 
@@ -43,15 +47,28 @@ class Skill:
     def read_body(self) -> str:
         """Return body content as string.
 
-        Note: Most error conditions (e.g. malformed frontmatter, missing
-            delimiters) are caught during discovery. EmptySkillBodyError can
-            only be raised if the skill file is modified between discovery
+        Note: Most error conditions are caught during discovery. These errors
+            can only be raised if the skill file is modified between discovery
             and activation.
-        """
-        with open(self.location, "r") as f:
-            skill_md = f.read()
 
-        _, _, body = skill_md.split("---", 2)
+        Raises:
+            SkillValidationError: If the file cannot be read.
+            InvalidFrontmatterError: If the frontmatter delimiters are missing
+                or malformed.
+            EmptySkillBodyError: If the body is empty or whitespace-only.
+        """
+        try:
+            with open(self.location, "r", encoding="utf-8") as f:
+                skill_md = f.read()
+        except OSError as e:
+            raise SkillValidationError(
+                f"Failed to read SKILL.md at {self.location}: {e}",
+            ) from e
+
+        try:
+            _, _, body = skill_md.split("---", 2)
+        except ValueError as e:
+            raise InvalidFrontmatterError(str(e)) from e
 
         if not body.strip():
             raise EmptySkillBodyError

--- a/tests/skills/test_skill.py
+++ b/tests/skills/test_skill.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from llm_agents_from_scratch.data_structures.skill import SkillInfo
-from llm_agents_from_scratch.errors import EmptySkillBodyError
+from llm_agents_from_scratch.errors import (
+    EmptySkillBodyError,
+    InvalidFrontmatterError,
+    SkillValidationError,
+)
 from llm_agents_from_scratch.skills.skill import Skill
 
 
@@ -55,6 +59,27 @@ def test_skill_read_body_raises_on_empty_body(tmp_path: Path) -> None:
     skill = Skill(info=info, location=skill_md, scope="project")
 
     with pytest.raises(EmptySkillBodyError):
+        skill.read_body()
+
+
+def test_skill_read_body_raises_on_unreadable_file(tmp_path: Path) -> None:
+    """Tests Skill.read_body() raises SkillValidationError if unreadable."""
+    skill_md = tmp_path / "SKILL.md"
+    info = SkillInfo(name="my-skill", description="Does things.")
+    skill = Skill(info=info, location=skill_md, scope="project")
+
+    with pytest.raises(SkillValidationError):
+        skill.read_body()
+
+
+def test_skill_read_body_raises_on_missing_delimiters(tmp_path: Path) -> None:
+    """Tests Skill.read_body() raises InvalidFrontmatterError if no delims."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("name: my-skill\ndescription: Does things.\n")
+    info = SkillInfo(name="my-skill", description="Does things.")
+    skill = Skill(info=info, location=skill_md, scope="project")
+
+    with pytest.raises(InvalidFrontmatterError):
         skill.read_body()
 
 


### PR DESCRIPTION
## Summary

Implements `Skill.read_body()` in `skills/skill.py`. Reads the `SKILL.md` file at `self.location`, strips the YAML frontmatter, and returns the markdown body stripped of leading/trailing whitespace. Raises `EmptySkillBodyError` if the body is empty (can only occur if the file is modified between discovery and activation). Adds unit tests for both the happy path and the empty body case. Closes #415.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Notebook update
- [ ] Documentation / capstone
- [ ] Chore (deps, CI, tooling)

## Checklist

- [x] Tests pass (`make test`)
- [ ] Linting is clean (`make lint`)
- [x] Changes are focused and minimal
