### PR TITLE
ch04: add pokemon-error-handling and pokemon-comparison more-examples notebooks

### DIFF
--- a/docs/more-examples/ch04/pokemon_comparison.ipynb
+++ b/docs/more-examples/ch04/pokemon_comparison.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch04/pokemon_comparison.ipynb

--- a/docs/more-examples/ch04/pokemon_error_handling.ipynb
+++ b/docs/more-examples/ch04/pokemon_error_handling.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch04/pokemon_error_handling.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ nav:
   - More Examples:
     - more-examples/index.md
     # Symlinked from more-examples/ — do not copy directly.
+    - Chapter 4:
+      - Handling Tool Errors (PokéAPI): more-examples/ch04/pokemon_error_handling.ipynb
+      - Multi-Step Chained Calls (PokéAPI): more-examples/ch04/pokemon_comparison.ipynb
     - Chapter 5:
       - GitHub MCP: more-examples/ch05/github_mcp.ipynb
       - GoodNews MCP: more-examples/ch05/goodnews_mcp.ipynb

--- a/more-examples/ch04/pokemon_comparison.ipynb
+++ b/more-examples/ch04/pokemon_comparison.ipynb
@@ -5,11 +5,11 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
-    "# Multi-Step Reasoning with Chained Tool Calls — PokéAPI\n",
+    "# Multi-Step Reasoning with Chained Tool Calls \u2014 Pok\u00e9API\n",
     "\n",
     "This notebook demonstrates the `LLMAgent` performing multi-step reasoning by chaining sequential tool calls.\n",
     "\n",
-    "We ask the agent to compare two Pokémon across a specific stat. To answer, it must call `get_pokemon` twice — once per Pokémon — then synthesise both results into a final answer."
+    "We ask the agent to compare two Pok\u00e9mon across a specific stat. To answer, it must call `get_pokemon` twice \u2014 once per Pok\u00e9mon \u2014 then synthesise both results into a final answer."
    ]
   },
   {
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [
@@ -43,7 +43,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Ollama already running at http://localhost:11434\n"
+      "\u2713 Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -67,7 +67,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -96,7 +96,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
@@ -128,7 +128,7 @@
     "\n",
     "\n",
     "def get_pokemon(name: str) -> str:\n",
-    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
+    "    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n",
     "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
     "    req = urllib.request.Request(\n",
     "        url,\n",
@@ -140,7 +140,7 @@
     "    except urllib.error.HTTPError as e:\n",
     "        if e.code == 404:  # noqa: PLR2004\n",
     "            raise ValueError(\n",
-    "                f\"Pokémon '{name}' not found. \"\n",
+    "                f\"Pok\u00e9mon '{name}' not found. \"\n",
     "                \"Check the spelling and try again.\",\n",
     "            ) from e\n",
     "        raise\n",
@@ -157,14 +157,14 @@
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
-    "## Example 1 — Comparing Speed\n",
+    "## Example 1 \u2014 Comparing Speed\n",
     "\n",
-    "The agent needs to look up both Pokémon before it can answer, making two sequential tool calls."
+    "The agent needs to look up both Pok\u00e9mon before it can answer, making two sequential tool calls."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "40cbc200-f4ba-48c7-88e3-35a398fa29cb",
    "metadata": {},
    "outputs": [],
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "outputs": [
@@ -186,43 +186,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon has higher base speed: Pikachu or Gengar?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon has higher base speed: Pikachu or Gengar?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to look up the base speed of Pikachu and Gengar to determine which one is higher. I'll start by checking Pikachu's base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Look up the base speed of Gengar next to compare with Pikachu's base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the base speed of Gengar next to compare with Pikachu's base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to look up the base speed of Gengar now to compare it with Pikachu's base speed. I'll call the get_pokemon function with the nam...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon function with the name 'Gengar' to retrieve its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon function with the name 'Gengar' to retrieve its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"error_type\": \"HTTPError\", \"message\": \"Internal error while executing tool: HTTP Error 403: Forbidden\"}\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: It seems there was an error retrieving the information about Gengar. The tool returned a \"Forbidden\" error, which might be due to a tem...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon function with the name 'Gengar' again to retrieve its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon function with the name 'Gengar' again to retrieve its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"error_type\": \"HTTPError\", \"message\": \"Internal error while executing tool: HTTP Error 403: Forbidden\"}\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: It seems there is a persistent issue retrieving information about Gengar using the tool, as the \"Forbidden\" error continues to occur. T...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Look up the base speed of Pikachu and Gengar using alternative sources or methods to answer the original question.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the base speed of Pikachu and Gengar using alternative sources or methods to answer the original question.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Since the tool is returning a \"Forbidden\" error, I cannot retrieve the information about Gengar using the provided function. However, I...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to look up the base speed of Pikachu and Gengar to determine which one is higher. I will start by looking up Pikachu's base spee...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the name 'Gengar' to look up its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the name 'Gengar' to look up its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I have now looked up the base speed of both Pikachu and Gengar. Pikachu has a base speed of 90, while Gengar has a base speed of 110. T...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Since the tool is returning a \"Forbidden\" error, I cannot retrieve the information about Gengar using the provided function. However...[TRUNCATED]\n"
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I have now looked up the base speed of both Pikachu and Gengar. Pikachu has a base speed of 90, while Gengar has a base speed of 110...[TRUNCATED]\n"
      ]
     }
    ],
