### PR TITLE
ch02: add async tools more-example (#512)

### DIFF
--- a/docs/more-examples/ch02/async_tools.ipynb
+++ b/docs/more-examples/ch02/async_tools.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch02/async_tools.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ nav:
   - More Examples:
     - more-examples/index.md
     # Symlinked from more-examples/ — do not copy directly.
+    - Chapter 2:
+      - Async Tools: more-examples/ch02/async_tools.ipynb
     - Chapter 3:
       - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
       - Structured Extraction from a PDF: more-examples/ch03/pdf_extraction.ipynb

--- a/more-examples/ch02/async_tools.ipynb
+++ b/more-examples/ch02/async_tools.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Async Tools\n",
+    "\n",
+    "This notebook demonstrates `AsyncSimpleFunctionTool` and\n",
+    "`AsyncPydanticFunctionTool` — the async counterparts to the sync tools\n",
+    "introduced in Chapter 2.\n",
+    "\n",
+    "Async tools wrap `async` functions and are invoked with `await`. They are\n",
+    "the right choice whenever the underlying operation is I/O-bound (network\n",
+    "calls, database queries, file reads), because they avoid blocking the\n",
+    "event loop while waiting for a response.\n",
+    "\n",
+    "No LLM is involved — this is pure Chapter 2 tool mechanics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `AsyncSimpleFunctionTool`\n",
+    "\n",
+    "`AsyncSimpleFunctionTool` wraps any `async` function the same way\n",
+    "`SimpleFunctionTool` wraps a sync one. Here we wrap a function that fetches\n",
+    "the current weather temperature for a location from the\n",
+    "[Open-Meteo API](https://open-meteo.com/) — a free, no-auth endpoint.\n",
+    "\n",
+    "We use `asyncio.to_thread` to run the blocking `urllib` call off the main\n",
+    "event loop, which is the standard pattern for wrapping sync I/O in async\n",
+    "code without adding extra dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tool name:  get_temperature\n",
+      "Tool desc:  Fetch the current temperature (°C) for a lat/lon coordinate.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "import json\n",
+    "import urllib.request\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import ToolCall\n",
+    "from llm_agents_from_scratch.tools import AsyncSimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "async def get_temperature(latitude: float, longitude: float) -> str:\n",
+    "    \"\"\"Fetch the current temperature (°C) for a lat/lon coordinate.\"\"\"\n",
+    "    url = (\n",
+    "        \"https://api.open-meteo.com/v1/forecast\"\n",
+    "        f\"?latitude={latitude}&longitude={longitude}\"\n",
+    "        \"&current_weather=true\"\n",
+    "    )\n",
+    "    req = urllib.request.Request(\n",
+    "        url,\n",
+    "        headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    "    )\n",
+    "    raw = await asyncio.to_thread(\n",
+    "        lambda: urllib.request.urlopen(req).read().decode(),\n",
+    "    )\n",
+    "    data = json.loads(raw)\n",
+    "    temp = data[\"current_weather\"][\"temperature\"]\n",
+    "    return f\"{temp} °C\"\n",
+    "\n",
+    "\n",
+    "temperature_tool = AsyncSimpleFunctionTool(func=get_temperature)\n",
+    "print(f\"Tool name:  {temperature_tool.name}\")\n",
+    "print(f\"Tool desc:  {temperature_tool.description}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    False\n",
+      "content:  10.5 °C\n"
+     ]
+    }
+   ],
+   "source": [
+    "# London: 51.5°N, -0.1°E\n",
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"get_temperature\",\n",
+    "    arguments={\"latitude\": 51.5, \"longitude\": -0.1},\n",
+    ")\n",
+    "\n",
+    "result = await temperature_tool(tool_call)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:  {result.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `AsyncPydanticFunctionTool`\n",
+    "\n",
+    "`AsyncPydanticFunctionTool` is the async version of `PydanticFunctionTool`:\n",
+    "the wrapped function must be `async` and must accept a single\n",
+    "`pydantic.BaseModel` argument. Pydantic validates the incoming arguments\n",
+    "before the function is called.\n",
+    "\n",
+    "Here we fetch sunrise and sunset times for a location from the\n",
+    "[Sunrise-Sunset API](https://sunrise-sunset.org/api) — also free and\n",
+    "no-auth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tool name:  get_sun_times\n",
+      "Tool desc:  Return sunrise and sunset times (UTC) for a given location and date.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "from llm_agents_from_scratch.tools import AsyncPydanticFunctionTool\n",
+    "\n",
+    "\n",
+    "class SunParams(BaseModel):\n",
+    "    \"\"\"Parameters for the sunrise/sunset lookup tool.\"\"\"\n",
+    "\n",
+    "    latitude: float = Field(description=\"Latitude of the location.\")\n",
+    "    longitude: float = Field(description=\"Longitude of the location.\")\n",
+    "    date: str = Field(\n",
+    "        description=\"Date in YYYY-MM-DD format. Use 'today' for today.\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "async def get_sun_times(params: SunParams) -> str:\n",
+    "    \"\"\"Return sunrise and sunset times (UTC) for a given location and date.\"\"\"\n",
+    "    url = (\n",
+    "        \"https://api.sunrise-sunset.org/json\"\n",
+    "        f\"?lat={params.latitude}&lng={params.longitude}\"\n",
+    "        f\"&date={params.date}&formatted=0\"\n",
+    "    )\n",
+    "    req = urllib.request.Request(\n",
+    "        url,\n",
+    "        headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    "    )\n",
+    "    raw = await asyncio.to_thread(\n",
+    "        lambda: urllib.request.urlopen(req).read().decode(),\n",
+    "    )\n",
+    "    data = json.loads(raw)[\"results\"]\n",
+    "    return json.dumps(\n",
+    "        {\"sunrise\": data[\"sunrise\"], \"sunset\": data[\"sunset\"]},\n",
+    "        indent=2,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "sun_tool = AsyncPydanticFunctionTool(func=get_sun_times)\n",
+    "print(f\"Tool name:  {sun_tool.name}\")\n",
+    "print(f\"Tool desc:  {sun_tool.description}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    False\n",
+      "content:\n",
+      "{\n",
+      "  \"sunrise\": \"2026-05-07T19:40:56+00:00\",\n",
+      "  \"sunset\": \"2026-05-08T09:34:30+00:00\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tokyo: 35.7°N, 139.7°E\n",
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"get_sun_times\",\n",
+    "    arguments={\"latitude\": 35.7, \"longitude\": 139.7, \"date\": \"today\"},\n",
+    ")\n",
+    "\n",
+    "result = await sun_tool(tool_call)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:\\n{result.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sync vs Async — Call Pattern Comparison\n",
+    "\n",
+    "The only difference at the call site is `await`. The `ToolCall` object and\n",
+    "`ToolCallResult` shape are identical, which is what will allow `LLMAgent` to\n",
+    "handle both tool types transparently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sync  result: 6  (error=False)\n",
+      "async result: 6  (error=False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def hailstone_step_func(x: int) -> int:\n",
+    "    \"\"\"Perform a single step of the Hailstone (Collatz) sequence.\"\"\"\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "async def async_hailstone_step_func(x: int) -> int:\n",
+    "    \"\"\"Perform a single step of the Hailstone (Collatz) sequence.\"\"\"\n",
+    "    return await asyncio.to_thread(hailstone_step_func, x)\n",
+    "\n",
+    "\n",
+    "sync_tool = SimpleFunctionTool(func=hailstone_step_func)\n",
+    "async_tool = AsyncSimpleFunctionTool(func=async_hailstone_step_func)\n",
+    "\n",
+    "tool_call = ToolCall(tool_name=\"hailstone_step_func\", arguments={\"x\": 12})\n",
+    "\n",
+    "sync_result = sync_tool(tool_call)  # sync — no await\n",
+    "async_result = await async_tool(tool_call)  # async — requires await\n",
+    "\n",
+    "print(f\"sync  result: {sync_result.content}  (error={sync_result.error})\")\n",
+    "print(f\"async result: {async_result.content}  (error={async_result.error})\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch02/async_tools.ipynb` — demonstrates `AsyncSimpleFunctionTool` and `AsyncPydanticFunctionTool` with real async I/O
- `AsyncSimpleFunctionTool`: wraps `get_temperature` fetching from the Open-Meteo API via `asyncio.to_thread`
- `AsyncPydanticFunctionTool`: wraps `get_sun_times` (Pydantic params model) fetching sunrise/sunset from the Sunrise-Sunset API
- Closes with a sync vs async comparison using the hailstone step function, showing `await` is the only call-site difference
- Adds `docs/more-examples/ch02/` symlink and `mkdocs.yml` nav entry under `More Examples > Chapter 2`

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)