### PR TITLE
ch06: UML class diagram for TaskHandler with Ch6 additions highlighted

### DIFF
--- a/uml/ch06/taskhandler.puml
+++ b/uml/ch06/taskhandler.puml
@@ -1,0 +1,31 @@
+@startuml uml-taskhandler-ch6
+!include ../common/book-clean.puml
+
+' External dependencies
+package "external_dependencies" <<Folder>> {
+  class "asyncio.Future" as Future
+}
+
+package "llm_agents_from_scratch.agent" <<Folder>> {
+  class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>+llm_agent: LLMAgent</color>
+    <color:#aaaaaa>+task: Task</color>
+    <color:#aaaaaa>+rollout: str</color>
+    <color:#aaaaaa>+step_counter: int</color>
+    <color:#aaaaaa>-_background_task: ~asyncio.Task</color>
+    +skills: dict[str, Skill]
+    -_skills_catalog: str
+    -_use_skill_tool: UseSkillTool | None
+    -_explicit_only_skills: set[str]
+    --
+    +<<constructor>> __init__(\n\tllm_agent: LLMAgent,\n\ttask: Task,\n\tskills_scopes: list[SkillScope],\n\texplicit_only_skills: set[str],\n\t*args, **kwargs\n):
+    <color:#aaaaaa>+<<async>> get_next_step(): TaskStep | TaskResult</color>
+    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
+    <color:#aaaaaa>-_rollout_contribution_from_single_run_step()</color>
+  }
+}
+
+' Relations
+Future <|.. TaskHandler : " inherits"
+
+@enduml

--- a/uml/ch06/taskhandler.puml
+++ b/uml/ch06/taskhandler.puml
@@ -20,7 +20,7 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     --
     +<<constructor>> __init__(\n\tllm_agent: LLMAgent,\n\ttask: Task,\n\tskills_scopes: list[SkillScope],\n\texplicit_only_skills: set[str],\n\t*args, **kwargs\n):
     <color:#aaaaaa>+<<async>> get_next_step(): TaskStep | TaskResult</color>
-    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
+    +<b><<async>> run_step(step: TaskStep): TaskStepResult</b>
     <color:#aaaaaa>-_rollout_contribution_from_single_run_step()</color>
   }
 }


### PR DESCRIPTION
## Summary

- New `uml/ch06/taskhandler.puml` diagram (Figure 6.8) showing `LLMAgent.TaskHandler` with Ch6 additions
- Existing Ch4 members rendered in lighter shade (`#aaaaaa`)
- Ch6 additions shown in default (dark) colour:
  - `skills: dict[str, Skill]`
  - `_skills_catalog: str` (property)
  - `_use_skill_tool: UseSkillTool | None`
  - `_explicit_only_skills: set[str]`
  - Updated `__init__` signature with `skills_scopes` and `explicit_only_skills` params

Closes #469

## Test plan

- [ ] Render diagram and verify Ch4 members appear lighter, Ch6 additions appear darker

🤖 Generated with [Claude Code](https://claude.com/claude-code)