### PR TITLE
525: implement JSONMemoryStore

### DIFF
--- a/docs/api_reference/base/memory.md
+++ b/docs/api_reference/base/memory.md
@@ -1,0 +1,3 @@
+# Memory
+
+::: llm_agents_from_scratch.base.memory

--- a/docs/api_reference/memory/json_store.md
+++ b/docs/api_reference/memory/json_store.md
@@ -1,0 +1,3 @@
+# JSONMemoryStore
+
+::: llm_agents_from_scratch.memory.json_store

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,8 @@ nav:
       - Pydantic Function: api_reference/tools/pydantic_function.md
       - MCP: api_reference/tools/mcp.md
       - Default Tools: api_reference/tools/default.md
+    - Memory:
+      - JSONMemoryStore: api_reference/memory/json_store.md
     - Skills:
       - Skill: api_reference/skills/skill.md
       - Discovery: api_reference/skills/discovery.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - API Reference:
     - Base:
       - LLM: api_reference/base/llm.md
+      - Memory: api_reference/base/memory.md
       - Tool: api_reference/base/tool.md
     - Agent:
       - LLMAgent: api_reference/agent/llm_agent.md

--- a/src/llm_agents_from_scratch/__init__.py
+++ b/src/llm_agents_from_scratch/__init__.py
@@ -6,6 +6,8 @@ from llm_agents_from_scratch._version import VERSION
 # ruff: noqa: F403, F401
 from .agent import *
 from .agent import __all__ as _agent_all
+from .memory import *
+from .memory import __all__ as _memory_all
 from .skills import *
 from .skills import __all__ as _skills_all
 from .tools import *
@@ -14,4 +16,6 @@ from .tools import __all__ as _tool_all
 __version__ = VERSION
 
 
-__all__ = sorted(_agent_all + _skills_all + _tool_all)  # noqa: PLE0605
+__all__ = sorted(  # noqa: PLE0605
+    _agent_all + _memory_all + _skills_all + _tool_all,
+)

--- a/src/llm_agents_from_scratch/memory/__init__.py
+++ b/src/llm_agents_from_scratch/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory implementations."""
+
+from .json_store import JSONMemoryStore
+
+__all__ = ["JSONMemoryStore"]

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -1,6 +1,5 @@
-"""JSON-file-backed episodic memory store."""
+"""JSONL-file-backed episodic memory store."""
 
-import json
 from pathlib import Path
 
 from llm_agents_from_scratch.base.memory import BaseMemoryStore
@@ -8,10 +7,14 @@ from llm_agents_from_scratch.data_structures.memory import Episode
 
 
 class JSONMemoryStore(BaseMemoryStore):
-    """Episodic memory store backed by a JSON file on disk.
+    """Episodic memory store backed by a JSONL file on disk.
+
+    Each episode is stored as one JSON object per line (JSONL format).
+    New episodes are appended to the file — no full rewrite on each write.
+    The full file is read into memory on construction and on ``read_recent``.
 
     Attributes:
-        path (Path): Path to the JSON file used for persistence.
+        path (Path): Path to the JSONL file used for persistence.
     """
 
     def __init__(self, path: Path) -> None:
@@ -21,7 +24,7 @@ class JSONMemoryStore(BaseMemoryStore):
         is created on the first ``write`` call if it does not yet exist.
 
         Args:
-            path (Path): Caller-supplied path to the backing JSON file. No
+            path (Path): Caller-supplied path to the backing JSONL file. No
                 default location is imposed by the library — the caller
                 decides where episodes are stored.
         """
@@ -32,28 +35,28 @@ class JSONMemoryStore(BaseMemoryStore):
         if not self.path.exists():
             return []
         with open(self.path) as f:
-            return [Episode(**ep) for ep in json.load(f)]
-
-    def _save(self) -> None:
-        with open(self.path, "w") as f:
-            json.dump(
-                [ep.model_dump(mode="json") for ep in self._episodes],
-                f,
-            )
+            return [
+                Episode.model_validate_json(line) for line in f if line.strip()
+            ]
 
     async def write(self, episode: Episode) -> None:
         """Persist an episode to the store.
 
-        Appends to the in-memory list and rewrites the full JSON file.
+        Appends one JSON line to the backing file. Does not rewrite existing
+        content.
 
         Args:
             episode (Episode): The completed episode to store.
         """
         self._episodes.append(episode)
-        self._save()
+        with open(self.path, "a") as f:
+            f.write(episode.model_dump_json() + "\n")
 
     async def read_recent(self, n: int) -> list[Episode]:
         """Return the N most recently recorded episodes.
