### PR TITLE
Refactor _SKILL_SUBDIRS to use .agents/skills only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - feat: handle `disable-model-invocation` flag and shadowing warnings (#429)
 - feat: inject skills catalog into `TaskHandler` system prompt (#423)
 - feat: add `skills_scopes` to `LLMAgent` and skill discovery to `TaskHandler` (#424)
-- refactor: introduce `SkillScope` enum and `get_skills_paths()` utility (#422)
+- refactor: introduce `SkillScope` enum and `get_skills_path()` utility (#422)
 - feat: implement `Skill.read_body()` (#419)
 - feat: implement `Skill.catalog()` (#418)
 - feat: implement validate_skill_dir() (#417)

--- a/src/llm_agents_from_scratch/skills/discovery.py
+++ b/src/llm_agents_from_scratch/skills/discovery.py
@@ -20,7 +20,7 @@ from ..errors import (
 )
 from .constants import MAX_NAME_LENGTH
 from .skill import Skill
-from .utils import get_skills_paths
+from .utils import get_skills_path
 
 
 def validate_skill_dir(
@@ -110,41 +110,41 @@ def discover_skills(scopes: list[SkillScope]) -> dict[str, Skill]:
     """
     skills: dict[str, Skill] = {}
     for scope in scopes:
-        for skills_path in get_skills_paths(scope):
-            if not skills_path.exists():
+        skills_path = get_skills_path(scope)
+        if not skills_path.exists():
+            continue
+
+        for skill_dir in sorted(skills_path.iterdir()):
+            if not skill_dir.is_dir():
                 continue
 
-            for skill_dir in sorted(skills_path.iterdir()):
-                if not skill_dir.is_dir():
-                    continue
-
-                # validate dir is an actual Skill dir
-                try:
-                    frontmatter, skill_warnings = validate_skill_dir(skill_dir)
-                except SkillValidationError as e:
-                    warnings.warn(
-                        str(e),
-                        SkillSkippedWarning,
-                        stacklevel=2,
-                    )
-                    continue
-
-                for w in skill_warnings:
-                    warnings.warn(str(w), type(w), stacklevel=2)
-
-                if frontmatter.name in skills:
-                    shadowed_scope = skills[frontmatter.name].scope
-                    warnings.warn(
-                        f"Skill '{frontmatter.name}' ({scope.value} scope)"
-                        f" shadows an existing skill of the same name"
-                        f" ({shadowed_scope.value} scope).",
-                        SkillShadowedWarning,
-                        stacklevel=2,
-                    )
-                skills[frontmatter.name] = Skill(
-                    frontmatter=frontmatter,
-                    location=(skill_dir / "SKILL.md").resolve(),
-                    scope=scope,  # type: ignore[arg-type]
+            # validate dir is an actual Skill dir
+            try:
+                frontmatter, skill_warnings = validate_skill_dir(skill_dir)
+            except SkillValidationError as e:
+                warnings.warn(
+                    str(e),
+                    SkillSkippedWarning,
+                    stacklevel=2,
                 )
+                continue
+
+            for w in skill_warnings:
+                warnings.warn(str(w), type(w), stacklevel=2)
+
+            if frontmatter.name in skills:
+                shadowed_scope = skills[frontmatter.name].scope
+                warnings.warn(
+                    f"Skill '{frontmatter.name}' ({scope.value} scope)"
+                    f" shadows an existing skill of the same name"
+                    f" ({shadowed_scope.value} scope).",
+                    SkillShadowedWarning,
+                    stacklevel=2,
+                )
+            skills[frontmatter.name] = Skill(
+                frontmatter=frontmatter,
+                location=(skill_dir / "SKILL.md").resolve(),
+                scope=scope,  # type: ignore[arg-type]
+            )
 
     return skills

--- a/src/llm_agents_from_scratch/skills/utils.py
+++ b/src/llm_agents_from_scratch/skills/utils.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from ..data_structures.skill import SkillScope
 
-_SKILL_SUBDIRS = [".from_scratch/skills", ".agent/skills"]
+_SKILL_SUBDIR = ".agents/skills"
 
 
-def get_skills_paths(scope: SkillScope) -> list[Path]:
+def get_skills_path(scope: SkillScope) -> Path:
     """Return skill directories to scan for a given scope.
 
     Paths are resolved at call time so that changes to the working directory
@@ -20,4 +20,4 @@ def get_skills_paths(scope: SkillScope) -> list[Path]:
         List of paths to scan for skills.
     """
     base = Path.cwd() if scope == SkillScope.PROJECT else Path.home()
-    return [base / subdir for subdir in _SKILL_SUBDIRS]
+    return base / _SKILL_SUBDIR

--- a/tests/skills/test_constants.py
+++ b/tests/skills/test_constants.py
@@ -5,38 +5,33 @@ from pathlib import Path
 import pytest
 
 from llm_agents_from_scratch.data_structures.skill import SkillScope
-from llm_agents_from_scratch.skills.utils import get_skills_paths
+from llm_agents_from_scratch.skills.utils import get_skills_path
 
 
-def test_get_skills_paths_project_returns_cwd_relative_paths() -> None:
-    """Tests project scope paths are resolved relative to cwd."""
-    paths = get_skills_paths(SkillScope.PROJECT)
+def test_get_skills_path_project_returns_cwd_relative_paths() -> None:
+    """Tests project scope path is resolved relative to cwd."""
+    path = get_skills_path(SkillScope.PROJECT)
 
-    assert isinstance(paths, list)
-    for path in paths:
-        assert isinstance(path, Path)
-        assert path.is_absolute()
-        assert str(path).startswith(str(Path.cwd()))
+    assert isinstance(path, Path)
+    assert path.is_absolute()
+    assert str(path).startswith(str(Path.cwd()))
 
 
-def test_get_skills_paths_user_returns_home_relative_paths() -> None:
-    """Tests user scope paths are resolved relative to home directory."""
-    paths = get_skills_paths(SkillScope.USER)
+def test_get_skills_path_user_returns_home_relative_paths() -> None:
+    """Tests user scope path is resolved relative to home directory."""
+    path = get_skills_path(SkillScope.USER)
 
-    assert isinstance(paths, list)
-    for path in paths:
-        assert isinstance(path, Path)
-        assert path.is_absolute()
-        assert str(path).startswith(str(Path.home()))
+    assert isinstance(path, Path)
+    assert path.is_absolute()
+    assert str(path).startswith(str(Path.home()))
 
 
-def test_get_skills_paths_project_reflects_cwd_change(
+def test_get_skills_path_project_reflects_cwd_change(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tests project scope paths reflect cwd at call time, not import time."""
+    """Tests project scope path reflects cwd at call time, not import time."""
     monkeypatch.chdir(tmp_path)
-    paths = get_skills_paths(SkillScope.PROJECT)
+    path = get_skills_path(SkillScope.PROJECT)
 
-    for path in paths:
-        assert str(path).startswith(str(tmp_path))
+    assert str(path).startswith(str(tmp_path))

--- a/tests/skills/test_discovery.py
+++ b/tests/skills/test_discovery.py
@@ -31,18 +31,22 @@ def skills_dir(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _patch_paths(project: list[Path], user: list[Path] | None = None):
-    """Return a context manager that patches get_skills_paths."""
-    paths = {SkillScope.PROJECT: project, SkillScope.USER: user or []}
+def _patch_paths(
+    project: Path,
+    user: Path | None = None,
+):
+    """Return a context manager that patches get_skills_path."""
+    _user = user or Path("/nonexistent/__user__")
+    paths = {SkillScope.PROJECT: project, SkillScope.USER: _user}
     return patch(
-        "llm_agents_from_scratch.skills.discovery.get_skills_paths",
+        "llm_agents_from_scratch.skills.discovery.get_skills_path",
         side_effect=lambda scope: paths[scope],
     )
 
 
 def test_discover_skills_skips_nonexistent_paths() -> None:
     """Tests discover_skills skips scope paths that do not exist."""
-    with _patch_paths(project=[Path("/nonexistent/path")]):
+    with _patch_paths(project=Path("/nonexistent/path")):
         skills = discover_skills(scopes=[SkillScope.PROJECT])
 
     assert skills == {}
@@ -53,7 +57,7 @@ def test_discover_skills_skips_non_directories(tmp_path: Path) -> None:
     (tmp_path / "not_a_dir.txt").write_text("hello")
 
     with (
-        _patch_paths(project=[tmp_path]),
+        _patch_paths(project=tmp_path),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
         ) as mock_validate,
@@ -70,7 +74,7 @@ def test_discover_skills_valid_skill_dir(skills_dir: Path) -> None:
     mock_info.name = "my-skill"
 
     with (
-        _patch_paths(project=[skills_dir]),
+        _patch_paths(project=skills_dir),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
             return_value=(mock_info, []),
@@ -94,7 +98,7 @@ def test_discover_skills_emits_cosmetic_warnings(skills_dir: Path) -> None:
     ]
 
     with (
-        _patch_paths(project=[skills_dir]),
+        _patch_paths(project=skills_dir),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
             return_value=(mock_info, cosmetic_warnings),
@@ -113,7 +117,7 @@ def test_discover_skills_emits_cosmetic_warnings(skills_dir: Path) -> None:
 def test_discover_skills_skips_on_fatal_error(skills_dir: Path) -> None:
     """Tests discover_skills emits SkillSkippedWarning and skips the skill."""
     with (
-        _patch_paths(project=[skills_dir]),
+        _patch_paths(project=skills_dir),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
             side_effect=SkillValidationError("missing SKILL.md"),
@@ -152,7 +156,7 @@ def test_discover_skills_project_overrides_user(tmp_path: Path) -> None:
         return project_info, []
 
     with (
-        _patch_paths(project=[project_dir], user=[user_dir]),
+        _patch_paths(project=project_dir, user=user_dir),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
             side_effect=_validate,
@@ -189,7 +193,7 @@ def test_discover_skills_emits_shadowed_warning(tmp_path: Path) -> None:
         return project_info, []
 
     with (
-        _patch_paths(project=[project_dir], user=[user_dir]),
+        _patch_paths(project=project_dir, user=user_dir),
         patch(
             "llm_agents_from_scratch.skills.discovery.validate_skill_dir",
             side_effect=_validate,


### PR DESCRIPTION
## Summary

- Replaces `_SKILL_SUBDIRS` (list) with `_SKILL_SUBDIR` (single string) in `skills/utils.py`, now pointing only to `.agents/skills`
- Drops `.from_scratch/skills` in favour of the standard cross-client path
- Corrects `.agent/skills` (singular) to `.agents/skills` (plural) to match the Agent Skills open standard
- Updates `discover_skills()` to use the single path directly (removes inner loop over paths)
- Updates tests to match the new single-path return type

Closes #451

## Test plan

- [x] `tests/skills/test_constants.py` — updated assertions for single `Path` return
- [x] `tests/skills/test_discovery.py` — updated `_patch_paths` helper and all call sites
- [x] Full suite: 194 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)