### PR TITLE
uml: replace flow arrows with UML dependency arrows in class diagrams

### DIFF
--- a/uml/ch01/uml_basics_class.puml
+++ b/uml/ch01/uml_basics_class.puml
@@ -25,9 +25,4 @@ package "llm_agents_from_scratch.data_structures" <<Folder>> {
   end note
 }
 
-' Relations
-BaseTool ..> ToolCallResult : " uses"
-note right on link
-  this describes a relation between classes
-end note
 @enduml

--- a/uml/ch01/uml_basics_class.puml
+++ b/uml/ch01/uml_basics_class.puml
@@ -26,7 +26,7 @@ package "llm_agents_from_scratch.data_structures" <<Folder>> {
 }
 
 ' Relations
-ToolCallResult <-- BaseTool : " returns"
+BaseTool ..> ToolCallResult : " uses"
 note right on link
   this describes a relation between classes
 end note

--- a/uml/ch02/async_tool_class.puml
+++ b/uml/ch02/async_tool_class.puml
@@ -47,7 +47,7 @@ llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scra
 ' Relations
 BaseModel <|-- ToolCall : " inherits"
 BaseModel <|-- ToolCallResult : " inherits"
-ToolCallResult <-- AsyncBaseTool::__call__ : " returns"
-ToolCall --> AsyncBaseTool::__call__ : " gets called with"
+AsyncBaseTool ..> ToolCall : " uses"
+AsyncBaseTool ..> ToolCallResult : " uses"
 
 @enduml

--- a/uml/ch02/async_tool_class.puml
+++ b/uml/ch02/async_tool_class.puml
@@ -2,6 +2,11 @@
 !include ../common/book-clean.puml
 
 