+
+        Reads all episodes from the in-memory list. A production
+        implementation would tail the file to avoid reading it in full.
 
         Args:
             n (int): Maximum number of episodes to return.

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -1,0 +1,84 @@
+"""JSON-file-backed episodic memory store."""
+
+import json
+from pathlib import Path
+
+from llm_agents_from_scratch.base.memory import BaseMemoryStore
+from llm_agents_from_scratch.data_structures.memory import Episode
+
+
+class JSONMemoryStore(BaseMemoryStore):
+    """Episodic memory store backed by a JSON file on disk.
+
+    Attributes:
+        path (Path): Path to the JSON file used for persistence.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Initialize a JSONMemoryStore.
+
+        Loads any existing episodes from ``path`` on construction. The file
+        is created on the first ``write`` call if it does not yet exist.
+
+        Args:
+            path (Path): Caller-supplied path to the backing JSON file. No
+                default location is imposed by the library — the caller
+                decides where episodes are stored.
+        """
+        self.path = path
+        self._episodes: list[Episode] = self._load()
+
+    def _load(self) -> list[Episode]:
+        if not self.path.exists():
+            return []
+        with open(self.path) as f:
+            return [Episode(**ep) for ep in json.load(f)]
+
+    def _save(self) -> None:
+        with open(self.path, "w") as f:
+            json.dump(
+                [ep.model_dump(mode="json") for ep in self._episodes],
+                f,
+            )
+
+    async def write(self, episode: Episode) -> None:
+        """Persist an episode to the store.
+
+        Appends to the in-memory list and rewrites the full JSON file.
+
+        Args:
+            episode (Episode): The completed episode to store.
+        """
+        self._episodes.append(episode)
+        self._save()
+
+    async def read_recent(self, n: int) -> list[Episode]:
+        """Return the N most recently recorded episodes.
+
+        Args:
+            n (int): Maximum number of episodes to return.
+
+        Returns:
+            list[Episode]: Episodes ordered from most recent to oldest.
+        """
+        return sorted(
+            self._episodes,
+            key=lambda e: e.completed_at,
+            reverse=True,
+        )[:n]
+
+    async def search(self, query: str, k: int) -> list[Episode]:
+        """Not implemented — similarity search is deferred to vector store.
+
+        Args:
+            query (str): The search query.
+            k (int): Maximum number of episodes to return.
+
+        Raises:
+            NotImplementedError: Always. Use a vector-backed store for
+                similarity search.
+        """
+        raise NotImplementedError(
+            "JSONMemoryStore does not support similarity search. "
+            "Use a vector-backed store instead.",
+        )

