### PR TITLE
notebooks: update default model to qwen3:14b across ch03–ch05

### DIFF
--- a/examples/ch03.ipynb
+++ b/examples/ch03.ipynb
@@ -126,11 +126,7 @@
    "id": "aaf19a60-8501-454a-8159-0af1dd8d7d19",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
-    "\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")"
-   ]
+   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\")"
   },
   {
    "cell_type": "markdown",
@@ -154,17 +150,7 @@
      ]
     }
    ],
-   "source": [
-    "import asyncio\n",
-    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
-    "\n",
-    "async def main():\n",
-    "    llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "    response = await llm.complete(\"Tell me a joke.\")\n",
-    "    print(response)\n",
-    "\n",
-    "asyncio.run(main())"
-   ]
+   "source": "import asyncio\nfrom llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nasync def main():\n    llm = OllamaLLM(model=\"qwen3:14b\")\n    response = await llm.complete(\"Tell me a joke.\")\n    print(response)\n\nasyncio.run(main())"
   },
   {
    "cell_type": "markdown",
@@ -189,16 +175,7 @@
      ]
     }
    ],
-   "source": [
-    "async def main():\n",
-    "    llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "    prompt = (\"Tell me a joke.\")\n",
-    "    joke = await llm.structured_output(prompt=prompt, mdl=Joke)\n",
-    "    print(joke.__class__.__name__)\n",
-    "    print(joke)\n",
-    "\n",
-    "asyncio.run(main())"
-   ]
+   "source": "async def main():\n    llm = OllamaLLM(model=\"qwen3:14b\")\n    prompt = (\"Tell me a joke.\")\n    joke = await llm.structured_output(prompt=prompt, mdl=Joke)\n    print(joke.__class__.__name__)\n    print(joke)\n\nasyncio.run(main())"
   },
   {
    "cell_type": "markdown",
@@ -244,29 +221,7 @@
      ]
     }
    ],
