### PR TITLE
ch06: initialize more-examples placeholder notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ core concepts to full multi-agent systems.
 | Ch | Title | Notebook |
 | -- | ----- | -------- |
 | 5 | MCP Tools | [Ch 5](https://masfromscratch.com/notebooks/ch05/) |
-| 6 | Skills | — |
+| 6 | Skills | [Ch 5](https://masfromscratch.com/notebooks/ch06/) |
 | 7 | Memory | — |
 | 8 | Human in the Loop | — |
 

--- a/more-examples/ch06/additional_resource_python.ipynb
+++ b/more-examples/ch06/additional_resource_python.ipynb
@@ -1,0 +1,59 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "92ce87e8-761a-4658-925a-a8717f5a1ff5",
+   "metadata": {},
+   "source": [
+    "# Skill with Additional Python Resource\n\nThis notebook demonstrates using a skill bundle that includes a Python script resource. It shows how an agent uses `ReadFileTool` and `PythonInterpreterTool` to load and execute the script as part of skill execution.\n\n## Setup Instructions\n\nTo ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n\n```sh\nuv run --with jupyter jupyter lab\n```\n\nAlternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPI by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3e83087a-6084-4d67-b2b7-160c411417a9",
+   "metadata": {},
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n# !pip install llm-agents-from-scratch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e15514b-8f09-43fe-bc53-53b909038824",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02aadb60-20e8-4b29-881e-1402765e33b1",
+   "metadata": {},
+   "source": [
+    "## Example\n\n> **Coming soon.** This notebook will build a skill bundle with an `assets/` or `scripts/` subdirectory containing a Python script, then run an agent task that triggers the skill and executes the script via tool calls."
+   ]
+  }
+ ]
+}

--- a/more-examples/ch06/skill_validation_errors.ipynb
+++ b/more-examples/ch06/skill_validation_errors.ipynb
@@ -1,0 +1,59 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "67765783-88b4-4a22-a793-3f1c596adc64",
+   "metadata": {},
+   "source": [
+    "# Skill Validation Errors\n\nThis notebook demonstrates what happens when a skill bundle is malformed. It covers fatal errors (`MissingSkillMdError`, `InvalidFrontmatterError`, `EmptySkillBodyError`) and cosmetic warnings (`NameMismatchWarning`, `NameTooLongWarning`) that are raised during skill discovery.\n\n## Setup Instructions\n\nTo ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n\n```sh\nuv run --with jupyter jupyter lab\n```\n\nAlternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPI by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0f4f6528-6ac3-4f6c-a7cf-465ebd5ab05b",
+   "metadata": {},
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n# !pip install llm-agents-from-scratch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "681709ba-c4f1-440d-9171-6c8cfc299550",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3679943-08c3-4966-b066-532afa7ac307",
+   "metadata": {},
+   "source": [
+    "## Example\n\n> **Coming soon.** This notebook will walk through each error and warning type with a minimal malformed skill bundle, showing the exception message and how to fix it."
+   ]
+  }
+ ]
+}

--- a/more-examples/ch06/skills_marketplace.ipynb
+++ b/more-examples/ch06/skills_marketplace.ipynb
@@ -1,0 +1,59 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a6fb950-52c5-4927-9072-09be61407154",
+   "metadata": {},
+   "source": [
+    "# Skills Marketplace\n\nThis notebook demonstrates using third-party skills from a skills marketplace. It shows how to install a skill from an external source and use it with an `LLMAgent`.\n\n## Setup Instructions\n\nTo ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n\n```sh\nuv run --with jupyter jupyter lab\n```\n\nAlternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPI by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "de460284-3960-46ca-9e85-166a2ef8749c",
+   "metadata": {},
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n# !pip install llm-agents-from-scratch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea5acca4-411d-48b3-a238-81247d0b2e10",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76975992-a0c2-4924-98a2-e61a20a749e9",
+   "metadata": {},
+   "source": [
+    "## Example\n\n> **Coming soon.** This notebook will walk through discovering, installing, and activating a skill sourced from an external skills marketplace."
+   ]
+  }
+ ]
+}

--- a/more-examples/ch06/user_explicit_hailstone.ipynb
+++ b/more-examples/ch06/user_explicit_hailstone.ipynb
@@ -1,0 +1,59 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "28078161-b077-4c7b-a97b-43166dc63bc6",
+   "metadata": {},
+   "source": [
+    "# User-Explicit Skill Activation \u2014 Hailstone\n\nThis notebook demonstrates user-explicit skill activation using `run_with_skill()` with the Hailstone (`stop-at-one`) skill. It compares the execution trace with the model-driven activation shown in the chapter's main example notebook.\n\n**Note:** Run this notebook from within the `examples/` directory so the `stop-at-one` skill is discovered as a project-scoped skill.\n\n## Setup Instructions\n\nTo ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n\n```sh\nuv run --with jupyter jupyter lab\n```\n\nAlternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPI by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8ac2426e-8d8f-4609-9ee5-2eadb17cbb8f",
+   "metadata": {},
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n# !pip install llm-agents-from-scratch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "124f4f81-a087-4aa7-8aa8-2c912c9d9b9d",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53d8c06b-fb22-405c-aae9-d2a22f083cb0",
+   "metadata": {},
+   "source": [
+    "## Example\n\n> **Coming soon.** This notebook will call `agent.run_with_skill()` directly with the `stop-at-one` skill and compare the resulting trace and step count against the model-driven activation from `examples/ch06.ipynb`."
+   ]
+  }
+ ]
+}

--- a/more-examples/ch06/with_and_without_skills.ipynb
+++ b/more-examples/ch06/with_and_without_skills.ipynb
@@ -1,0 +1,59 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8f5a284a-e0f4-459f-8e1d-65e85a201ed2",
+   "metadata": {},
+   "source": [
+    "# Task Execution: With and Without Skills\n\nThis notebook compares task executions with and without skills enabled, using the Hailstone (`stop-at-one`) skill as the example. It highlights the difference in execution trace, number of steps taken, and output quality.\n\n**Note:** Run this notebook from within the `examples/` directory so the `stop-at-one` skill is discovered as a project-scoped skill.\n\n## Setup Instructions\n\nTo ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n\n```sh\nuv run --with jupyter jupyter lab\n```\n\nAlternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPI by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "04208401-f9b4-4304-be56-c9bb90fe0476",
+   "metadata": {},
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n# !pip install llm-agents-from-scratch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdb83ab2-3569-482e-a7c4-748563705ac3",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7679ced-aaa0-482c-bd1c-2c38b1382218",
+   "metadata": {},
+   "source": [
+    "## Example\n\n> **Coming soon.** This notebook will run the same task twice \u2014 once with skills enabled and once without \u2014 then display both traces side by side to illustrate the impact of skill-augmented execution."
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## Summary

Creates `more-examples/ch06/` with 5 placeholder notebooks so chapter links are not broken when the chapter ships to editors. Each notebook has the standard setup instructions (uv/PyPI install, Ollama note) and a placeholder section with a "Coming soon" description of what will be implemented.

**Notebooks added:**
- `skill_validation_errors.ipynb` — fatal errors and cosmetic warnings during skill discovery
- `additional_resource_python.ipynb` — skill bundle with Python script resource
- `user_explicit_hailstone.ipynb` — user-explicit activation via `run_with_skill()`
- `skills_marketplace.ipynb` — installing and using a third-party skill
- `with_and_without_skills.ipynb` — side-by-side trace comparison

Closes #475

## Test plan

- [ ] Verify all 5 notebooks open cleanly in Jupyter
- [ ] Verify setup cells match the pattern from `examples/ch06.ipynb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)