### PR TITLE
ch03: add structured PDF extraction more-example (#506)

### DIFF
--- a/docs/more-examples/ch03/pdf_extraction.ipynb
+++ b/docs/more-examples/ch03/pdf_extraction.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch03/pdf_extraction.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
     # Symlinked from more-examples/ — do not copy directly.
     - Chapter 3:
       - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
+      - Structured Extraction from a PDF: more-examples/ch03/pdf_extraction.ipynb
     - Chapter 4:
       - Handling Tool Errors (PokéAPI): more-examples/ch04/pokemon_error_handling.ipynb
       - Multi-Step Chained Calls (PokéAPI): more-examples/ch04/pokemon_comparison.ipynb

--- a/more-examples/ch03/pdf_extraction.ipynb
+++ b/more-examples/ch03/pdf_extraction.ipynb
@@ -1,0 +1,402 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Structured Extraction from a PDF\n",
+    "\n",
+    "This notebook demonstrates `structured_output()` applied to a real-world task:\n",
+    "extracting structured metadata from a research paper that has been converted\n",
+    "to markdown.\n",
+    "\n",
+    "We fetch the [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629)\n",
+    "paper (Yao et al., 2022), parse its first three pages to markdown using\n",
+    "`pymupdf4llm`, then ask the LLM to fill in a Pydantic model with the paper's\n",
+    "key fields.\n",
+    "\n",
+    "> **Chapter 3 concept:** `structured_output()` accepts any text prompt and a\n",
+    "> Pydantic model class, and returns a validated instance of that model. Here\n",
+    "> we use it to turn unstructured PDF text into a typed Python object in a\n",
+    "> single call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama\n",
+    "installed on your local machine and have its LLM hosting service running.\n",
+    "To download Ollama, follow the instructions found on this page:\n",
+    "https://ollama.com/download. After downloading and installing Ollama, you\n",
+    "can start a service by opening a terminal and running the command\n",
+    "`ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installing the PDF Parser\n",
+    "\n",
+    "We use [`pymupdf4llm`](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/)\n",
+    "to convert PDF pages to markdown. It is not part of the core\n",
+    "`llm-agents-from-scratch` dependencies, so we install it here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mAudited \u001b[1m1 package\u001b[0m \u001b[2min 0.66ms\u001b[0m\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!uv pip install pymupdf4llm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetching the Paper\n",
+    "\n",
+    "We download the first three pages of the ReAct paper directly from arXiv.\n",
+    "These pages cover the title, authors, abstract, and opening sections —\n",
+    "enough context for the LLM to fill in all extraction fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded 633,805 bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import pymupdf4llm\n",
+    "\n",
+    "PDF_URL = \"https://arxiv.org/pdf/2210.03629\"\n",
+    "PDF_PAGES = [0, 1, 2]  # title, abstract, intro\n",
+    "\n",
+    "req = urllib.request.Request(\n",
+    "    PDF_URL,\n",
+    "    headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    ")\n",
+    "with urllib.request.urlopen(req) as resp:\n",
+    "    pdf_bytes = resp.read()\n",
+    "\n",
+    "print(f\"Downloaded {len(pdf_bytes):,} bytes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parsing PDF to Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracted 14,957 characters of markdown\n",
+      "--- preview (first 500 chars) ---\n",
+      "Published as a conference paper at ICLR 2023 \n",
+      "\n",
+      "# REACT: SYNERGIZING REASONING AND ACTING IN LANGUAGE MODELS \n",
+      "\n",
+      "Shunyu Yao _[∗]_[*,1] , Jeffrey Zhao[2] , Dian Yu[2] , Nan Du[2] , Izhak Shafran[2] , Karthik Narasimhan[1] , Yuan Cao[2] \n",
+      "\n",
+      "1Department of Computer Science, Princeton University \n",
+      "\n",
+      "2Google Research, Brain team \n",
+      "\n",
+      "1{shunyuy,karthikn}@princeton.edu \n",
+      "\n",
+      "2{jeffreyzhao,dianyu,dunan,izhak,yuancao}@google.com \n",
+      "\n",
+      "## ABSTRACT \n",
+      "\n",
+      "While large language models (LLMs) have demonstrated impressive performanc\n"
+     ]
+    }
+   ],
+   "source": [
+    "with tempfile.NamedTemporaryFile(\n",
+    "    suffix=\".pdf\",\n",
+    "    delete=False,\n",
+    ") as tmp:\n",
+    "    tmp.write(pdf_bytes)\n",
+    "    tmp_path = Path(tmp.name)\n",
+    "\n",
+    "try:\n",
+    "    md_text = pymupdf4llm.to_markdown(str(tmp_path), pages=PDF_PAGES)\n",
+    "finally:\n",
+    "    tmp_path.unlink(missing_ok=True)\n",
+    "\n",
+    "print(f\"Extracted {len(md_text):,} characters of markdown\")\n",
+    "print(\"--- preview (first 500 chars) ---\")\n",
+    "print(md_text[:500])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining the Extraction Model\n",
+    "\n",
+    "We define a Pydantic model that captures the key metadata fields we want\n",
+    "to pull from the paper. The LLM will populate every field from the markdown\n",
+    "text in a single `structured_output()` call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "class PaperSummary(BaseModel):\n",
+    "    \"\"\"Structured metadata extracted from a research paper.\"\"\"\n",
+    "\n",
+    "    title: str = Field(description=\"Full title of the paper.\")\n",
+    "    authors: list[str] = Field(\n",
+    "        description=\"List of author names as they appear on the paper.\",\n",
+    "    )\n",
+    "    year: int = Field(\n",
+    "        description=\"Year the paper was published or submitted.\",\n",
+    "    )\n",
+    "    abstract: str = Field(\n",
+    "        description=\"The paper's abstract, faithfully reproduced.\",\n",
+    "    )\n",
+    "    key_contributions: list[str] = Field(\n",
+    "        description=(\n",
+    "            \"Three to five concise bullet points summarising \"\n",
+    "            \"the paper's main contributions.\"\n",
+    "        ),\n",
+    "    )\n",
+    "    primary_topic: str = Field(\n",
+    "        description=(\n",
+    "            \"One short phrase describing the paper's primary research topic \"\n",
+    "            \"(e.g. 'LLM reasoning', 'tool use', 'multi-agent systems').\"\n",
+    "        ),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extracting Structured Data\n",
+    "\n",
+    "We pass the markdown text as the prompt and `PaperSummary` as the target\n",
+    "model. `structured_output()` returns a fully validated `PaperSummary`\n",
+    "instance — no parsing or post-processing needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class '__main__.PaperSummary'> \n",
+      "\n",
+      "{'title': 'REACT: SYNERGIZING REASONING AND ACTING IN LANGUAGE MODELS', 'authors': ['Shunyu Yao', 'Jeffrey Zhao', 'Dian Yu', 'Nan Du', 'Izhak Shafran', 'Karthik Narasimhan', 'Yuan Cao'], 'year': 2023, 'abstract': 'While large language models (LLMs) have demonstrated impressive performance across tasks in language understanding and interactive decision making, their abilities for reasoning (e.g. chain-of-thought prompting) and acting (e.g. action plan generation) have primarily been studied as separate topics. In this paper, we explore the use of LLMs to generate both verbal reasoning traces and actions pertaining to a task in an interleaved manner, which allows the model to perform dynamic reasoning to create, maintain, and adjust high-level plans for acting while also interacting with external environments to incorporate additional information into reasoning. We conduct empirical evaluations of ReAct and state-of-the-art baselines on four diverse benchmarks: HotPotQA, Fever, ALFWorld, and WebShop. ReAct outperforms existing methods in few-shot learning setups and demonstrates benefits in interpretability, trustworthiness, and diagnosability.', 'key_contributions': ['Introduce ReAct, a novel prompt-based paradigm to synergize reasoning and acting in language models for general task solving.', 'Perform extensive experiments across diverse benchmarks to showcase the advantage of ReAct in a few-shot learning setup over prior approaches that perform either reasoning or action generation in isolation.', 'Present systematic ablations and analysis to understand the importance of acting in reasoning tasks, and reasoning in interactive tasks.', 'Analyze the limitations of ReAct under the prompting setup and perform initial finetuning experiments showing the potential of ReAct to improve with additional training data.'], 'primary_topic': 'Synergizing reasoning and acting in language models for general task solving using the ReAct paradigm.'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "\n",
+    "prompt = (\n",
+    "    \"Extract structured metadata from the following research paper.\\n\\n\"\n",
+    "    f\"{md_text}\"\n",
+    ")\n",
+    "\n",
+    "summary = await llm.structured_output(prompt=prompt, mdl=PaperSummary)\n",
+    "print(type(summary), \"\\n\")\n",
+    "print(summary.model_dump())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Title:          REACT: SYNERGIZING REASONING AND ACTING IN LANGUAGE MODELS\n",
+      "Year:           2023\n",
+      "Authors:        Shunyu Yao, Jeffrey Zhao, Dian Yu, Nan Du, Izhak Shafran, Karthik Narasimhan, Yuan Cao\n",
+      "Primary topic:  Synergizing reasoning and acting in language models for general task solving using the ReAct paradigm.\n",
+      "\n",
+      "Abstract:\n",
+      "While large language models (LLMs) have demonstrated impressive performance across tasks in language understanding and interactive decision making, their abilities for reasoning (e.g. chain-of-thought prompting) and acting (e.g. action plan generation) have primarily been studied as separate topics. In this paper, we explore the use of LLMs to generate both verbal reasoning traces and actions pertaining to a task in an interleaved manner, which allows the model to perform dynamic reasoning to create, maintain, and adjust high-level plans for acting while also interacting with external environments to incorporate additional information into reasoning. We conduct empirical evaluations of ReAct and state-of-the-art baselines on four diverse benchmarks: HotPotQA, Fever, ALFWorld, and WebShop. ReAct outperforms existing methods in few-shot learning setups and demonstrates benefits in interpretability, trustworthiness, and diagnosability.\n",
+      "\n",
+      "Key contributions:\n",
+      "  • Introduce ReAct, a novel prompt-based paradigm to synergize reasoning and acting in language models for general task solving.\n",
+      "  • Perform extensive experiments across diverse benchmarks to showcase the advantage of ReAct in a few-shot learning setup over prior approaches that perform either reasoning or action generation in isolation.\n",
+      "  • Present systematic ablations and analysis to understand the importance of acting in reasoning tasks, and reasoning in interactive tasks.\n",
+      "  • Analyze the limitations of ReAct under the prompting setup and perform initial finetuning experiments showing the potential of ReAct to improve with additional training data.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Title:          {summary.title}\")\n",
+    "print(f\"Year:           {summary.year}\")\n",
+    "print(f\"Authors:        {', '.join(summary.authors)}\")\n",
+    "print(f\"Primary topic:  {summary.primary_topic}\")\n",
+    "print()\n",
+    "print(\"Abstract:\")\n",
+    "print(summary.abstract)\n",
+    "print()\n",
+    "print(\"Key contributions:\")\n",
+    "for point in summary.key_contributions:\n",
+    "    print(f\"  • {point}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch03/pdf_extraction.ipynb` — uses `structured_output()` to extract typed metadata from a real research paper
- Fetches the ReAct paper (arXiv:2210.03629) directly from arXiv, converts the first three pages to markdown using `pymupdf4llm` (installed inline via `!uv pip install`)
- Populates a `PaperSummary` Pydantic model: `title`, `authors` (`list[str]`), `year`, `abstract`, `key_contributions` (`list[str]`), `primary_topic`
- Adds `docs/more-examples/ch03/` symlink and `mkdocs.yml` nav entry

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)