-   "source": [
-    "from llm_agents_from_scratch import LLMAgent\n",
-    "from llm_agents_from_scratch.data_structures import Task\n",
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "\n",
-    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
-    "\n",
-    "task = Task(\n",
-    "    instruction=\"Which Pokémon has higher base speed: Pikachu or Gengar?\",\n",
-    ")\n",
-    "result = await agent.run(task)"
-   ]
+   "source": "from llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.llms import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n\ntask = Task(\n    instruction=(\n        \"Which Pok\u00e9mon has higher base speed: Pikachu or Gengar? \"\n        \"Use the get_pokemon tool for each \u2014 do not rely on prior knowledge.\"\n    ),\n)\nresult = await agent.run(task)"
   },
   {
    "cell_type": "code",
@@ -239,9 +216,9 @@
    "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "source": [
-    "## Example 2 — Comparing Attack and Defense\n",
+    "## Example 2 \u2014 Comparing Attack and Defense\n",
     "\n",
-    "A second comparison task to reinforce the chaining pattern — this time across two different stats."
+    "A second comparison task to reinforce the chaining pattern \u2014 this time across two different stats."
    ]
   },
   {
@@ -250,18 +227,7 @@
    "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
-    "\n",
-    "task = Task(\n",
-    "    instruction=(\n",
-    "        \"Compare Bulbasaur and Charmander. \"\n",
-    "        \"Which has higher attack and which has higher defense?\"\n",
-    "    ),\n",
-    ")\n",
-    "result = await agent.run(task)"
-   ]
+   "source": "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n\ntask = Task(\n    instruction=(\n        \"Compare Bulbasaur and Charmander. \"\n        \"Which has higher attack and which has higher defense? \"\n        \"Use the get_pokemon tool for each \u2014 do not rely on prior knowledge.\"\n    ),\n)\nresult = await agent.run(task)"
   },
   {
    "cell_type": "code",

--- a/more-examples/ch04/pokemon_comparison.ipynb
+++ b/more-examples/ch04/pokemon_comparison.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": "# Multi-Step Reasoning with Chained Tool Calls \u2014 Pok\u00e9API\n\nThis notebook demonstrates the `LLMAgent` performing multi-step reasoning by chaining sequential tool calls.\n\nWe ask the agent to compare two Pok\u00e9mon across a specific stat. To answer, it must call `get_pokemon` twice \u2014 once per Pok\u00e9mon \u2014 then synthesise both results into a final answer."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": "## Defining the Tool"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nimport urllib.error\nimport urllib.request\n\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\n\ndef get_pokemon(name: str) -> str:\n    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n    try:\n        with urllib.request.urlopen(url) as resp:\n            data = json.loads(resp.read())\n    except urllib.error.HTTPError as e:\n        if e.code == 404:  # noqa: PLR2004\n            raise ValueError(\n                f\"Pok\u00e9mon '{name}' not found. \"\n                \"Check the spelling and try again.\",\n            ) from e\n        raise\n    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n\n\nget_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "source": "## Example 1 \u2014 Comparing Speed\n\nThe agent needs to look up both Pok\u00e9mon before it can answer, making two sequential tool calls."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(\n",
+    "    instruction=\"Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\",\n",
+    ")\n",
+    "result = await agent.run(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": "## Example 2 \u2014 Comparing Attack and Defense\n\nA second comparison task to reinforce the chaining pattern \u2014 this time across two different stats."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compare Bulbasaur and Charmander. \"\n",
+    "        \"Which has higher attack and which has higher defense?\"\n",
+    "    ),\n",
+    ")\n",
+    "result = await agent.run(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/more-examples/ch04/pokemon_comparison.ipynb
+++ b/more-examples/ch04/pokemon_comparison.ipynb
@@ -4,7 +4,13 @@
    "cell_type": "markdown",
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
-   "source": "# Multi-Step Reasoning with Chained Tool Calls \u2014 Pok\u00e9API\n\nThis notebook demonstrates the `LLMAgent` performing multi-step reasoning by chaining sequential tool calls.\n\nWe ask the agent to compare two Pok\u00e9mon across a specific stat. To answer, it must call `get_pokemon` twice \u2014 once per Pok\u00e9mon \u2014 then synthesise both results into a final answer."
+   "source": [
+    "# Multi-Step Reasoning with Chained Tool Calls — PokéAPI\n",
+    "\n",
+    "This notebook demonstrates the `LLMAgent` performing multi-step reasoning by chaining sequential tool calls.\n",
+    "\n",
+    "We ask the agent to compare two Pokémon across a specific stat. To answer, it must call `get_pokemon` twice — once per Pokémon — then synthesise both results into a final answer."
+   ]
   },
   {
    "cell_type": "code",
@@ -21,14 +27,26 @@
    "cell_type": "markdown",
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
-   "source": "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -49,7 +67,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -78,7 +96,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -91,43 +109,117 @@
    "cell_type": "markdown",
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
-   "source": "## Defining the Tool"
+   "source": [
+    "## Defining the Tool"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
-   "source": "import json\nimport urllib.error\nimport urllib.request\n\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\n\ndef get_pokemon(name: str) -> str:\n    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n    try:\n        with urllib.request.urlopen(url) as resp:\n            data = json.loads(resp.read())\n    except urllib.error.HTTPError as e:\n        if e.code == 404:  # noqa: PLR2004\n            raise ValueError(\n                f\"Pok\u00e9mon '{name}' not found. \"\n                \"Check the spelling and try again.\",\n            ) from e\n        raise\n    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n\n\nget_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+   "source": [
+    "import json\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def get_pokemon(name: str) -> str:\n",
+    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
+    "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
+    "    req = urllib.request.Request(\n",
+    "        url,\n",
+    "        headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    "    )\n",
+    "    try:\n",
+    "        with urllib.request.urlopen(req) as resp:\n",
+    "            data = json.loads(resp.read())\n",
+    "    except urllib.error.HTTPError as e:\n",
+    "        if e.code == 404:  # noqa: PLR2004\n",
+    "            raise ValueError(\n",
+    "                f\"Pokémon '{name}' not found. \"\n",
+    "                \"Check the spelling and try again.\",\n",
+    "            ) from e\n",
+    "        raise\n",
+    "    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n",
+    "    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n",
+    "    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n",
+    "\n",
+    "\n",
+    "get_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
-   "source": "## Example 1 \u2014 Comparing Speed\n\nThe agent needs to look up both Pok\u00e9mon before it can answer, making two sequential tool calls."
+   "source": [
+    "## Example 1 — Comparing Speed\n",
+    "\n",
+    "The agent needs to look up both Pokémon before it can answer, making two sequential tool calls."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "execution_count": 3,
+   "id": "40cbc200-f4ba-48c7-88e3-35a398fa29cb",
    "metadata": {},
    "outputs": [],
    "source": [
     "import logging\n",
     "\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "\n",
+    "enable_console_logging(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon has higher base speed: Pikachu or Gengar?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon has higher base speed: Pikachu or Gengar?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to look up the base speed of Pikachu and Gengar to determine which one is higher. I'll start by checking Pikachu's base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Look up the base speed of Gengar next to compare with Pikachu's base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the base speed of Gengar next to compare with Pikachu's base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to look up the base speed of Gengar now to compare it with Pikachu's base speed. I'll call the get_pokemon function with the nam...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon function with the name 'Gengar' to retrieve its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon function with the name 'Gengar' to retrieve its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"error_type\": \"HTTPError\", \"message\": \"Internal error while executing tool: HTTP Error 403: Forbidden\"}\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: It seems there was an error retrieving the information about Gengar. The tool returned a \"Forbidden\" error, which might be due to a tem...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon function with the name 'Gengar' again to retrieve its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon function with the name 'Gengar' again to retrieve its base speed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"error_type\": \"HTTPError\", \"message\": \"Internal error while executing tool: HTTP Error 403: Forbidden\"}\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: It seems there is a persistent issue retrieving information about Gengar using the tool, as the \"Forbidden\" error continues to occur. T...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Look up the base speed of Pikachu and Gengar using alternative sources or methods to answer the original question.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the base speed of Pikachu and Gengar using alternative sources or methods to answer the original question.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Since the tool is returning a \"Forbidden\" error, I cannot retrieve the information about Gengar using the provided function. However, I...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Since the tool is returning a \"Forbidden\" error, I cannot retrieve the information about Gengar using the provided function. However...[TRUNCATED]\n"
+     ]
+    }
+   ],
+   "source": [
     "from llm_agents_from_scratch import LLMAgent\n",
     "from llm_agents_from_scratch.data_structures import Task\n",
     "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch.logger import enable_console_logging\n",
-    "\n",
-    "enable_console_logging(logging.INFO)\n",
     "\n",
     "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
     "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
     "\n",
     "task = Task(\n",
-    "    instruction=\"Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\",\n",
+    "    instruction=\"Which Pokémon has higher base speed: Pikachu or Gengar?\",\n",
     ")\n",
     "result = await agent.run(task)"
    ]
