### PR TITLE
ch06: UML class diagram for UseSkillTool

### DIFF
--- a/uml/ch06/taskhandler.puml
+++ b/uml/ch06/taskhandler.puml
@@ -1,4 +1,4 @@
-@startuml uml-taskhandler-ch6
+@startuml uml_taskhandler_updates
 !include ../common/book-clean.puml
 
 ' External dependencies

--- a/uml/ch06/use_skill_tool.puml
+++ b/uml/ch06/use_skill_tool.puml
@@ -1,4 +1,4 @@
-@startuml uml-use-skill-tool
+@startuml uml_use_skill_tool
 !include ../common/book-clean.puml
 
 package "llm_agents_from_scratch.base.tool" <<Folder>> {

--- a/uml/ch06/use_skill_tool.puml
+++ b/uml/ch06/use_skill_tool.puml
@@ -1,0 +1,29 @@
+@startuml uml-use-skill-tool
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.base.tool" <<Folder>> {
+  abstract class BaseTool {
+    +name: str
+    +description: str
+    +parameters_json_schema: dict[str, Any]
+    --
+    +__call__(tool_call: ToolCall): ToolCallResult
+  }
+}
+
+package "llm_agents_from_scratch.skills.tools" <<Folder>> {
+  class UseSkillTool {
+    -_skills: dict[str, Skill]
+    -_explicit_only_skills: set[str]
+    -_visible: list[str]
+    --
+    +<<constructor>> __init__(\n\tskills: dict[str, Skill],\n\texplicit_only_skills: set[str]\n):
+    -_build_skill_content(name: str): str
+    +__call__(tool_call: ToolCall, ...): ToolCallResult
+  }
+}
+
+' Relations
+BaseTool <|-- UseSkillTool : " inherits"
+
+@enduml


### PR DESCRIPTION
## Summary

- New `uml/ch06/use_skill_tool.puml` diagram (Figure 6.9)
- Shows `UseSkillTool` inheriting from `BaseTool`, styled after Ch02 `SimpleFunctionTool` diagrams
- Includes private attributes (`_skills`, `_explicit_only_skills`, `_visible`), properties from `BaseTool`, constructor, and methods

Closes #471

## Test plan

- [ ] Render diagram and verify layout and inheritance arrow are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)