### PR TITLE
refactor: rename rollout contribution method and templates (#502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: rename rollout contribution method, templates, and local vars (#502)
 - refactor: rip out disable_model_invocation from LLMAgent (#456)
 - refactor: outsource SKILL_SUBDIR to skills/constants (#453)
 - Refactor _SKILL_SUBDIRS to use .agents/skills only (#452)

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -203,7 +203,7 @@ class LLMAgent:
             chat_history: list[ChatMessage],
         ) -> str:
             """Format a run_step's chat history as a rollout entry."""
-            rollout_contributions = ["=== Task Step Start ==="]
+            rollout_lines = ["=== Task Step Start ==="]
             for msg in chat_history:
                 # don't include system messages in rollout
                 content = msg.content
@@ -235,7 +235,7 @@ class LLMAgent:
                         called_tools=called_tools,
                     )
 
-                rollout_contributions.append(
+                rollout_lines.append(
                     self.llm_agent.templates[
                         "step_rollout_chat_message"
                     ].format(
@@ -245,11 +245,11 @@ class LLMAgent:
                     ),
                 )
 
-            rollout_contributions.append(
+            rollout_lines.append(
                 "=== Task Step End ===",
             )
 
-            return "\n\n".join(rollout_contributions)
+            return "\n\n".join(rollout_lines)
 
         async def get_next_step(
             self,
@@ -451,14 +451,14 @@ class LLMAgent:
                 ]
 
             # augment rollout from this turn
-            rollout_contribution = self._format_step_for_rollout(
+            formatted_step = self._format_step_for_rollout(
                 chat_history=chat_history,
             )
             if self.rollout:
-                self.rollout += "\n\n" + rollout_contribution
+                self.rollout += "\n\n" + formatted_step
 
             else:
-                self.rollout = rollout_contribution
+                self.rollout = formatted_step
 
             self.logger.info(
                 f"✅ Step Result: {final_content}",

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -198,11 +198,11 @@ class LLMAgent:
                 skills=entries,
             )
 
-        def _rollout_contribution_from_single_run_step(
+        def _format_step_for_rollout(
             self,
             chat_history: list[ChatMessage],
         ) -> str:
-            """Update rollout after a run_step execution."""
+            """Format a run_step's chat history as a rollout entry."""
             rollout_contributions = ["=== Task Step Start ==="]
             for msg in chat_history:
                 # don't include system messages in rollout
@@ -217,7 +217,7 @@ class LLMAgent:
                     # we'll simplify to just LLM agent having a monologue
                     role = ChatRole.ASSISTANT
                     content = self.llm_agent.templates[
-                        "rollout_contribution_content_instruction"
+                        "step_rollout_content_instruction"
                     ].format(
                         instruction=content,
                     )
@@ -230,14 +230,14 @@ class LLMAgent:
                         ],
                     )
                     content = self.llm_agent.templates[
-                        "rollout_contribution_content_tool_call_request"
+                        "step_rollout_content_tool_call_request"
                     ].format(
                         called_tools=called_tools,
                     )
 
                 rollout_contributions.append(
                     self.llm_agent.templates[
-                        "rollout_contribution_from_chat_message"
+                        "step_rollout_chat_message"
                     ].format(
                         actor=("🔧 " if role == ChatRole.TOOL else "💬 ")
                         + role.value,
@@ -451,10 +451,8 @@ class LLMAgent:
                 ]
 
             # augment rollout from this turn
-            rollout_contribution = (
-                self._rollout_contribution_from_single_run_step(
-                    chat_history=chat_history,
-                )
+            rollout_contribution = self._format_step_for_rollout(
+                chat_history=chat_history,
             )
             if self.rollout:
                 self.rollout += "\n\n" + rollout_contribution

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -44,13 +44,13 @@ What is your decision?
 
 DEFAULT_RUN_STEP_USER_MESSAGE = "{instruction}"
 
-DEFAULT_ROLLOUT_CONTRIBUTION_FROM_CHAT_MESSAGE = "{actor}: {content}"
+DEFAULT_STEP_ROLLOUT_CHAT_MESSAGE = "{actor}: {content}"
 
-DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_INSTRUCTION = (
+DEFAULT_STEP_ROLLOUT_CONTENT_INSTRUCTION = (
     "My current instruction is '{instruction}'"
 )
 
-DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_TOOL_CALL_REQUEST = (
+DEFAULT_STEP_ROLLOUT_CONTENT_TOOL_CALL_REQUEST = (
     "I need to make the following tool call(s):\n\n{called_tools}."
 )
 

--- a/src/llm_agents_from_scratch/agent/templates/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/templates/llm_agent.py
@@ -4,13 +4,13 @@ from typing import TypedDict
 
 from .defaults import (
     DEFAULT_GET_NEXT_INSTRUCTION_PROMPT,
-    DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_INSTRUCTION,
-    DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_TOOL_CALL_REQUEST,
-    DEFAULT_ROLLOUT_CONTRIBUTION_FROM_CHAT_MESSAGE,
     DEFAULT_RUN_STEP_SYSTEM_MESSAGE,
     DEFAULT_RUN_STEP_SYSTEM_MESSAGE_WITHOUT_ROLLOUT,
     DEFAULT_RUN_STEP_USER_MESSAGE,
     DEFAULT_SKILLS_CATALOG,
+    DEFAULT_STEP_ROLLOUT_CHAT_MESSAGE,
+    DEFAULT_STEP_ROLLOUT_CONTENT_INSTRUCTION,
+    DEFAULT_STEP_ROLLOUT_CONTENT_TOOL_CALL_REQUEST,
     DEFAULT_SYSTEM_MESSAGE,
 )
 
@@ -21,9 +21,9 @@ class LLMAgentTemplates(TypedDict):
     system_message: str
     # for task handler
     get_next_step: str
-    rollout_contribution_from_chat_message: str
-    rollout_contribution_content_instruction: str
-    rollout_contribution_content_tool_call_request: str
+    step_rollout_chat_message: str
+    step_rollout_content_instruction: str
+    step_rollout_content_tool_call_request: str
     run_step_system_message_without_rollout: str
     run_step_system_message: str
     run_step_user_message: str
@@ -34,9 +34,9 @@ class LLMAgentTemplates(TypedDict):
 default_templates = LLMAgentTemplates(
     system_message=DEFAULT_SYSTEM_MESSAGE,
     get_next_step=DEFAULT_GET_NEXT_INSTRUCTION_PROMPT,
-    rollout_contribution_from_chat_message=DEFAULT_ROLLOUT_CONTRIBUTION_FROM_CHAT_MESSAGE,
-    rollout_contribution_content_instruction=DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_INSTRUCTION,
-    rollout_contribution_content_tool_call_request=DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_TOOL_CALL_REQUEST,
+    step_rollout_chat_message=DEFAULT_STEP_ROLLOUT_CHAT_MESSAGE,
+    step_rollout_content_instruction=DEFAULT_STEP_ROLLOUT_CONTENT_INSTRUCTION,
+    step_rollout_content_tool_call_request=DEFAULT_STEP_ROLLOUT_CONTENT_TOOL_CALL_REQUEST,
     run_step_system_message_without_rollout=DEFAULT_RUN_STEP_SYSTEM_MESSAGE_WITHOUT_ROLLOUT,
     run_step_system_message=DEFAULT_RUN_STEP_SYSTEM_MESSAGE,
     run_step_user_message=DEFAULT_RUN_STEP_USER_MESSAGE,

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -261,11 +261,11 @@ def test_private_format_step_for_rollout(
     ]
 
     # act
-    rollout_contribution = handler._format_step_for_rollout(
+    formatted_step = handler._format_step_for_rollout(
         chat_history=chat_history,
     )
 
-    expected_rollout_contribution = (
+    expected_formatted_step = (
         "=== Task Step Start ===\n\n"
         "💬 assistant: My current instruction is 'a user message'\n\n"
         "💬 assistant: I need to make the following tool call(s):"
@@ -275,7 +275,7 @@ def test_private_format_step_for_rollout(
         "=== Task Step End ==="
     )
 
-    assert rollout_contribution == expected_rollout_contribution
+    assert formatted_step == expected_formatted_step
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -218,7 +218,7 @@ async def test_get_next_step_raises_error_from_structured_output_call(
     assert initial_step.instruction == "mock instruction"
 
 
-def test_private_rollout_contribution_from_single_run_step(
+def test_private_format_step_for_rollout(
     mock_llm: BaseLLM,
 ) -> None:
     """Tests helper method to get rollout contribution from run step."""
@@ -261,7 +261,7 @@ def test_private_rollout_contribution_from_single_run_step(
     ]
 
     # act
-    rollout_contribution = handler._rollout_contribution_from_single_run_step(
+    rollout_contribution = handler._format_step_for_rollout(
         chat_history=chat_history,
     )
 


### PR DESCRIPTION
## Summary

- Renames `_rollout_contribution_from_single_run_step` → `_format_step_for_rollout`
- Renames `DEFAULT_ROLLOUT_CONTRIBUTION_FROM_CHAT_MESSAGE` → `DEFAULT_STEP_ROLLOUT_CHAT_MESSAGE`
- Renames `DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_INSTRUCTION` → `DEFAULT_STEP_ROLLOUT_CONTENT_INSTRUCTION`
- Renames `DEFAULT_ROLLOUT_CONTRIBUTION_CONTENT_TOOL_CALL_REQUEST` → `DEFAULT_STEP_ROLLOUT_CONTENT_TOOL_CALL_REQUEST`
- Updates `LLMAgentTemplates` TypedDict keys accordingly (`step_rollout_*` prefix)
- Updates test to match new method name

## Test plan

- [x] All 196 unit tests pass
- [x] `make lint` passes (ruff + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)