### PR TITLE
chore: update TaskHandler UML diagrams with renamed method (#504)

### DIFF
--- a/uml/ch04/llm_agent_class_pt2.puml
+++ b/uml/ch04/llm_agent_class_pt2.puml
@@ -38,7 +38,7 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     +<<constructor>> __init__(\n\tllm_agent: LLMAgent,\n\ttask: Task \n):
     +<<async>> get_next_step(\n\tprevious_step_result: TaskStepResult | None\n): TaskStep | TaskResult
     +<<async>> run_step(step: TaskStep): TaskStepResult
-    -_rollout_contribution_from_single_run_step()
+    -_format_step_for_rollout()
   }
 
 }

--- a/uml/ch06/taskhandler.puml
+++ b/uml/ch06/taskhandler.puml
@@ -21,7 +21,7 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     +<<constructor>> __init__(\n\tllm_agent: LLMAgent,\n\ttask: Task,\n\tskills_scopes: list[SkillScope],\n\texplicit_only_skills: set[str],\n\t*args, **kwargs\n):
     <color:#aaaaaa>+<<async>> get_next_step(): TaskStep | TaskResult</color>
     +<b><<async>> run_step(step: TaskStep): TaskStepResult</b>
-    <color:#aaaaaa>-_rollout_contribution_from_single_run_step()</color>
+    <color:#aaaaaa>-_format_step_for_rollout()</color>
   }
 }
 


### PR DESCRIPTION
## Summary

- Updates `_rollout_contribution_from_single_run_step` → `_format_step_for_rollout` in `uml/ch04/llm_agent_class_pt2.puml`
- Same update in `uml/ch06/taskhandler.puml` (greyed-out inherited entry)

Follows the rename done in #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)