### PR TITLE
ch06: refine skill_types UML diagram

### DIFF
--- a/uml/ch06/skill_types.puml
+++ b/uml/ch06/skill_types.puml
@@ -29,8 +29,8 @@ package "llm_agents_from_scratch.skills.skill" <<Folder>> {
     +frontmatter: SkillFrontmatter
     +location: Path
     +scope: SkillScope
-    --
     +resources: list[Path]
+    --
     +read_body(): str
     +catalog(): str
   }

--- a/uml/ch06/skill_types.puml
+++ b/uml/ch06/skill_types.puml
@@ -1,6 +1,11 @@
 @startuml skill_types
 !include ../common/book-clean.puml
 
+' External dependencies
+package "external_dependencies" <<Folder>> {
+  class "pydantic.BaseModel" as BaseModel
+}
+
 package "llm_agents_from_scratch.data_structures.skill" <<Folder>> {
 
   enum SkillScope {
@@ -8,7 +13,7 @@ package "llm_agents_from_scratch.data_structures.skill" <<Folder>> {
     USER = 'user'
   }
 
-  class SkillFrontmatter <<Pydantic BaseModel>> {
+  class SkillFrontmatter {
     +name: str
     +description: str
     +license: str | None
@@ -32,6 +37,7 @@ package "llm_agents_from_scratch.skills.skill" <<Folder>> {
 }
 
 ' Relations
+BaseModel <|-- SkillFrontmatter : " inherits"
 Skill --> SkillFrontmatter : " has"
 Skill --> SkillScope : " has"
 

--- a/uml/ch06/skill_types.puml
+++ b/uml/ch06/skill_types.puml
@@ -38,7 +38,7 @@ package "llm_agents_from_scratch.skills.skill" <<Folder>> {
 
 ' Relations
 BaseModel <|-- SkillFrontmatter : " inherits"
-Skill --> SkillFrontmatter : " has"
-Skill --> SkillScope : " has"
+Skill *-- SkillFrontmatter : " has"
+Skill *-- SkillScope : " has"
 
 @enduml

--- a/uml/ch06/skill_types.puml
+++ b/uml/ch06/skill_types.puml
@@ -1,4 +1,4 @@
-@startuml uml-skill-types
+@startuml skill_types
 !include ../common/book-clean.puml
 
 package "llm_agents_from_scratch.data_structures.skill" <<Folder>> {

--- a/uml/ch06/uml-skill-types.puml
+++ b/uml/ch06/uml-skill-types.puml
@@ -1,0 +1,38 @@
+@startuml uml-skill-types
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.data_structures.skill" <<Folder>> {
+
+  enum SkillScope {
+    PROJECT = 'project'
+    USER = 'user'
+  }
+
+  class SkillFrontmatter <<Pydantic BaseModel>> {
+    +name: str
+    +description: str
+    +license: str | None
+    +compatibility: str | None
+    +metadata: dict[str, str] | None
+    +allowed_tools: str | None
+  }
+}
+
+package "llm_agents_from_scratch.skills.skill" <<Folder>> {
+
+  class Skill {
+    +frontmatter: SkillFrontmatter
+    +location: Path
+    +scope: SkillScope
+    --
+    +resources: list[Path]
+    +read_body(): str
+    +catalog(): str
+  }
+}
+
+' Relations
+Skill --> SkillFrontmatter : " has"
+Skill --> SkillScope : " has"
+
+@enduml


### PR DESCRIPTION
## Summary

- Switch `Skill --> SkillFrontmatter/SkillScope` associations to composition notation (`*--`) with `" has"` labels
- Move `resources` property from methods section to attributes section

## Test plan

- [ ] Verify rendered UML diagram looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)