@@ -146,7 +238,11 @@
    "cell_type": "markdown",
    "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
-   "source": "## Example 2 \u2014 Comparing Attack and Defense\n\nA second comparison task to reinforce the chaining pattern \u2014 this time across two different stats."
+   "source": [
+    "## Example 2 — Comparing Attack and Defense\n",
+    "\n",
+    "A second comparison task to reinforce the chaining pattern — this time across two different stats."
+   ]
   },
   {
    "cell_type": "code",
@@ -185,8 +281,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/more-examples/ch04/pokemon_comparison.ipynb
+++ b/more-examples/ch04/pokemon_comparison.ipynb
@@ -5,11 +5,11 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
-    "# Multi-Step Reasoning with Chained Tool Calls \u2014 Pok\u00e9API\n",
+    "# Multi-Step Reasoning with Chained Tool Calls — PokéAPI\n",
     "\n",
     "This notebook demonstrates the `LLMAgent` performing multi-step reasoning by chaining sequential tool calls.\n",
     "\n",
-    "We ask the agent to compare two Pok\u00e9mon across a specific stat. To answer, it must call `get_pokemon` twice \u2014 once per Pok\u00e9mon \u2014 then synthesise both results into a final answer."
+    "We ask the agent to compare two Pokémon across a specific stat. To answer, it must call `get_pokemon` twice — once per Pokémon — then synthesise both results into a final answer."
    ]
   },
   {
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [
@@ -43,7 +43,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2713 Ollama already running at http://localhost:11434\n"
+      "✓ Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -67,7 +67,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -96,7 +96,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
@@ -128,7 +128,7 @@
     "\n",
     "\n",
     "def get_pokemon(name: str) -> str:\n",
-    "    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n",
+    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
     "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
     "    req = urllib.request.Request(\n",
     "        url,\n",
@@ -140,7 +140,7 @@
     "    except urllib.error.HTTPError as e:\n",
     "        if e.code == 404:  # noqa: PLR2004\n",
     "            raise ValueError(\n",
-    "                f\"Pok\u00e9mon '{name}' not found. \"\n",
+    "                f\"Pokémon '{name}' not found. \"\n",
     "                \"Check the spelling and try again.\",\n",
     "            ) from e\n",
     "        raise\n",
@@ -157,14 +157,14 @@
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
-    "## Example 1 \u2014 Comparing Speed\n",
+    "## Example 1 — Comparing Speed\n",
     "\n",
-    "The agent needs to look up both Pok\u00e9mon before it can answer, making two sequential tool calls."
+    "The agent needs to look up both Pokémon before it can answer, making two sequential tool calls."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "id": "40cbc200-f4ba-48c7-88e3-35a398fa29cb",
    "metadata": {},
    "outputs": [],
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "outputs": [
@@ -186,27 +186,52 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Which Pok\u00e9mon has higher base speed: Pikachu or Gengar?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to look up the base speed of Pikachu and Gengar to determine which one is higher. I will start by looking up Pikachu's base spee...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the name 'Gengar' to look up its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the name 'Gengar' to look up its base speed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I have now looked up the base speed of both Pikachu and Gengar. Pikachu has a base speed of 90, while Gengar has a base speed of 110. T...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon has higher base speed: Pikachu or Gengar? Use the get_pokemon tool for each — do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon has higher base speed: Pikachu or Gengar? Use the get_pokemon tool for each — do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool for Pikachu and Gengar to retrieve their base speed stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool for Pikachu and Gengar to retrieve their base speed stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool for Pikachu and Gengar to retrieve their base speed stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Pikachu has a base speed of 90, while Gengar has a base speed of 110. Therefore, Gengar has a higher base speed.\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I have now looked up the base speed of both Pikachu and Gengar. Pikachu has a base speed of 90, while Gengar has a base speed of 110...[TRUNCATED]\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Pikachu has a base speed of 90, while Gengar has a base speed of 110. Therefore, Gengar has a higher base speed.\n"
      ]
     }
    ],