+' External dependencies
+package "external_dependencies" <<Folder>> {
+    class "pydantic.BaseModel" as BaseModel
+}
+
 ' Data structures
 package "llm_agents_from_scratch.data_structures.tool" <<Folder>> {
 

--- a/uml/ch02/async_tool_class.puml
+++ b/uml/ch02/async_tool_class.puml
@@ -2,11 +2,6 @@
 !include ../common/book-clean.puml
 
 
-' External dependencies
-package "external_dependencies" <<Folder>> {
-    class "pydantic.BaseModel" as BaseModel
-}
-
 ' Data structures
 package "llm_agents_from_scratch.data_structures.tool" <<Folder>> {
 
@@ -44,10 +39,5 @@ end note
 
 llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scratch.base
 
-' Relations
-BaseModel <|-- ToolCall : " inherits"
-BaseModel <|-- ToolCallResult : " inherits"
-AsyncBaseTool ..> ToolCall : " uses"
-AsyncBaseTool ..> ToolCallResult : " uses"
 
 @enduml

--- a/uml/ch02/async_tool_class.puml
+++ b/uml/ch02/async_tool_class.puml
@@ -44,5 +44,9 @@ end note
 
 llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scratch.base
 
+' Relations
+BaseModel <|-- ToolCall : " inherits"
+BaseModel <|-- ToolCallResult : " inherits"
+
 
 @enduml

--- a/uml/ch02/tool_class.puml
+++ b/uml/ch02/tool_class.puml
@@ -2,6 +2,11 @@
 !include ../common/book-clean.puml
 
 
+' External dependencies
+package "external_dependencies" <<Folder>> {
+    class "pydantic.BaseModel" as BaseModel
+}
+
 ' Data structures
 package "llm_agents_from_scratch.data_structures.tool" <<Folder>> {
 

--- a/uml/ch02/tool_class.puml
+++ b/uml/ch02/tool_class.puml
@@ -2,11 +2,6 @@
 !include ../common/book-clean.puml
 
 
-' External dependencies
-package "external_dependencies" <<Folder>> {
-    class "pydantic.BaseModel" as BaseModel
-}
-
 ' Data structures
 package "llm_agents_from_scratch.data_structures.tool" <<Folder>> {
 
@@ -41,10 +36,5 @@ end note
 
 llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scratch.base
 
-' Relations
-BaseModel <|-- ToolCall : " inherits"
-BaseModel <|-- ToolCallResult : " inherits"
-BaseTool ..> ToolCall : " uses"
-BaseTool ..> ToolCallResult : " uses"
 
 @enduml

--- a/uml/ch02/tool_class.puml
+++ b/uml/ch02/tool_class.puml
@@ -41,5 +41,9 @@ end note
 
 llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scratch.base
 
+' Relations
+BaseModel <|-- ToolCall : " inherits"
+BaseModel <|-- ToolCallResult : " inherits"
+
 
 @enduml

--- a/uml/ch02/tool_class.puml
+++ b/uml/ch02/tool_class.puml
@@ -44,7 +44,7 @@ llm_agents_from_scratch.data_structures.tool -[hidden]down- llm_agents_from_scra
 ' Relations
 BaseModel <|-- ToolCall : " inherits"
 BaseModel <|-- ToolCallResult : " inherits"
-ToolCall --> BaseTool::__call__ : " input"
-ToolCallResult <-- BaseTool::__call__ : " returns"
+BaseTool ..> ToolCall : " uses"
+BaseTool ..> ToolCallResult : " uses"
 
 @enduml

--- a/uml/ch03/llm_class.puml
+++ b/uml/ch03/llm_class.puml
@@ -2,11 +2,6 @@
 !include ../common/book-clean.puml
 
 
-' External dependencies
-package "external_dependencies" <<Folder>> {
-    class "pydantic.BaseModel" as BaseModel
-}
-
 ' Data structures
 package "llm_agents_from_scratch.data_structures.llm" <<Folder>> {
   class CompleteResult {
@@ -44,12 +39,5 @@ package "llm_agents_from_scratch.base.llm" <<Folder>> {
 
 llm_agents_from_scratch.data_structures.llm -[hidden]down- llm_agents_from_scratch.base
 
-' Relations
-BaseModel <|-- CompleteResult : " inherits"
-BaseModel <|-- ChatMessage : " inherits"
-ChatMessage *-left- ChatRole
-
-BaseLLM ..> ChatMessage : " uses"
-BaseLLM ..> CompleteResult : " uses"
 
 @enduml

--- a/uml/ch03/llm_class.puml
+++ b/uml/ch03/llm_class.puml
@@ -44,5 +44,10 @@ package "llm_agents_from_scratch.base.llm" <<Folder>> {
 
 llm_agents_from_scratch.data_structures.llm -[hidden]down- llm_agents_from_scratch.base
 
+' Relations
+BaseModel <|-- CompleteResult : " inherits"
+BaseModel <|-- ChatMessage : " inherits"
+ChatMessage *-left- ChatRole
+
 
 @enduml

--- a/uml/ch03/llm_class.puml
+++ b/uml/ch03/llm_class.puml
@@ -49,9 +49,7 @@ BaseModel <|-- CompleteResult : " inherits"
 BaseModel <|-- ChatMessage : " inherits"
 ChatMessage *-left- ChatRole
 
-ChatMessage -up-> BaseLLM::chat : " optional input"
-ChatMessage <-down- BaseLLM::chat : " returns"
-
-CompleteResult <-- BaseLLM::complete : " returns"
+BaseLLM ..> ChatMessage : " uses"
+BaseLLM ..> CompleteResult : " uses"
 
 @enduml

--- a/uml/ch03/llm_class.puml
+++ b/uml/ch03/llm_class.puml
@@ -42,7 +42,7 @@ package "llm_agents_from_scratch.base.llm" <<Folder>> {
 }
 
 
-llm_agents_from_scratch.data_structures.llm -[hidden]down- llm_agents_from_scratch.base
+llm_agents_from_scratch.data_structures.llm -[hidden]down- llm_agents_from_scratch.base.llm
 
 ' Relations
 BaseModel <|-- CompleteResult : " inherits"

--- a/uml/ch03/llm_class.puml
+++ b/uml/ch03/llm_class.puml
@@ -2,6 +2,11 @@
 !include ../common/book-clean.puml
 
 
+' External dependencies
+package "external_dependencies" <<Folder>> {
+    class "pydantic.BaseModel" as BaseModel
+}
+
 ' Data structures
 package "llm_agents_from_scratch.data_structures.llm" <<Folder>> {
   class CompleteResult {


### PR DESCRIPTION
## Summary

- Removes flow-style arrows (`input`, `returns`, `gets called with`) from `uml/ch01/uml_basics_class.puml`, `uml/ch02/tool_class.puml`, `uml/ch02/async_tool_class.puml`, and `uml/ch03/llm_class.puml`
- Replaces them with standard UML dependency arrows (`..>`) so all class diagrams follow consistent UML conventions
- The method signatures in the class boxes already convey parameter/return types, making the flow annotations redundant

Resolves #518

## Test plan

- [ ] Verify `make diagrams` runs cleanly
- [ ] Visually inspect rendered SVGs to confirm arrows render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)