### PR TITLE
ch03: add multi-turn trivia chat more-example (#505)

### DIFF
--- a/docs/more-examples/ch03/multi_turn_chat.ipynb
+++ b/docs/more-examples/ch03/multi_turn_chat.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch03/multi_turn_chat.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ nav:
   - More Examples:
     - more-examples/index.md
     # Symlinked from more-examples/ — do not copy directly.
+    - Chapter 3:
+      - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
     - Chapter 4:
       - Handling Tool Errors (PokéAPI): more-examples/ch04/pokemon_error_handling.ipynb
       - Multi-Step Chained Calls (PokéAPI): more-examples/ch04/pokemon_comparison.ipynb

--- a/more-examples/ch03/multi_turn_chat.ipynb
+++ b/more-examples/ch03/multi_turn_chat.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Turn Trivia Chat\n",
+    "\n",
+    "This notebook demonstrates stateful multi-turn conversation using `chat()` with a manually maintained `chat_history`.\n",
+    "\n",
+    "We cast the LLM as a trivia quiz master. The notebook supplies hardcoded user answers so the whole conversation runs end-to-end without human input. After each answer the LLM gives feedback and tracks the score, showing how context accumulates across turns.\n",
+    "\n",
+    "> **Chapter 3 concept:** `chat()` returns the new `(user_msg, assistant_msg)` pair each turn. By appending both messages to `chat_history` before the next call, the LLM sees the full conversation and can reason across turns — the foundation of everything the `LLMAgent` automates later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We initialise the LLM and seed `chat_history` with a system message that gives the quiz master its persona and instructs it to ask exactly three specific questions in order. This keeps the notebook reproducible — the hardcoded answers below are written to match those questions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch.data_structures.llm import ChatMessage, ChatRole\n",
+    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
+    "\n",
+    "SYSTEM_PROMPT = (\n",
+    "    \"You are an enthusiastic trivia quiz master running\\n\"\n",
+    "    \"a 3-question general-knowledge quiz.\\n\\n\"\n",
+    "    \"Rules:\\n\"\n",
+    "    \"- Ask exactly these three questions, one per turn, in this order:\\n\"\n",
+    "    \"  1. What planet in our solar system is known as the Red Planet?\\n\"\n",
+    "    \"  2. What is the largest ocean on Earth?\\n\"\n",
+    "    \"  3. In what year did the first crewed Moon landing take place?\\n\"\n",
+    "    \"- After each answer, say whether it is correct or incorrect,\\n\"\n",
+    "    \"  and give a one-sentence explanation.\\n\"\n",
+    "    '- Keep a running score (e.g. \"Score: 1/1\") visible after each feedback.\\n'\n",
+    "    \"- After the third answer, announce the final score\\n\"\n    \"  and a short closing remark.\\n\"\n",
+    "    \"- Keep all responses concise.\"\n",
+    ")\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "\n",
+    "system_msg = ChatMessage(role=ChatRole.SYSTEM, content=SYSTEM_PROMPT)\n",
+    "chat_history = [system_msg]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Turn 1 — Starting the Game\n",
+    "\n",
+    "The user kicks off the game. The LLM responds with a welcome and asks the first question.\n",
+    "Both messages are appended to `chat_history` before the next call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[User]         Let's play! I'm ready.\n",
+      "[Quiz Master]  Sure thing! Let's get started with the first question:\n",
+      "\n",
+      "**1. What planet in our solar system is known as the Red Planet?**\n"
+     ]
+    }
+   ],
+   "source": [
+    "user_msg, assistant_msg = await llm.chat(\n",
+    "    \"Let's play! I'm ready.\",\n",
+    "    chat_history=chat_history,\n",
+    ")\n",
+    "chat_history += [user_msg, assistant_msg]\n",
+    "\n",
+    "print(\"[User]         Let's play! I'm ready.\")\n",
+    "print(f\"[Quiz Master]  {assistant_msg.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Turn 2 — Question 1 Answer\n",
+    "\n",
+    "The user answers correctly. We append both messages and call `chat()` again with the full history."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[User]         Mars!\n",
+      "[Quiz Master]  Correct! Mars is called the Red Planet due to its reddish appearance, caused by iron oxide (rust) on its surface.  \n",
+      "Score: 1/1\n",
+      "\n",
+      "**2. What is the largest ocean on Earth?**\n"
+     ]
+    }
+   ],
+   "source": [
+    "answer_1 = \"Mars!\"\n",
+    "\n",
+    "user_msg, assistant_msg = await llm.chat(\n",
+    "    answer_1,\n",
+    "    chat_history=chat_history,\n",
+    ")\n",
+    "chat_history += [user_msg, assistant_msg]\n",
+    "\n",
+    "print(f\"[User]         {answer_1}\")\n",
+    "print(f\"[Quiz Master]  {assistant_msg.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspecting the growing chat history\n",
+    "\n",
+    "After two turns the history already holds 5 messages (system + 2 user + 2 assistant). Every subsequent `chat()` call sends this full context to the LLM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Messages in chat_history: 5\n",
+      "\n",
+      "  [system    ]  You are an enthusiastic trivia quiz master running a 3-question general-knowledg...\n",
+      "  [user      ]  Let's play! I'm ready.\n",
+      "  [assistant ]  Sure thing! Let's get started with the first question:  **1. What planet in our ...\n",
+      "  [user      ]  Mars!\n",
+      "  [assistant ]  Correct! Mars is called the Red Planet due to its reddish appearance, caused by ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "PREVIEW_LEN = 80\n",
+    "print(f\"Messages in chat_history: {len(chat_history)}\\n\")\n",
+    "for msg in chat_history:\n",
+    "    preview = msg.content[:PREVIEW_LEN].replace(\"\\n\", \" \")\n",
+    "    suffix = \"...\" if len(msg.content) > PREVIEW_LEN else \"\"\n",
+    "    print(f\"  [{msg.role.value:10s}]  {preview}{suffix}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Turn 3 — Question 2 Answer\n",
+    "\n",
+    "The user answers incorrectly this time (`Atlantic Ocean` instead of `Pacific Ocean`). The LLM should catch the mistake, correct it, and update the score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[User]         I think it's the Atlantic Ocean.\n",
+      "[Quiz Master]  Incorrect. The largest ocean on Earth is the Pacific Ocean, which covers more than 60 million square miles.  \n",
+      "Score: 1/2\n",
+      "\n",
+      "**3. In what year did the first crewed Moon landing take place?**\n"
+     ]
+    }
+   ],
+   "source": [
+    "answer_2 = \"I think it's the Atlantic Ocean.\"\n",
+    "\n",
+    "user_msg, assistant_msg = await llm.chat(\n",
+    "    answer_2,\n",
+    "    chat_history=chat_history,\n",
+    ")\n",
+    "chat_history += [user_msg, assistant_msg]\n",
+    "\n",
+    "print(f\"[User]         {answer_2}\")\n",
+    "print(f\"[Quiz Master]  {assistant_msg.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Turn 4 — Final Question Answer & Score\n",
+    "\n",
+    "The user answers the last question correctly. The LLM tallies the final score and wraps up the game."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[User]         1969.\n",
+      "[Quiz Master]  Correct! The first crewed Moon landing occurred in 1969, with NASA's Apollo 11 mission.  \n",
+      "Score: 2/2\n",
+      "\n",
+      "Congratulations! You got 2 out of 3 questions correct. Great job!\n"
+     ]
+    }
+   ],
+   "source": [
+    "answer_3 = \"1969.\"\n",
+    "\n",
+    "user_msg, assistant_msg = await llm.chat(\n",
+    "    answer_3,\n",
+    "    chat_history=chat_history,\n",
+    ")\n",
+    "chat_history += [user_msg, assistant_msg]\n",
+    "\n",
+    "print(f\"[User]         {answer_3}\")\n",
+    "print(f\"[Quiz Master]  {assistant_msg.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Final Chat History\n",
+    "\n",
+    "After 4 turns the history holds 9 messages. This is exactly what an `LLMAgent` manages internally — `chat_history` is the agent's short-term memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total messages in chat_history: 9\n",
+      "\n",
+      "  [system    ]  You are an enthusiastic trivia quiz master running a 3-question general-knowledge quiz.  Rules: - As...\n",
+      "  [user      ]  Let's play! I'm ready.\n",
+      "  [assistant ]  Sure thing! Let's get started with the first question:  **1. What planet in our solar system is know...\n",
+      "  [user      ]  Mars!\n",
+      "  [assistant ]  Correct! Mars is called the Red Planet due to its reddish appearance, caused by iron oxide (rust) on...\n",
+      "  [user      ]  I think it's the Atlantic Ocean.\n",
+      "  [assistant ]  Incorrect. The largest ocean on Earth is the Pacific Ocean, which covers more than 60 million square...\n",
+      "  [user      ]  1969.\n",
+      "  [assistant ]  Correct! The first crewed Moon landing occurred in 1969, with NASA's Apollo 11 mission.   Score: 2/2...\n"
+     ]
+    }
+   ],
+   "source": [
+    "PREVIEW_LEN = 100\n",
+    "print(f\"Total messages in chat_history: {len(chat_history)}\\n\")\n",
+    "for msg in chat_history:\n",
+    "    preview = msg.content[:PREVIEW_LEN].replace(\"\\n\", \" \")\n",
+    "    suffix = \"...\" if len(msg.content) > PREVIEW_LEN else \"\"\n",
+    "    print(f\"  [{msg.role.value:10s}]  {preview}{suffix}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch03/multi_turn_chat.ipynb` — a multi-turn trivia game demonstrating stateful conversation via `chat()` with a manually maintained `chat_history`
- LLM plays quiz master across 3 rounds; hardcoded user answers (one deliberately wrong) so the notebook runs end-to-end
- Mid-game and final history inspection cells show the growing message list, bridging to what `LLMAgent` automates in ch04
- Adds `docs/more-examples/ch03/` symlink and `mkdocs.yml` nav entry under `More Examples > Chapter 3`

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)