### PR TITLE
chore: add think attribute to OllamaLLM UML diagram (#511)

### DIFF
--- a/src/llm_agents_from_scratch/data_structures/llm.py
+++ b/src/llm_agents_from_scratch/data_structures/llm.py
@@ -45,7 +45,7 @@ class CompleteResult(BaseModel):
 
     Attributes:
         response: The completion response provided by the LLM.
-        full_response: Input prompt and completion text.
+        prompt: The input prompt.
     """
 
     response: str

--- a/uml/ch03/ollama_llm.puml
+++ b/uml/ch03/ollama_llm.puml
@@ -17,8 +17,9 @@ package "llm_agents_from_scratch.llms" <<Folder>> {
   class OllamaLLM {
     +model: str
     -_client: ~ollama.AsyncClient
+    +think: bool
     --
-    +<<constructor>> __init__(\n\tmodel:str,\n\thost: str | None\n):
+    +<<constructor>> __init__(\n\tmodel:str,\n\thost: str | None,\n\tthink: bool\n):
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `think: bool` attribute to `OllamaLLM` in `uml/ch03/ollama_llm.puml`
- Updates the constructor signature to include the `think` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)