--- a/tests/api/test_memory_imports.py
+++ b/tests/api/test_memory_imports.py
@@ -1,0 +1,15 @@
+import importlib
+
+import pytest
+
+from llm_agents_from_scratch.memory import __all__ as _memory_all
+
+
+@pytest.mark.parametrize("name", _memory_all)
+def test_memory_all_importable(name: str) -> None:
+    """Tests that all names listed in memory __all__ are importable."""
+    mod = importlib.import_module("llm_agents_from_scratch.memory")
+    attr = getattr(mod, name)
+
+    assert hasattr(mod, name)
+    assert attr is not None

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -24,15 +24,15 @@ def make_episode(
 
 def test_init_empty_when_file_missing(tmp_path: Path) -> None:
     """Tests store starts empty when backing file does not exist."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
     assert store._episodes == []
 
 
 def test_init_loads_existing_episodes(tmp_path: Path) -> None:
-    """Tests store loads episodes from an existing JSON file on init."""
-    path = tmp_path / "episodes.json"
+    """Tests store loads episodes from an existing JSONL file on init."""
+    path = tmp_path / "episodes.jsonll"
     ep = make_episode()
-    path.write_text(json.dumps([ep.model_dump(mode="json")]))
+    path.write_text(ep.model_dump_json() + "\n")
 
     store = JSONMemoryStore(path=path)
     assert len(store._episodes) == 1
@@ -41,23 +41,23 @@ def test_init_loads_existing_episodes(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_write_persists_to_disk(tmp_path: Path) -> None:
-    """Tests write appends episode and saves to JSON file."""
-    path = tmp_path / "episodes.json"
+    """Tests write appends one JSON line to the JSONL file."""
+    path = tmp_path / "episodes.jsonll"
     store = JSONMemoryStore(path=path)
     ep = make_episode()
 
     await store.write(ep)
 
     assert path.exists()
-    data = json.loads(path.read_text())
-    assert len(data) == 1
-    assert data[0]["task"]["instruction"] == ep.task.instruction
+    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["task"]["instruction"] == ep.task.instruction  # noqa: E501
 
 
 @pytest.mark.asyncio
 async def test_write_multiple_episodes(tmp_path: Path) -> None:
     """Tests multiple writes accumulate on disk."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
 
     await store.write(make_episode("task 1"))
     await store.write(make_episode("task 2"))
@@ -69,7 +69,7 @@ async def test_write_multiple_episodes(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_reload_restores_written_episodes(tmp_path: Path) -> None:
     """Tests a new store instance loads episodes written by a previous one."""
-    path = tmp_path / "episodes.json"
+    path = tmp_path / "episodes.jsonl"
     store = JSONMemoryStore(path=path)
     await store.write(make_episode("persisted task"))
 
@@ -81,7 +81,7 @@ async def test_reload_restores_written_episodes(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_read_recent_returns_n_most_recent(tmp_path: Path) -> None:
     """Tests read_recent returns episodes ordered newest-first, capped at n."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
     await store.write(make_episode("oldest"))
     await store.write(make_episode("middle"))
     await store.write(make_episode("newest"))
@@ -98,7 +98,7 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
     tmp_path: Path,
 ) -> None:
     """Tests read_recent returns all episodes when n > stored count."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
     await store.write(make_episode())
 
     recent = await store.read_recent(10)
@@ -108,7 +108,7 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
 @pytest.mark.asyncio
 async def test_search_raises_not_implemented(tmp_path: Path) -> None:
     """Tests search raises NotImplementedError."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
 
     with pytest.raises(NotImplementedError):
         await store.search("query", k=3)

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -1,0 +1,114 @@
+"""Unit tests for JSONMemoryStore."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from llm_agents_from_scratch.data_structures import Task, TaskResult
+from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory import JSONMemoryStore
+
+
+def make_episode(
+    instruction: str = "do something",
+    content: str = "done",
+) -> Episode:
+    task = Task(instruction=instruction)
+    return Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content=content),
+    )
+
+
+def test_init_empty_when_file_missing(tmp_path: Path) -> None:
+    """Tests store starts empty when backing file does not exist."""
+    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    assert store._episodes == []
+
+
+def test_init_loads_existing_episodes(tmp_path: Path) -> None:
+    """Tests store loads episodes from an existing JSON file on init."""
+    path = tmp_path / "episodes.json"
+    ep = make_episode()
+    path.write_text(json.dumps([ep.model_dump(mode="json")]))
+
+    store = JSONMemoryStore(path=path)
+    assert len(store._episodes) == 1
+    assert store._episodes[0].task.instruction == ep.task.instruction
+
+
+@pytest.mark.asyncio
+async def test_write_persists_to_disk(tmp_path: Path) -> None:
+    """Tests write appends episode and saves to JSON file."""
+    path = tmp_path / "episodes.json"
+    store = JSONMemoryStore(path=path)
+    ep = make_episode()
+
+    await store.write(ep)
+
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert len(data) == 1
+    assert data[0]["task"]["instruction"] == ep.task.instruction
+
+
+@pytest.mark.asyncio
+async def test_write_multiple_episodes(tmp_path: Path) -> None:
+    """Tests multiple writes accumulate on disk."""
+    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+
+    await store.write(make_episode("task 1"))
+    await store.write(make_episode("task 2"))
+    await store.write(make_episode("task 3"))
+
+    assert len(store._episodes) == 3  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_reload_restores_written_episodes(tmp_path: Path) -> None:
+    """Tests a new store instance loads episodes written by a previous one."""
+    path = tmp_path / "episodes.json"
+    store = JSONMemoryStore(path=path)
+    await store.write(make_episode("persisted task"))
+
+    store2 = JSONMemoryStore(path=path)
+    assert len(store2._episodes) == 1
+    assert store2._episodes[0].task.instruction == "persisted task"
+
+
+@pytest.mark.asyncio
+async def test_read_recent_returns_n_most_recent(tmp_path: Path) -> None:
+    """Tests read_recent returns episodes ordered newest-first, capped at n."""
+    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    await store.write(make_episode("oldest"))
+    await store.write(make_episode("middle"))
+    await store.write(make_episode("newest"))
+
+    recent = await store.read_recent(2)
+
+    assert len(recent) == 2  # noqa: PLR2004
+    assert recent[0].task.instruction == "newest"
+    assert recent[1].task.instruction == "middle"
+
+
+@pytest.mark.asyncio
+async def test_read_recent_returns_all_when_n_exceeds_count(
+    tmp_path: Path,
+) -> None:
+    """Tests read_recent returns all episodes when n > stored count."""
+    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+    await store.write(make_episode())
+
+    recent = await store.read_recent(10)
+    assert len(recent) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_raises_not_implemented(tmp_path: Path) -> None:
+    """Tests search raises NotImplementedError."""
+    store = JSONMemoryStore(path=tmp_path / "episodes.json")
+
+    with pytest.raises(NotImplementedError):
+        await store.search("query", k=3)


### PR DESCRIPTION
## Summary

- Adds `src/llm_agents_from_scratch/memory/json_store.py` with `JSONMemoryStore(BaseMemoryStore)`
- Caller-owned `path: Path` — no default location imposed by the library
- Loads existing episodes from disk on `__init__`; creates file on first `write`
- `write(episode)` appends to in-memory list and rewrites the full JSON file (`model_dump(mode="json")` for serialization, `Episode(**ep)` for deserialization)
- `read_recent(n)` returns N most recent episodes sorted by `completed_at` descending
- `search(query, k)` raises `NotImplementedError` — similarity search deferred to vector store material
- Exports `JSONMemoryStore` from top-level package via new `memory/` package

## Test plan

- [ ] `pytest tests/memory/test_json_store.py -v` — 8 tests covering init (missing/existing file), write persistence, reload across instances, `read_recent` ordering and capping, `search` raises
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)