### PR TITLE
ch03: add parallel tool calls more-example (#507)

### DIFF
--- a/docs/more-examples/ch03/parallel_tool_calls.ipynb
+++ b/docs/more-examples/ch03/parallel_tool_calls.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch03/parallel_tool_calls.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Chapter 3:
       - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
       - Structured Extraction from a PDF: more-examples/ch03/pdf_extraction.ipynb
+      - Parallel Tool Calls: more-examples/ch03/parallel_tool_calls.ipynb
     - Chapter 4:
       - Handling Tool Errors (PokéAPI): more-examples/ch04/pokemon_error_handling.ipynb
       - Multi-Step Chained Calls (PokéAPI): more-examples/ch04/pokemon_comparison.ipynb

--- a/more-examples/ch03/parallel_tool_calls.ipynb
+++ b/more-examples/ch03/parallel_tool_calls.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parallel Tool Calls\n",
+    "\n",
+    "This notebook demonstrates how a single LLM response can contain\n",
+    "**multiple tool call requests**, and how to execute them all before\n",
+    "returning the results in one `continue_chat_with_tool_results()` call.\n",
+    "\n",
+    "We use the `hailstone_step_func` tool from Chapter 3 and ask the LLM\n",
+    "to apply it to several numbers at once. The LLM batches the calls\n",
+    "in a single response; we execute each one and send all results back\n",
+    "together.\n",
+    "\n",
+    "> **Chapter 3 concept:** `chat()` returns an assistant `ChatMessage`\n",
+    "> whose `tool_calls` field can hold *any number* of requests. Collecting\n",
+    "> all results before calling `continue_chat_with_tool_results()` is\n",
+    "> the correct pattern — and exactly what `LLMAgent` automates in ch04."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama\n",
+    "installed on your local machine and have its LLM hosting service running.\n",
+    "To download Ollama, follow the instructions found on this page:\n",
+    "https://ollama.com/download. After downloading and installing Ollama, you\n",
+    "can start a service by opening a terminal and running the command\n",
+    "`ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining the Tool\n",
+    "\n",
+    "`hailstone_step_func` performs a single step of the\n",
+    "[Collatz sequence](https://en.wikipedia.org/wiki/Collatz_conjecture):\n",
+    "halve the number if it is even, otherwise apply 3x + 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def hailstone_step_func(x: int) -> int:\n",
+    "    \"\"\"Perform a single step of the Hailstone (Collatz) sequence.\"\"\"\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "hailstone_tool = SimpleFunctionTool(func=hailstone_step_func)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Eliciting Parallel Tool Calls\n",
+    "\n",
+    "We ask the LLM to apply the hailstone step to three numbers at once.\n",
+    "A well-prompted model will return all three tool call requests in a\n",
+    "single assistant message rather than one at a time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tool calls returned: 3\n",
+      "  → hailstone_step_func({'x': 10})\n",
+      "  → hailstone_step_func({'x': 15})\n",
+      "  → hailstone_step_func({'x': 27})\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "\n",
+    "user_input = (\n",
+    "    \"Apply the hailstone_step_func to each of the following numbers: \"\n",
+    "    \"10, 15, and 27. \"\n",
+    "    \"Call the tool once for each number.\"\n",
+    ")\n",
+    "\n",
+    "user_msg, assistant_msg = await llm.chat(\n",
+    "    user_input,\n",
+    "    tools=[hailstone_tool],\n",
+    ")\n",
+    "\n",
+    "print(f\"Tool calls returned: {len(assistant_msg.tool_calls)}\")\n",
+    "for tc in assistant_msg.tool_calls:\n",
+    "    print(f\"  → {tc.tool_name}({tc.arguments})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Executing All Tool Calls\n",
+    "\n",
+    "We iterate over every `ToolCall` in the assistant message and execute\n",
+    "each one, collecting the `ToolCallResult` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  hailstone_step_func(x=10) → 5\n",
+      "  hailstone_step_func(x=15) → 46\n",
+      "  hailstone_step_func(x=27) → 82\n"
+     ]
+    }
+   ],
+   "source": [
+    "tool_call_results = [hailstone_tool(tc) for tc in assistant_msg.tool_calls]\n",
+    "\n",
+    "for tc, result in zip(\n",
+    "    assistant_msg.tool_calls,\n",
+    "    tool_call_results,\n",
+    "    strict=False,\n",
+    "):\n",
+    "    print(\n",
+    "        f\"  hailstone_step_func(x={tc.arguments['x']!r}) → {result.content}\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Returning All Results in One Call\n",
+    "\n",
+    "We pass the full list of `ToolCallResult` objects to\n",
+    "`continue_chat_with_tool_results()` in a single batch.\n",
+    "The LLM receives all three results at once and produces a final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The results of applying the hailstone_step_func to each number are as follows:\n",
+      "\n",
+      "- For 10, the result is 5.\n",
+      "- For 15, the result is 46.\n",
+      "- For 27, the result is 82.\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_messages, final_response = await llm.continue_chat_with_tool_results(\n",
+    "    tool_call_results=tool_call_results,\n",
+    "    chat_history=[user_msg, assistant_msg],\n",
+    "    tools=[hailstone_tool],\n",
+    ")\n",
+    "\n",
+    "print(final_response.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Full Conversation at a Glance\n",
+    "\n",
+    "Printing the complete message sequence shows the structure the\n",
+    "`LLMAgent` manages automatically: user → parallel tool requests →\n",
+    "tool results (one per call) → final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[user      ]  Apply the hailstone_step_func to each of the following numbers: 10, 15, and 27. \n",
+      "[assistant ]  <tool calls> hailstone_step_func({'x': 10}), hailstone_step_func({'x': 15}), hailstone_step_func({'x': 27})\n",
+      "[tool      ]  {     \"tool_call_id\": \"ff713bbf-fa95-4bd9-a10e-a0a451fc2682\",     \"content\": \"5\"\n",
+      "[tool      ]  {     \"tool_call_id\": \"9b132fa9-17b7-441f-932c-61f2a252075f\",     \"content\": \"46\n",
+      "[tool      ]  {     \"tool_call_id\": \"33ad59da-a1a3-479d-9a81-733d99129fa9\",     \"content\": \"82\n",
+      "[assistant ]  The results of applying the hailstone_step_func to each number are as follows:  \n"
+     ]
+    }
+   ],
+   "source": [
+    "all_messages = [user_msg, assistant_msg, *new_messages, final_response]\n",
+    "\n",
+    "for msg in all_messages:\n",
+    "    role = msg.role.value\n",
+    "    if msg.tool_calls:\n",
+    "        calls = \", \".join(\n",
+    "            f\"{tc.tool_name}({tc.arguments})\" for tc in msg.tool_calls\n",
+    "        )\n",
+    "        print(f\"[{role:10s}]  <tool calls> {calls}\")\n",
+    "    else:\n",
+    "        preview = msg.content[:80].replace(\"\\n\", \" \")\n",
+    "        print(f\"[{role:10s}]  {preview}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch03/parallel_tool_calls.ipynb` — demonstrates the LLM returning multiple tool call requests in a single response
- Prompts the LLM to apply `hailstone_step_func` to three numbers at once (10, 15, 27); shows the assistant message carrying all three `ToolCall` objects
- Executes all calls in a loop then passes the full `ToolCallResult` batch to `continue_chat_with_tool_results()` in one shot
- Ends with a full conversation walkthrough cell showing the user → parallel requests → results → final answer structure
- Raw LLM API only — no `LLMAgent`
- Adds `docs/more-examples/ch03/` symlink and `mkdocs.yml` nav entry

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)