### PR TITLE
ch02: add PydanticFunctionTool validation errors more-example (#514)

### DIFF
--- a/docs/more-examples/ch02/pydantic_tool_validation.ipynb
+++ b/docs/more-examples/ch02/pydantic_tool_validation.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch02/pydantic_tool_validation.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Chapter 2:
       - Async Tools: more-examples/ch02/async_tools.ipynb
       - Multi-Tool Registry: more-examples/ch02/multi_tool_registry.ipynb
+      - PydanticFunctionTool Validation Errors: more-examples/ch02/pydantic_tool_validation.ipynb
     - Chapter 3:
       - Multi-Turn Trivia Chat: more-examples/ch03/multi_turn_chat.ipynb
       - Structured Extraction from a PDF: more-examples/ch03/pdf_extraction.ipynb

--- a/more-examples/ch02/pydantic_tool_validation.ipynb
+++ b/more-examples/ch02/pydantic_tool_validation.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PydanticFunctionTool Validation Errors\n",
+    "\n",
+    "This notebook demonstrates what happens when a `PydanticFunctionTool`\n",
+    "receives malformed arguments: a missing required field, or a value that\n",
+    "fails a custom Pydantic validator.\n",
+    "\n",
+    "When validation fails, `PydanticFunctionTool` does **not** raise an\n",
+    "exception. Instead it catches the error and returns a\n",
+    "`ToolCallResult(error=True)` with a descriptive message. This matters\n",
+    "because in an LLM agent loop the result must always be returned to the LLM\n",
+    "so it can understand what went wrong and decide how to recover. For\n",
+    "example, it may fix the arguments and retry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining the Tool\n",
+    "\n",
+    "We wrap a `divide` function whose `DivideParams` model enforces two\n",
+    "constraints: both fields are required, and `denominator` must not be zero\n",
+    "(enforced by a `@field_validator`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field, field_validator\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import ToolCall\n",
+    "from llm_agents_from_scratch.tools import PydanticFunctionTool\n",
+    "\n",
+    "\n",
+    "class DivideParams(BaseModel):\n",
+    "    \"\"\"Parameters for the divide tool.\"\"\"\n",
+    "\n",
+    "    numerator: float = Field(description=\"The dividend.\")\n",
+    "    denominator: float = Field(description=\"The divisor (must not be zero).\")\n",
+    "\n",
+    "    @field_validator(\"denominator\")\n",
+    "    @classmethod\n",
+    "    def denominator_not_zero(cls, v: float) -> float:\n",
+    "        \"\"\"Reject zero denominators.\"\"\"\n",
+    "        if v == 0:\n",
+    "            raise ValueError(\"denominator must not be zero\")\n",
+    "        return v\n",
+    "\n",
+    "\n",
+    "def divide(params: DivideParams) -> float:\n",
+    "    \"\"\"Divide numerator by denominator and return the result.\"\"\"\n",
+    "    return params.numerator / params.denominator\n",
+    "\n",
+    "\n",
+    "divide_tool = PydanticFunctionTool(func=divide)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: Valid Call\n",
+    "\n",
+    "Both fields are present and valid. The tool executes and returns a\n",
+    "successful `ToolCallResult`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    False\n",
+      "content:  2.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"divide\",\n",
+    "    arguments={\"numerator\": 10.0, \"denominator\": 4.0},\n",
+    ")\n",
+    "\n",
+    "result = divide_tool(tool_call)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:  {result.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: Missing Required Field\n",
+    "\n",
+    "`denominator` is omitted. Pydantic raises a `ValidationError` which\n",
+    "`PydanticFunctionTool` catches and surfaces as an error result.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    True\n",
+      "content:  {\"error_type\": \"ValidationError\", \"message\": \"Internal error while executing tool: 1 validation error for DivideParams\\ndenominator\\n  Field required [type=missing, input_value={'numerator': 10.0}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.13/v/missing\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"divide\",\n",
+    "    arguments={\"numerator\": 10.0},\n",
+    ")\n",
+    "\n",
+    "result = divide_tool(tool_call)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:  {result.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: Custom Validator Failure\n",
+    "\n",
+    "Both fields are present but `denominator` is `0`, which fails the\n",
+    "`@field_validator`. The validator raises a `ValueError`, Pydantic wraps\n",
+    "it in a `ValidationError`, and the tool returns an error result.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "error:    True\n",
+      "content:  {\"error_type\": \"ValidationError\", \"message\": \"Internal error while executing tool: 1 validation error for DivideParams\\ndenominator\\n  Value error, denominator must not be zero [type=value_error, input_value=0, input_type=int]\\n    For further information visit https://errors.pydantic.dev/2.13/v/value_error\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"divide\",\n",
+    "    arguments={\"numerator\": 10.0, \"denominator\": 0},\n",
+    ")\n",
+    "\n",
+    "result = divide_tool(tool_call)\n",
+    "print(f\"error:    {result.error}\")\n",
+    "print(f\"content:  {result.content}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch02/pydantic_tool_validation.ipynb` — shows three cases for `PydanticFunctionTool`: valid call, missing required field, and custom `@field_validator` failure
- Each error case returns `ToolCallResult(error=True)` rather than raising, so the LLM receives the error and can recover
- Uses a `divide` function with a `DivideParams` model that enforces a non-zero denominator via `@field_validator`
- No LLM calls — pure ch02 tool mechanics
- Adds `docs/more-examples/ch02/` symlink and `mkdocs.yml` nav entry

## Test plan

- [x] Notebook fully executed with visible outputs
- [x] `make lint` passes (ruff check + ruff format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)