### PR TITLE
refactor: remove _activated_skills from TaskHandler

### DIFF
--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -104,8 +104,6 @@ class LLMAgent:
             _explicit_only_skills (set[str]): Skill names excluded from the
                 model-visible catalog for this run. They remain loadable via
                 ``run_with_skill()``. Added in Chapter 6.
-            _activated_skills (set[str]): Names of skills already activated
-                in this task run. Added in Chapter 6.
             _use_skill_tool (UseSkillTool | None): Task-scoped skill
                 activation tool. Set when skills are discovered; ``None``
                 otherwise. Added in Chapter 6.
@@ -150,7 +148,6 @@ class LLMAgent:
             )
             self.skills: dict[str, Skill] = discover_skills(_scopes)
             self._explicit_only_skills: set[str] = explicit_only_skills or set()
-            self._activated_skills: set[str] = set()
             self._use_skill_tool: UseSkillTool | None = (
                 UseSkillTool(
                     skills=self.skills,


### PR DESCRIPTION
Scaffolded but never used. Deduplication is a recommended (not required) behaviour per the Agent Skills standard; tracked in #460 for future work.

Closes #461

## Summary

<!-- What does this PR change and why? Be concise. -->

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Notebook update
- [ ] Documentation / capstone
- [x] Chore (deps, CI, tooling)

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting is clean (`make lint`)
- [x] Changes are focused and minimal