-   "source": "from llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.llms import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n\ntask = Task(\n    instruction=(\n        \"Which Pok\u00e9mon has higher base speed: Pikachu or Gengar? \"\n        \"Use the get_pokemon tool for each \u2014 do not rely on prior knowledge.\"\n    ),\n)\nresult = await agent.run(task)"
+   "source": [
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Which Pokémon has higher base speed: Pikachu or Gengar? \"\n",
+    "        \"Use the get_pokemon tool for each — do not rely on prior knowledge.\"\n",
+    "    ),\n",
+    ")\n",
+    "result = await agent.run(task)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pikachu has a base speed of 90, while Gengar has a base speed of 110. Therefore, Gengar has a higher base speed.\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -216,25 +241,73 @@
    "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "source": [
-    "## Example 2 \u2014 Comparing Attack and Defense\n",
+    "## Example 2 — Comparing Attack and Defense\n",
     "\n",
-    "A second comparison task to reinforce the chaining pattern \u2014 this time across two different stats."
+    "A second comparison task to reinforce the chaining pattern — this time across two different stats."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
-   "outputs": [],
-   "source": "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n\ntask = Task(\n    instruction=(\n        \"Compare Bulbasaur and Charmander. \"\n        \"Which has higher attack and which has higher defense? \"\n        \"Use the get_pokemon tool for each \u2014 do not rely on prior knowledge.\"\n    ),\n)\nresult = await agent.run(task)"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compare Bulbasaur and Charmander. Which has higher attack and which has higher defense? Use the get_pokemon tool for each — do not re...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compare Bulbasaur and Charmander. Which has higher attack and which has higher defense? Use the get_pokemon tool for each — do not...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool for Bulbasaur and Charmander to retrieve their base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool for Bulbasaur and Charmander to retrieve their base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool for Bulbasaur and Charmander to retrieve their base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"bulbasaur\", \"types\": [\"grass\", \"poison\"], \"stats\": {\"hp\": 45, \"attack\": 49, \"defense\": 49, \"special-attack\": 65, \"sp...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"charmander\", \"types\": [\"fire\"], \"stats\": {\"hp\": 39, \"attack\": 52, \"defense\": 43, \"special-attack\": 60, \"special-defe...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have retrieved the base stats for both Bulbasaur and Charmander. Let me compare their attack and defense stats.\n",
+      "\n",
+      "- Bulbasaur's attack...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have retrieved the base stats for both Bulbasaur and Charmander. Let me compare their attack and defense stats.\n",
+      "\n",
+      "- Bulbasaur's att...[TRUNCATED]\n"
+     ]
+    }
+   ],
+   "source": [
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compare Bulbasaur and Charmander. \"\n",
+    "        \"Which has higher attack and which has higher defense? \"\n",
+    "        \"Use the get_pokemon tool for each — do not rely on prior knowledge.\"\n",
+    "    ),\n",
+    ")\n",
+    "result = await agent.run(task)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I have retrieved the base stats for both Bulbasaur and Charmander. Let me compare their attack and defense stats.\n",
+      "\n",
+      "- Bulbasaur's attack is 49 and defense is 49.\n",
+      "- Charmander's attack is 52 and defense is 43.\n",
+      "\n",
+      "From this, I can conclude that Charmander has a higher attack, while Bulbasaur has a higher defense.\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]

--- a/more-examples/ch04/pokemon_error_handling.ipynb
+++ b/more-examples/ch04/pokemon_error_handling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
-   "source": "# Handling Tool Errors Gracefully \u2014 Pok\u00e9API\n\nThis notebook demonstrates how the `LLMAgent` handles tool errors gracefully.\n\nWe define a `get_pokemon` tool that fetches data from the [Pok\u00e9API](https://pokeapi.co/). When a Pok\u00e9mon name is not found the tool raises a `ValueError`. We then give the agent a task with a deliberate typo and observe how it recognises the error and self-corrects."
+   "source": "# Handling Tool Errors Gracefully — PokéAPI\n\nThis notebook demonstrates how the `LLMAgent` handles tool errors gracefully.\n\nWe define a `get_pokemon` tool that fetches data from the [PokéAPI](https://pokeapi.co/). When a Pokémon name is not found the tool raises a `ValueError`. We then give the agent a task with a deliberate typo and observe how it recognises the error and self-corrects."
   },
   {
    "cell_type": "code",
@@ -49,7 +49,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -78,7 +78,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -99,13 +99,44 @@
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
-   "source": "import json\nimport urllib.error\nimport urllib.request\n\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\n\ndef get_pokemon(name: str) -> str:\n    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n    try:\n        with urllib.request.urlopen(url) as resp:\n            data = json.loads(resp.read())\n    except urllib.error.HTTPError as e:\n        if e.code == 404:  # noqa: PLR2004\n            raise ValueError(\n                f\"Pok\u00e9mon '{name}' not found. \"\n                \"Check the spelling and try again.\",\n            ) from e\n        raise\n    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n\n\nget_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+   "source": [
+    "import json\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def get_pokemon(name: str) -> str:\n",
+    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
+    "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
+    "    req = urllib.request.Request(\n",
+    "        url,\n",
+    "        headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    "    )\n",
+    "    try:\n",
+    "        with urllib.request.urlopen(req) as resp:\n",
+    "            data = json.loads(resp.read())\n",
+    "    except urllib.error.HTTPError as e:\n",
+    "        if e.code == 404:  # noqa: PLR2004\n",
+    "            raise ValueError(\n",
+    "                f\"Pokémon '{name}' not found. \"\n",
+    "                \"Check the spelling and try again.\",\n",
+    "            ) from e\n",
+    "        raise\n",
+    "    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n",
+    "    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n",
+    "    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n",
+    "\n",
+    "\n",
+    "get_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
-   "source": "## Example 1 \u2014 Successful Lookup\n\nA straightforward lookup with the correct name."
+   "source": "## Example 1 — Successful Lookup\n\nA straightforward lookup with the correct name."
   },
   {
    "cell_type": "code",
@@ -144,7 +175,7 @@
    "cell_type": "markdown",
    "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
-   "source": "## Example 2 \u2014 Graceful Error Recovery\n\nWe give the agent a deliberate typo (`'Pikachuu'`). The tool returns a `ValueError` and the agent observes the error message, self-corrects the spelling, and retries."
+   "source": "## Example 2 — Graceful Error Recovery\n\nWe give the agent a deliberate typo (`'Pikachuu'`). The tool returns a `ValueError` and the agent observes the error message, self-corrects the spelling, and retries."
   },
   {
    "cell_type": "code",

--- a/more-examples/ch04/pokemon_error_handling.ipynb
+++ b/more-examples/ch04/pokemon_error_handling.ipynb
@@ -4,7 +4,13 @@
    "cell_type": "markdown",
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
-   "source": "# Handling Tool Errors Gracefully — PokéAPI\n\nThis notebook demonstrates how the `LLMAgent` handles tool errors gracefully.\n\nWe define a `get_pokemon` tool that fetches data from the [PokéAPI](https://pokeapi.co/). When a Pokémon name is not found the tool raises a `ValueError`. We then give the agent a task with a deliberate typo and observe how it recognises the error and self-corrects."
+   "source": [
+    "# Handling Tool Errors Gracefully — PokéAPI\n",
+    "\n",
+    "This notebook demonstrates how the `LLMAgent` handles tool errors gracefully.\n",
+    "\n",
+    "We define a `get_pokemon` tool that fetches data from the [PokéAPI](https://pokeapi.co/). When a Pokémon name is not found the tool raises a `ValueError`. We then give the agent a task with a deliberate typo and observe how it recognises the error and self-corrects."
+   ]
   },
   {
    "cell_type": "code",
@@ -21,14 +27,26 @@
    "cell_type": "markdown",
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
-   "source": "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -91,11 +109,13 @@
    "cell_type": "markdown",
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
-   "source": "## Defining the Tool"
+   "source": [
+    "## Defining the Tool"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
@@ -136,14 +156,47 @@
    "cell_type": "markdown",
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
-   "source": "## Example 1 — Successful Lookup\n\nA straightforward lookup with the correct name."
+   "source": [
+    "## Example 1 — Successful Lookup\n",
+    "\n",
+    "A straightforward lookup with the correct name."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What type is Pikachu and what are its base stats?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What type is Pikachu and what are its base stats?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Pikachu\" to retrieve its type and base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its type and base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its type and base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Pikachu is an Electric-type Pokémon. Its base stats are as follows:\n",
+      "\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Pikachu is an Electric-type Pokémon. Its base stats are as follows:\n",
+      "\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Spec...[TRUNCATED]\n"
+     ]
+    }
+   ],
    "source": [
     "import logging\n",
     "\n",
@@ -163,10 +216,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pikachu is an Electric-type Pokémon. Its base stats are as follows:\n",
+      "\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special Defense: 50\n",
+      "- Speed: 90\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -175,14 +243,40 @@
    "cell_type": "markdown",
    "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
-   "source": "## Example 2 — Graceful Error Recovery\n\nWe give the agent a deliberate typo (`'Pikachuu'`). The tool returns a `ValueError` and the agent observes the error message, self-corrects the spelling, and retries."
+   "source": [
+    "## Example 2 — Graceful Error Recovery\n",
+    "\n",
+    "We give the agent a deliberate typo (`'Pikachuu'`). The tool returns a `ValueError` and the agent observes the error message, self-corrects the spelling, and retries."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What type is Pikachuu?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What type is Pikachuu?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Pikachuu\" to find out its type.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Pikachuu' to retrieve its type information.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Pikachuu' to retrieve its type information.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"error_type\": \"ValueError\", \"message\": \"Internal error while executing tool: Pok\\u00e9mon 'Pikachuu' not found. Check the spe...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: It seems that there was an error because the Pokémon \"Pikachuu\" could not be found. This might be due to a typo or incorrect spelling. ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its type information.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its type information.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Pokémon \"Pikachu\" is of the **electric** type.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Pokémon \"Pikachu\" is of the **electric** type.\n"
+     ]
+    }
+   ],
    "source": [
     "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
     "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
@@ -193,10 +287,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Pokémon \"Pikachu\" is of the **electric** type.\n"
+     ]
+    }
+   ],
    "source": [
     "print(result)"
    ]