-   "source": [
-    "import asyncio\n",
-    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
-    "from llm_agents_from_scratch.data_structures.llm import ChatMessage\n",
-    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
-    "\n",
-    "hailstone_tool = SimpleFunctionTool(hailstone_step_func)\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "\n",
-    "async def main():\n",
-    "    user_input = (\n",
-    "        \"What is the result of taking the next step of the \"\n",
-    "        \"Hailstone sequence on the number 3?\\n\\n\"\n",
-    "        \"Be very succinct in your response.\"\n",
-    "    )\n",
-    "    return await llm.chat(\n",
-    "        user_input,\n",
-    "        tools=[hailstone_tool],\n",
-    "    )\n",
-    "\n",
-    "user_msg, response_msg = asyncio.run(main())\n",
-    "print(response_msg.tool_calls)"
-   ]
+   "source": "import asyncio\nfrom llm_agents_from_scratch.llms.ollama import OllamaLLM\nfrom llm_agents_from_scratch.data_structures.llm import ChatMessage\nfrom llm_agents_from_scratch.tools import SimpleFunctionTool\n\nhailstone_tool = SimpleFunctionTool(hailstone_step_func)\nllm = OllamaLLM(model=\"qwen3:14b\")\n\nasync def main():\n    user_input = (\n        \"What is the result of taking the next step of the \"\n        \"Hailstone sequence on the number 3?\\n\\n\"\n        \"Be very succinct in your response.\"\n    )\n    return await llm.chat(\n        user_input,\n        tools=[hailstone_tool],\n    )\n\nuser_msg, response_msg = asyncio.run(main())\nprint(response_msg.tool_calls)"
   },
   {
    "cell_type": "markdown",

--- a/examples/ch04.ipynb
+++ b/examples/ch04.ipynb
@@ -72,15 +72,7 @@
    "id": "bc0ab1b8-aec1-49df-a63e-60ab2317be2f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch import LLMAgent\n",
-    "\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "llm_agent = LLMAgent(\n",
-    "    llm=llm,\n",
-    ")"
-   ]
+   "source": "from llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch import LLMAgent\n\nllm = OllamaLLM(model=\"qwen3:14b\")\nllm_agent = LLMAgent(\n    llm=llm,\n)"
   },
   {
    "cell_type": "code",
@@ -235,11 +227,7 @@
    "id": "00463e83-28fd-4ad9-b375-0e0e5ed9ab81",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")"
-   ]
+   "source": "from llm_agents_from_scratch.llms import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\")"
   },
   {
    "cell_type": "markdown",

--- a/examples/ch05.ipynb
+++ b/examples/ch05.ipynb
@@ -335,21 +335,7 @@
    "id": "11b19865-a2c4-41c8-9476-01776a0e1340",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch import LLMAgent\n",
-    "\n",
-    "provider = MCPToolProvider(\n",
-    "    name=\"hailstone\",\n",
-    "    stdio_params=server_params,\n",
-    ")\n",
-    "tools = await provider.get_tools()\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "llm_agent = LLMAgent(\n",
-    "    llm=llm,\n",
-    "    tools=tools,\n",
-    ")"
-   ]
+   "source": "from llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch import LLMAgent\n\nprovider = MCPToolProvider(\n    name=\"hailstone\",\n    stdio_params=server_params,\n)\ntools = await provider.get_tools()\nllm = OllamaLLM(model=\"qwen3:14b\")\nllm_agent = LLMAgent(\n    llm=llm,\n    tools=tools,\n)"
   },
   {
    "cell_type": "code",
@@ -386,32 +372,7 @@
    "id": "f18fe5a7-dd2d-483f-8084-50a172cd0082",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch.agent.builder import LLMAgentBuilder\n",
-    "\n",
-    "provider = MCPToolProvider(\n",
-    "    name=\"hailstone\",\n",
-    "    stdio_params=server_params,\n",
-    ")\n",
-    "llm = OllamaLLM(model=\"qwen2.5:3b\")\n",
-    "\n",
-    "# directly passing attributes at construction\n",
-    "builder = LLMAgentBuilder(\n",
-    "    llm=llm,\n",
-    "    mcp_providers=[provider],\n",
-    ")\n",
-    "\n",
-    "# fluent style with builder methods\n",
-    "builder = LLMAgentBuilder()\\\n",
-    "    .with_llm(llm)\\\n",
-    "    .with_mcp_provider(provider)\n",
-    "\n",
-    "# another fluent style\n",
-    "builder = LLMAgentBuilder()\\\n",
-    "    .with_mcp_providers([provider])\\\n",
-    "    .with_llm(llm)"
-   ]
+   "source": "from llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.agent.builder import LLMAgentBuilder\n\nprovider = MCPToolProvider(\n    name=\"hailstone\",\n    stdio_params=server_params,\n)\nllm = OllamaLLM(model=\"qwen3:14b\")\n\n# directly passing attributes at construction\nbuilder = LLMAgentBuilder(\n    llm=llm,\n    mcp_providers=[provider],\n)\n\n# fluent style with builder methods\nbuilder = LLMAgentBuilder()\\\n    .with_llm(llm)\\\n    .with_mcp_provider(provider)\n\n# another fluent style\nbuilder = LLMAgentBuilder()\\\n    .with_mcp_providers([provider])\\\n    .with_llm(llm)"
   },
   {
    "cell_type": "markdown",
@@ -427,21 +388,7 @@
    "id": "43dbee5f-d18d-4fc8-96b3-a2ba2eabef9c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch.agent.builder import LLMAgentBuilder\n",
-    "\n",
-    "provider = MCPToolProvider(\n",
-    "    name=\"hailstone\",\n",
-    "    stdio_params=server_params,\n",
-    ")\n",
-    "llm = OllamaLLM(model=\"qwen3:4b\")\n",
-    "\n",
-    "llm_agent = await LLMAgentBuilder()\\\n",
-    "    .with_llm(llm)\\\n",
-    "    .with_mcp_provider(provider)\\\n",
-    "    .build()"
-   ]
+   "source": "from llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.agent.builder import LLMAgentBuilder\n\nprovider = MCPToolProvider(\n    name=\"hailstone\",\n    stdio_params=server_params,\n)\nllm = OllamaLLM(model=\"qwen3:14b\")\n\nllm_agent = await LLMAgentBuilder()\\\n    .with_llm(llm)\\\n    .with_mcp_provider(provider)\\\n    .build()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Updates all `OllamaLLM(model=...)` calls in ch03, ch04, and ch05 notebooks to use `qwen3:14b` as the default model, consistent with ch06 and all more-examples notebooks.

| Notebook | Before | After |
| -------- | ------ | ----- |
| ch03 | `qwen2.5:3b` | `qwen3:14b` |
| ch04 | `qwen2.5:3b` | `qwen3:14b` |
| ch05 | `qwen2.5:3b`, `qwen3:4b` | `qwen3:14b` |

ch06 and all more-examples were already on `qwen3:14b` — no changes needed there.

## Test plan

- [ ] Verify ch03 examples run correctly with qwen3:14b
- [ ] Verify ch04 examples run correctly with qwen3:14b
- [ ] Verify ch05 examples run correctly with qwen3:14b

🤖 Generated with [Claude Code](https://claude.com/claude-code)