### PR TITLE
ch02: add multi-tool registry more-example (#513)

### DIFF
--- a/docs/more-examples/ch02/multi_tool_registry.ipynb
+++ b/docs/more-examples/ch02/multi_tool_registry.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch02/multi_tool_registry.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
     # Symlinked from more-examples/ — do not copy directly.
     - Chapter 2:
       - Async Tools: more-examples/ch02/async_tools.ipynb
+      - Multi-Tool Registry: more-examples/ch02/multi_tool_registry.ipynb
     - Chapter 3:
       - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
       - Structured Extraction from a PDF: more-examples/ch03/pdf_extraction.ipynb

--- a/more-examples/ch02/multi_tool_registry.ipynb
+++ b/more-examples/ch02/multi_tool_registry.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Tool Registry\n",
+    "\n",
+    "This notebook builds a small **tool registry** — a `dict` keyed by tool\n",
+    "name — over several `SimpleFunctionTool` instances, then shows how to\n",
+    "dispatch an incoming `ToolCall` to the correct tool by name.\n",
+    "\n",
+    "> **Coming up in Chapter 4:** you'll build an `LLMAgent` that manages a\n",
+    "> collection of tools and routes each tool call the LLM makes to the right\n",
+    "> one automatically. The registry pattern you see here is exactly how it\n",
+    "> does that under the hood.\n",
+    "\n",
+    "No LLM is involved — this is pure Chapter 2 tool mechanics.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining the Tools\n",
+    "\n",
+    "We define four simple utility functions and wrap each in a\n",
+    "`SimpleFunctionTool`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  celsius_to_fahrenheit\n",
+      "  word_count\n",
+      "  circle_area\n",
+      "  reverse_string\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def celsius_to_fahrenheit(celsius: float) -> float:\n",
+    "    \"\"\"Convert a temperature from Celsius to Fahrenheit.\"\"\"\n",
+    "    return celsius * 9 / 5 + 32\n",
+    "\n",
+    "\n",
+    "def word_count(text: str) -> int:\n",
+    "    \"\"\"Count the number of words in a string.\"\"\"\n",
+    "    return len(text.split())\n",
+    "\n",
+    "\n",
+    "def circle_area(radius: float) -> float:\n",
+    "    \"\"\"Calculate the area of a circle given its radius.\"\"\"\n",
+    "    return round(math.pi * radius**2, 4)\n",
+    "\n",
+    "\n",
+    "def reverse_string(text: str) -> str:\n",
+    "    \"\"\"Reverse the characters of a string.\"\"\"\n",
+    "    return text[::-1]\n",
+    "\n",
+    "\n",
+    "tools = [\n",
+    "    SimpleFunctionTool(func=celsius_to_fahrenheit),\n",
+    "    SimpleFunctionTool(func=word_count),\n",
+    "    SimpleFunctionTool(func=circle_area),\n",
+    "    SimpleFunctionTool(func=reverse_string),\n",
+    "]\n",
+    "\n",
+    "for t in tools:\n",
+    "    print(f\"  {t.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building the Registry\n",
+    "\n",
+    "A registry is just a `dict` keyed by tool name. You'll see this exact\n",
+    "one-liner again in Chapter 4 when we build the LLM agent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registry keys: ['celsius_to_fahrenheit', 'word_count', 'circle_area', 'reverse_string']\n"
+     ]
+    }
+   ],
+   "source": [
+    "tools_registry = {t.name: t for t in tools}\n",
+    "\n",
+    "print(\"Registry keys:\", list(tools_registry.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dispatching Tool Calls\n",
+    "\n",
+    "Given a list of `ToolCall` objects, look up each tool by name and invoke it.\n",
+    "This is the core dispatch pattern that an LLM agent will later automate. For\n",
+    "now we drive it manually so the mechanics are fully visible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  celsius_to_fahrenheit({'celsius': 100.0}) → 212.0\n",
+      "  word_count({'text': 'the quick brown fox jumps over the lazy dog'}) → 9\n",
+      "  circle_area({'radius': 5.0}) → 78.5398\n",
+      "  reverse_string({'text': 'agents'}) → stnega\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.data_structures import ToolCall\n",
+    "\n",
+    "tool_calls = [\n",
+    "    ToolCall(\n",
+    "        tool_name=\"celsius_to_fahrenheit\",\n",
+    "        arguments={\"celsius\": 100.0},\n",
+    "    ),\n",
+    "    ToolCall(\n",
+    "        tool_name=\"word_count\",\n",
+    "        arguments={\"text\": \"the quick brown fox jumps over the lazy dog\"},\n",
+    "    ),\n",
+    "    ToolCall(\n",
+    "        tool_name=\"circle_area\",\n",
+    "        arguments={\"radius\": 5.0},\n",
+    "    ),\n",
+    "    ToolCall(\n",
+    "        tool_name=\"reverse_string\",\n",
+    "        arguments={\"text\": \"agents\"},\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for tc in tool_calls:\n",
+    "    tool = tools_registry[tc.tool_name]\n",
+    "    result = tool(tc)\n",
+    "    print(f\"  {tc.tool_name}({tc.arguments}) → {result.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handling an Unknown Tool Name\n",
+    "\n",
+    "When a tool name isn't in the registry, rather than raising an exception,\n",
+    "we should instead return a `ToolCallResult` with `error=True` so that the\n",
+    "information reaches the LLM. With that context the LLM can understand what\n",
+    "went wrong and decide what to do next, such as correcting a misspelled tool\n",
+    "name or choosing a different tool entirely. (You'll learn about LLM tool-calling\n",
+    "in the next chapter!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    True\n",
+      "content:  {\"error_type\": \"UnknownToolError\", \"message\": \"Tool 'get_weather' not found. Available: ['celsius_to_fahrenheit', 'word_count', 'circle_area', 'reverse_string']\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import ToolCallResult\n",
+    "\n",
+    "\n",
+    "def dispatch(tc: ToolCall) -> ToolCallResult:\n",
+    "    \"\"\"Dispatch a ToolCall, returning an error result for unknown tools.\"\"\"\n",
+    "    tool = tools_registry.get(tc.tool_name)\n",
+    "    if tool is None:\n",
+    "        return ToolCallResult(\n",
+    "            tool_call_id=tc.id_,\n",
+    "            content=json.dumps(\n",
+    "                {\n",
+    "                    \"error_type\": \"UnknownToolError\",\n",
+    "                    \"message\": (\n",
+    "                        f\"Tool '{tc.tool_name}' not found. \"\n",
+    "                        f\"Available: {list(tools_registry.keys())}\"\n",
+    "                    ),\n",
+    "                },\n",
+    "            ),\n",
+    "            error=True,\n",
+    "        )\n",
+    "    return tool(tc)\n",
+    "\n",
+    "\n",
+    "unknown_tc = ToolCall(\n",
+    "    tool_name=\"get_weather\",\n",
+    "    arguments={\"city\": \"London\"},\n",
+    ")\n",
+    "\n",
+    "result = dispatch(unknown_tc)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:  {result.content}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch02/multi_tool_registry.ipynb` — builds a tool registry (`{t.name: t for t in tools}`) over four `SimpleFunctionTool` instances and shows manual dispatch
- Dispatch loop: look up each `ToolCall` by name, invoke, collect `ToolCallResult`
- Unknown tool name handled gracefully via `ToolCallResult(error=True)` with an explanation the LLM can use to self-correct
- Frames the registry pattern as a preview of what `LLMAgent` automates in Chapter 4
- No LLM calls — pure ch02 tool mechanics
- Adds `docs/more-examples/ch02/` symlink and `mkdocs.yml` nav entry

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)