### PR TITLE
530: add with_memory() to LLMAgentBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: add `with_memory()` and `with_memories()` to `LLMAgentBuilder` (#530)
 - feat: wire memory recall and record into `LLMAgent` and `TaskHandler`
 - feat: add `BaseMemory` and `BaseMemoryStore` abstract base classes (#539)
 - feat: add `Episode` data structure to `data_structures.memory` (#535)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- feat: add `with_memory()` and `with_memories()` to `LLMAgentBuilder` (#530)
+- feat: add `with_memory()` and `with_memories()` to `LLMAgentBuilder` (#541)
 - feat: wire memory recall and record into `LLMAgent` and `TaskHandler`
 - feat: add `BaseMemory` and `BaseMemoryStore` abstract base classes (#539)
 - feat: add `Episode` data structure to `data_structures.memory` (#535)

--- a/src/llm_agents_from_scratch/agent/builder.py
+++ b/src/llm_agents_from_scratch/agent/builder.py
@@ -10,6 +10,7 @@ from llm_agents_from_scratch.agent.templates import (
     default_templates,
 )
 from llm_agents_from_scratch.base import LLM
+from llm_agents_from_scratch.base.memory import BaseMemory
 from llm_agents_from_scratch.base.tool import Tool
 from llm_agents_from_scratch.errors import LLMAgentBuilderError
 from llm_agents_from_scratch.tools import MCPTool
@@ -27,6 +28,7 @@ class LLMAgentBuilder:
         templates (LLMAgentTemplates): Prompt templates for the agent.
         mcp_providers (list[MCPToolProvider]): MCP providers for tool
             discovery.
+        memories (list[BaseMemory]): Memory backends for the agent.
     """
 
     def __init__(
@@ -35,6 +37,7 @@ class LLMAgentBuilder:
         tools: list[Tool] | None = None,
         templates: LLMAgentTemplates = default_templates,
         mcp_providers: list[MCPToolProvider] | None = None,
+        memories: list[BaseMemory] | None = None,
     ) -> None:
         """Initialize an LLMAgentBuilder.
 
@@ -49,6 +52,7 @@ class LLMAgentBuilder:
                     .with_llm(llm)
                     .with_tool(my_tool)
                     .with_mcp_provider(provider)
+                    .with_memory(my_memory)
                     .build()
                 )
 
@@ -58,6 +62,7 @@ class LLMAgentBuilder:
                     llm=llm,
                     tools=[my_tool],
                     mcp_providers=[provider],
+                    memories=[my_memory],
                 ).build()
 
         Args:
@@ -70,11 +75,15 @@ class LLMAgentBuilder:
             mcp_providers (list[MCPToolProvider] | None, optional): MCP
                 providers for tool discovery. Tools are fetched during
                 `build()`. Defaults to None.
+            memories (list[BaseMemory] | None, optional): Memory backends
+                for the agent. No default implementation is provided — the
+                caller must supply a concrete subclass. Defaults to None.
         """
         self.llm = llm
         self.templates = templates
         self.mcp_providers = mcp_providers or []
         self.tools = tools or []
+        self.memories: list[BaseMemory] = memories or []
 
     def with_llm(self, llm: LLM) -> Self:
         """Set llm of builder."""
@@ -104,6 +113,16 @@ class LLMAgentBuilder:
     def with_mcp_providers(self, providers: list[MCPToolProvider]) -> Self:
         """Add mcp providers to builder."""
         self.mcp_providers.extend(providers)
+        return self
+
+    def with_memory(self, memory: BaseMemory) -> Self:
+        """Add a memory backend to builder."""
+        self.memories.append(memory)
+        return self
+
+    def with_memories(self, memories: list[BaseMemory]) -> Self:
+        """Add memory backends to builder."""
+        self.memories.extend(memories)
         return self
 
     async def build(self) -> LLMAgent:
@@ -142,4 +161,5 @@ class LLMAgentBuilder:
             llm=self.llm,
             tools=self.tools + mcp_tools,
             templates=self.templates,
+            memories=self.memories,
         )

--- a/src/llm_agents_from_scratch/agent/builder.py
+++ b/src/llm_agents_from_scratch/agent/builder.py
@@ -37,6 +37,7 @@ class LLMAgentBuilder:
         tools: list[Tool] | None = None,
         templates: LLMAgentTemplates = default_templates,
         mcp_providers: list[MCPToolProvider] | None = None,
+        # added in ch07
         memories: list[BaseMemory] | None = None,
     ) -> None:
         """Initialize an LLMAgentBuilder.
@@ -83,6 +84,7 @@ class LLMAgentBuilder:
         self.templates = templates
         self.mcp_providers = mcp_providers or []
         self.tools = tools or []
+        # added in ch07
         self.memories: list[BaseMemory] = memories or []
 
     def with_llm(self, llm: LLM) -> Self:
@@ -116,12 +118,12 @@ class LLMAgentBuilder:
         return self
 
     def with_memory(self, memory: BaseMemory) -> Self:
-        """Add a memory backend to builder."""
+        """Add a memory backend to builder. Added in Chapter 7."""
         self.memories.append(memory)
         return self
 
     def with_memories(self, memories: list[BaseMemory]) -> Self:
-        """Add memory backends to builder."""
+        """Add memory backends to builder. Added in Chapter 7."""
         self.memories.extend(memories)
         return self
 
@@ -161,5 +163,5 @@ class LLMAgentBuilder:
             llm=self.llm,
             tools=self.tools + mcp_tools,
             templates=self.templates,
-            memories=self.memories,
+            memories=self.memories,  # added in ch07
         )

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -190,12 +190,13 @@ class LLMAgent:
         def _skills_catalog(self) -> str:
             """Return formatted skills catalog, or empty string.
 
+            Added in Chapter 6.
+
             Builds the ``<available_skills>`` XML block from discovered
             skills that have not opted out of model-driven activation
             (i.e. ``disable-model-invocation`` is not set). Returns an
             empty string when no visible skills remain so callers can
-            append it unconditionally without adding noise. Added in
-            Chapter 6.
+            append it unconditionally without adding noise.
             """
             visible = [
                 skill
@@ -501,10 +502,12 @@ class LLMAgent:
         async def load_memories(self) -> None:
             """Recall relevant episodes from all configured memory backends.
 
+            Added in Chapter 7.
+
             Calls ``recall`` on each memory in ``self.llm_agent.memories``
             and stores the formatted string in ``self._recalled_memories``
             for prompt injection during ``run_step``. No-op when no memories
-            are configured. Added in Chapter 7.
+            are configured.
             """
             loaded = []
             for memory in self.llm_agent.memories:
@@ -606,6 +609,8 @@ class LLMAgent:
         max_steps: int | None = None,
     ) -> TaskHandler:
         """User-explicit skill activation: the programmatic slash command.
+
+        Added in Chapter 6.
 
         Frames the task instruction to direct the model to activate the named
         skill as its first action, then runs the full agent loop. Relies on

--- a/tests/agent/test_builder.py
+++ b/tests/agent/test_builder.py
@@ -6,6 +6,7 @@ import pytest
 
 from llm_agents_from_scratch import LLMAgentBuilder
 from llm_agents_from_scratch.agent.templates import default_templates
+from llm_agents_from_scratch.base.memory import BaseMemory
 from llm_agents_from_scratch.errors import LLMAgentBuilderError
 from llm_agents_from_scratch.tools.mcp.tool import MCPTool
 
@@ -15,17 +16,20 @@ def test_init() -> None:
     mock_llm = MagicMock()
     mock_tool = MagicMock()
     mock_mcp_provider = MagicMock()
+    mock_memory = MagicMock(spec=BaseMemory)
 
     # direct params
     builder = LLMAgentBuilder(
         llm=mock_llm,
         tools=[mock_tool],
         mcp_providers=[mock_mcp_provider],
+        memories=[mock_memory],
     )
     assert builder.llm == mock_llm
     assert builder.tools == [mock_tool]
     assert builder.mcp_providers == [mock_mcp_provider]
     assert builder.templates == default_templates
+    assert builder.memories == [mock_memory]
 
     # fluent chaining
     builder = (
@@ -34,22 +38,26 @@ def test_init() -> None:
         .with_llm(mock_llm)
         .with_templates(default_templates)
         .with_mcp_provider(mock_mcp_provider)
+        .with_memory(mock_memory)
     )
     assert builder.llm == mock_llm
     assert builder.tools == [mock_tool]
     assert builder.mcp_providers == [mock_mcp_provider]
     assert builder.templates == default_templates
+    assert builder.memories == [mock_memory]
 
     # mix
     builder = (
         LLMAgentBuilder(llm=mock_llm)
         .with_tools([mock_tool])
         .with_mcp_providers([mock_mcp_provider])
+        .with_memories([mock_memory])
     )
     assert builder.llm == mock_llm
     assert builder.tools == [mock_tool]
     assert builder.mcp_providers == [mock_mcp_provider]
     assert builder.templates == default_templates
+    assert builder.memories == [mock_memory]
 
 
 @pytest.mark.asyncio
@@ -80,6 +88,24 @@ async def test_build() -> None:
     mock_get_tools.assert_awaited_once()
     assert agent.llm == builder.llm
     assert agent.templates == builder.templates
+    assert agent.memories == []
+
+
+@pytest.mark.asyncio
+async def test_build_passes_memories_to_agent() -> None:
+    """Tests build passes memories through to the constructed LLMAgent."""
+    mock_llm = MagicMock()
+    mock_memory_a = MagicMock(spec=BaseMemory)
+    mock_memory_b = MagicMock(spec=BaseMemory)
+
+    agent = await (
+        LLMAgentBuilder(llm=mock_llm)
+        .with_memory(mock_memory_a)
+        .with_memory(mock_memory_b)
+        .build()
+    )
+
+    assert agent.memories == [mock_memory_a, mock_memory_b]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `with_memory(memory)` and `with_memories(memories)` fluent builder methods to `LLMAgentBuilder`
- Adds `memories` parameter to `LLMAgentBuilder.__init__` for direct-param style
- Passes `memories` through to `LLMAgent` in `build()`
- Updates class and `__init__` docstrings with `memories` attribute and arg

## Test plan

- [ ] `pytest tests/agent/test_builder.py -v` — all 4 tests pass (init covers direct/fluent/mix styles with memories; new `test_build_passes_memories_to_agent` asserts end-to-end wiring)
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)