@@ -209,8 +311,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/more-examples/ch04/pokemon_error_handling.ipynb
+++ b/more-examples/ch04/pokemon_error_handling.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": "# Handling Tool Errors Gracefully \u2014 Pok\u00e9API\n\nThis notebook demonstrates how the `LLMAgent` handles tool errors gracefully.\n\nWe define a `get_pokemon` tool that fetches data from the [Pok\u00e9API](https://pokeapi.co/). When a Pok\u00e9mon name is not found the tool raises a `ValueError`. We then give the agent a task with a deliberate typo and observe how it recognises the error and self-corrects."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": "## Running an Ollama service\n\nTo execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": "## Defining the Tool"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nimport urllib.error\nimport urllib.request\n\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\n\ndef get_pokemon(name: str) -> str:\n    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n    try:\n        with urllib.request.urlopen(url) as resp:\n            data = json.loads(resp.read())\n    except urllib.error.HTTPError as e:\n        if e.code == 404:  # noqa: PLR2004\n            raise ValueError(\n                f\"Pok\u00e9mon '{name}' not found. \"\n                \"Check the spelling and try again.\",\n            ) from e\n        raise\n    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n\n\nget_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "source": "## Example 1 \u2014 Successful Lookup\n\nA straightforward lookup with the correct name."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(instruction=\"What type is Pikachu and what are its base stats?\")\n",
+    "result = await agent.run(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": "## Example 2 \u2014 Graceful Error Recovery\n\nWe give the agent a deliberate typo (`'Pikachuu'`). The tool returns a `ValueError` and the agent observes the error message, self-corrects the spelling, and retries."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool])\n",
+    "\n",
+    "task = Task(instruction=\"What type is Pikachuu?\")\n",
+    "result = await agent.run(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Closes #499.

Creates `more-examples/ch04/` with two new notebooks:

- **`pokemon_error_handling.ipynb`** — Shows the `LLMAgent` handling a tool error gracefully. A `get_pokemon` tool raises a `ValueError` on a 404 from the PokéAPI. The agent observes the error, self-corrects a typo in the Pokémon name, and retries.
- **`pokemon_comparison.ipynb`** — Shows multi-step reasoning via chained tool calls. The agent calls `get_pokemon` twice (once per Pokémon) and synthesises both results to answer comparison questions.

Both notebooks are symlinked into `docs/more-examples/ch04/` and wired into the `mkdocs.yml` nav under a new Chapter 4 section in More Examples.

## Test plan

- [x] Run `pokemon_error_handling.ipynb` — confirm agent self-corrects the typo "Pikachuu" → "pikachu"
- [x] Run `pokemon_comparison.ipynb` — confirm agent makes two sequential tool calls before answering

🤖 Generated with [Claude Code](https://claude.com/claude-code)