### PR TITLE
546: more-examples ch07 — RecencyMemory + JSONMemoryStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ capstones/one/_capstone_1_ch05-openai.ipynb
 # untracked skills
 **/skills/slack-gif-creator
 **/output.gif
+
+# generated notebook artifacts
+more-examples/**/*.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- refactor: `JSONMemoryStore` now takes `dir` + `filename` params instead of a single `path` (#547)
+
 ### Added
 
 - feat: add count() to store (#545)

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,16 @@ engineering required.
 [Open Notebook](more-examples/ch06/skills_marketplace.ipynb){ .md-button .md-button--primary }
 </div>
 
+<div class="landing-card landing-card--example" markdown>
+### :material-brain: Episodic Memory
+
+Run three Pokémon lookups, then ask a synthesis question — the agent answers
+from recalled episodes without calling any tools. A second agent instance
+points at the same JSONL file and picks up all prior episodes from disk.
+
+[Open Notebook](more-examples/ch07/recency_memory.ipynb){ .md-button .md-button--primary }
+</div>
+
 </div>
 
 [Browse all examples :octicons-arrow-right-24:](more-examples/ch06/skills_marketplace.ipynb){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,8 @@ nav:
       - Skill Validation Errors: more-examples/ch06/skill_validation_errors.ipynb
       - User Explicit Skill (Hailstone): more-examples/ch06/user_explicit_hailstone.ipynb
       - Skills Marketplace: more-examples/ch06/skills_marketplace.ipynb
+    - Chapter 7:
+      - Episodic Memory (PokéAPI): more-examples/ch07/recency_memory.ipynb
   - Capstones:
     # Symlinked from capstones/ — do not copy directly.
     - Capstone 1:

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "id": "38d01453b7654a53bcd8741072c0e275",
    "metadata": {},
    "outputs": [
@@ -61,7 +61,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Ollama already running at http://localhost:11434\n"
+      "Starting Ollama server (/usr/local/bin/ollama)...\n",
+      "✓ Ollama up and running at http://localhost:11434\n"
      ]
     }
    ],
@@ -125,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d7ce6abee05845d094ec30c32274f27f",
    "metadata": {},
    "outputs": [],
@@ -157,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "e1205db265d24c4d86fe43c1b91d00a5",
    "metadata": {},
    "outputs": [],
@@ -189,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "c566c45c76b0465a855130ecfd7e6946",
    "metadata": {},
    "outputs": [],
@@ -217,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3fd32b727c05411585f17b526a901dff",
    "metadata": {},
    "outputs": [],
@@ -243,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "f2f317d9468c403d9d1cf49d6f0752eb",
    "metadata": {},
    "outputs": [
@@ -251,8 +252,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
@@ -296,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "5f1cfe1ed942475ba02c18b420560fae",
    "metadata": {},
    "outputs": [
@@ -314,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "5d947fc8637a4621ace3887325dedc25",
    "metadata": {},
    "outputs": [
@@ -322,8 +323,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Gengar\" to retrieve its base stats.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
@@ -367,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "fdc46ea0dbff4783afcd0a4904c160fe",
    "metadata": {},
    "outputs": [
@@ -385,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "f9e4010ec9a8410ab3b073e71a821d42",
    "metadata": {},
    "outputs": [
@@ -393,8 +394,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Mewtwo\" to retrieve its base stats.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Mewtwo' to retrieve its base stats.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Mewtwo' to retrieve its base stats.\n",
@@ -438,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "195307ead80c4a34b24981bd1bcefb6d",
    "metadata": {},
    "outputs": [
@@ -470,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "283f1670b3c54073b96c2a772d766fa1",
    "metadata": {},
    "outputs": [
@@ -478,19 +479,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use only ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use on...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched so far:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched:\n",
       "\n",
       "- Mewtwo has a base speed of 130.\n",
       "- Gengar has a base speed of 110.\n",
-      "- Pikachu has a base sp...[TRUNCATED]\n",
+      "- Pikachu has a base speed of ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched so far:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched:\n",
       "\n",
       "- Mewtwo has a base speed of 130.\n",
       "- Gengar has a base speed of 110.\n",
-      "- Pikachu has a base...[TRUNCATED]\n"
+      "- Pikachu has a base speed ...[TRUNCATED]\n"
      ]
     }
    ],
@@ -507,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "d19db3129a674ef78f1384c1c4b832a7",
    "metadata": {},
    "outputs": [
@@ -515,13 +516,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "From the Pokémon I have researched so far:\n",
+      "From the Pokémon I have researched:\n",
       "\n",
       "- Mewtwo has a base speed of 130.\n",
       "- Gengar has a base speed of 110.\n",
       "- Pikachu has a base speed of 90.\n",
       "\n",
-      "Among these, **Mewtwo** has the highest base speed of **130**.\n"
+      "Mewtwo has the highest base speed among these Pokémon.\n"
      ]
     }
    ],
@@ -543,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "4b8658719c7a48bf8d9e2f599cc13e93",
    "metadata": {},
    "outputs": [
@@ -554,7 +555,7 @@
       "4 episode(s) on disk\n",
       "\n",
       "  <episode>\n",
-      "    <task>What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <task>What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.</task>\n",
       "    <result>The base stats for Pikachu are as follows:\n",
       "- HP: 35\n",
       "- Attack: 55\n",
@@ -563,11 +564,11 @@
       "- Special Defense: 50\n",
       "- Speed: 90\n",
       "    </result>\n",
-      "    <completed_at>2026-05-17 21:59:57</completed_at>\n",
+      "    <completed_at>2026-05-17 23:00:30</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
-      "    <task>What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <task>What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.</task>\n",
       "    <result>The base stats for Gengar are as follows:\n",
       "- HP: 60\n",
       "- Attack: 65\n",
@@ -576,11 +577,11 @@
       "- Special Defense: 75\n",
       "- Speed: 110\n",
       "    </result>\n",
-      "    <completed_at>2026-05-17 22:00:38</completed_at>\n",
+      "    <completed_at>2026-05-17 23:00:50</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
-      "    <task>What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <task>What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.</task>\n",
       "    <result>The base stats for Mewtwo are as follows:\n",
       "- HP: 106\n",
       "- Attack: 110\n",
@@ -589,20 +590,20 @@
       "- Special Defense: 90\n",
       "- Speed: 130\n",
       "    </result>\n",
-      "    <completed_at>2026-05-17 22:01:03</completed_at>\n",
+      "    <completed_at>2026-05-17 23:01:12</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
-      "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use only what you already know.</task>\n",
-      "    <result>From the Pokémon I have researched so far:\n",
+      "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
+      "    <result>From the Pokémon I have researched:\n",
       "\n",
       "- Mewtwo has a base speed of 130.\n",
       "- Gengar has a base speed of 110.\n",
       "- Pikachu has a base speed of 90.\n",
       "\n",
-      "Among these, **Mewtwo** has the highest base speed of **130**.\n",
+      "Mewtwo has the highest base speed among these Pokémon.\n",
       "    </result>\n",
-      "    <completed_at>2026-05-17 22:01:16</completed_at>\n",
+      "    <completed_at>2026-05-17 23:01:22</completed_at>\n",
       "  </episode>\n",
       "\n"
      ]
@@ -632,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "cc17f94c55c64a979f54336e521243a2",
    "metadata": {},
    "outputs": [],
@@ -645,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "0536293e0cd8472a97cc3cc2101868d9",
    "metadata": {},
    "outputs": [
@@ -663,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "160b2241c5234a20a11686a1167f7b50",
    "metadata": {},
    "outputs": [
@@ -671,23 +672,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools - use only ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools - use on...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched the following Pokémon:\n",
-      "\n",
-      "- Mewtwo\n",
-      "- Gengar\n",
-      "- Pikachu\n",
-      "\n",
-      "Among these, **Mewtwo** has the highest base speed of...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130.\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched the following Pokémon:\n",
-      "\n",
-      "- Mewtwo\n",
-      "- Gengar\n",
-      "- Pikachu\n",
-      "\n",
-      "Among these, **Mewtwo** has the highest base speed...[TRUNCATED]\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130...[TRUNCATED]\n"
      ]
     }
    ],
@@ -704,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "bd6cd6a0293b491387bbd6b15cc089f4",
    "metadata": {},
    "outputs": [
@@ -712,13 +701,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I have previously researched the following Pokémon:\n",
-      "\n",
-      "- Mewtwo\n",
-      "- Gengar\n",
-      "- Pikachu\n",
-      "\n",
-      "Among these, **Mewtwo** has the highest base speed of **130**.\n"
+      "I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130.\n"
      ]
     }
    ],

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -180,8 +180,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "STORE_PATH = Path(\"./pokemon_research.jsonl\")\n",
-    "STORE_PATH.unlink(missing_ok=True)  # start clean on each full run"
+    "STORE_DIR = Path(\".\")\n",
+    "STORE_DIR.mkdir(exist_ok=True)\n",
+    "(STORE_DIR / \"episodes.jsonl\").unlink(\n",
+    "    missing_ok=True,\n",
+    ")  # start clean on each full run"
    ]
   },
   {
@@ -205,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store = JSONMemoryStore(path=STORE_PATH)\n",
+    "store = JSONMemoryStore(dir=STORE_DIR)\n",
     "memory = RecencyMemory(store=store, n=3)\n",
     "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
     "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
@@ -592,7 +595,7 @@
     }
    ],
    "source": [
-    "lines = STORE_PATH.read_text().splitlines()\n",
+    "lines = (STORE_DIR / \"episodes.jsonl\").read_text().splitlines()\n",
     "print(f\"{len(lines)} episode(s) on disk\\n\")\n",
     "for line in lines:\n",
     "    episode = Episode.model_validate_json(line)\n",
@@ -620,7 +623,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "store2 = JSONMemoryStore(path=STORE_PATH)\n",
+    "store2 = JSONMemoryStore(dir=STORE_DIR)\n",
     "memory2 = RecencyMemory(store=store2, n=3)\n",
     "llm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
     "agent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -1,0 +1,758 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e3fac0284bf040c785cee3d5d3b5bec1",
+   "metadata": {},
+   "source": [
+    "# Episodic Memory — Research Accumulation and Persistence\n",
+    "\n",
+    "This notebook demonstrates `RecencyMemory` and `JSONMemoryStore` working together\n",
+    "to give an `LLMAgent` episodic memory that accumulates across tasks and survives\n",
+    "agent restarts.\n",
+    "\n",
+    "Two properties are illustrated:\n",
+    "\n",
+    "- **Recall across tasks.** After each task the agent records an episode.\n",
+    "  Subsequent tasks receive the most recent `n` episodes injected into their system\n",
+    "  prompt, so the agent can answer synthesis questions without repeating tool calls.\n",
+    "- **Persistence across restarts.** `JSONMemoryStore` writes episodes to a JSONL\n",
+    "  file on disk. A brand-new agent instance pointing to the same file picks up all\n",
+    "  prior episodes immediately.\n",
+    "\n",
+    "> **This notebook uses the same PokéAPI tool as `ch04/pokemon_comparison.ipynb`.**\n",
+    "> Reading that notebook first is recommended."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fc3a3d7cdf442629c669b92df78f8dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "994c9e595b8747c0ae3cfbb1939c4b44",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed\n",
+    "on your local machine and have its LLM hosting service running. To download Ollama,\n",
+    "follow the instructions found on this page: https://ollama.com/download. After\n",
+    "downloading and installing Ollama, you can start a service by opening a terminal\n",
+    "and running the command `ollama serve`.\n",
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "38d01453b7654a53bcd8741072c0e275",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting Ollama server (/usr/local/bin/ollama)...\n",
+      "✓ Ollama up and running at http://localhost:11434\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "510d6f75dba1430e904e10f8dd9e7743",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.memory import JSONMemoryStore, RecencyMemory\n",
+    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "\n",
+    "def get_pokemon(name: str) -> str:\n",
+    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
+    "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
+    "    req = urllib.request.Request(\n",
+    "        url,\n",
+    "        headers={\"User-Agent\": \"llm-agents-from-scratch/1.0\"},\n",
+    "    )\n",
+    "    try:\n",
+    "        with urllib.request.urlopen(req) as resp:\n",
+    "            data = json.loads(resp.read())\n",
+    "    except urllib.error.HTTPError as e:\n",
+    "        if e.code == 404:  # noqa: PLR2004\n",
+    "            raise ValueError(\n",
+    "                f\"Pokémon '{name}' not found. \"\n",
+    "                \"Check the spelling and try again.\",\n",
+    "            ) from e\n",
+    "        raise\n",
+    "    types = [t[\"type\"][\"name\"] for t in data[\"types\"]]\n",
+    "    stats = {s[\"stat\"][\"name\"]: s[\"base_stat\"] for s in data[\"stats\"]}\n",
+    "    return json.dumps({\"name\": data[\"name\"], \"types\": types, \"stats\": stats})\n",
+    "\n",
+    "\n",
+    "get_pokemon_tool = SimpleFunctionTool(func=get_pokemon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c566c45c76b0465a855130ecfd7e6946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STORE_PATH = Path(\"./pokemon_research.jsonl\")\n",
+    "STORE_PATH.unlink(missing_ok=True)  # start clean on each full run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0358fe6d0724395a61f5ef940f9e47e",
+   "metadata": {},
+   "source": [
+    "## Creating the Agent with Memory\n",
+    "\n",
+    "`JSONMemoryStore` manages the JSONL file at `STORE_PATH`. `RecencyMemory` wraps\n",
+    "the store and decides what to recall (the `n` most recent episodes) and how to\n",
+    "format the result for the system prompt. The agent holds the memory in its\n",
+    "`memories` list. `TaskHandler` calls `recall` at task start and `record` at\n",
+    "task end automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3fd32b727c05411585f17b526a901dff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store = JSONMemoryStore(path=STORE_PATH)\n",
+    "memory = RecencyMemory(store=store, n=3)\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c9d5b00b35d4f9cbba5866815f631d1",
+   "metadata": {},
+   "source": [
+    "## Part 1 — Building Up Episodic Memory\n",
+    "\n",
+    "Three sequential Pokémon lookups. Each task calls `get_pokemon` once and records\n",
+    "an episode at the end. The memory summary after each task shows the store count\n",
+    "growing from 0 to 3. By the time the fourth task runs, all three episodes\n",
+    "will be recalled into its system prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f2f317d9468c403d9d1cf49d6f0752eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Pikachu are as follows:\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special Defense: 50\n",
+      "- Speed: 90\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Pikachu are as follows:\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special Defense: 50\n",
+      "- Speed: 9...[TRUNCATED]\n",
+      "The base stats for Pikachu are as follows:\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special Defense: 50\n",
+      "- Speed: 90\n"
+     ]
+    }
+   ],
+   "source": [
+    "task1 = Task(\n",
+    "    instruction=(\n",
+    "        \"What are Pikachu's base stats? \"\n",
+    "        \"Use the get_pokemon tool. Do not rely on prior knowledge.\"\n",
+    "    ),\n",
+    ")\n",
+    "result1 = await agent.run(task1)\n",
+    "print(result1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5f1cfe1ed942475ba02c18b420560fae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RecencyMemory: 1 episodes stored, recalling last 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(await agent.memories[0].summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5d947fc8637a4621ace3887325dedc25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Gengar\" to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Gengar are as follows:\n",
+      "- HP: 60\n",
+      "- Attack: 65\n",
+      "- Defense: 60\n",
+      "- Special Attack: 130\n",
+      "- Special Defense: 75\n",
+      "- Speed: 110\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Gengar are as follows:\n",
+      "- HP: 60\n",
+      "- Attack: 65\n",
+      "- Defense: 60\n",
+      "- Special Attack: 130\n",
+      "- Special Defense: 75\n",
+      "- Speed: 1...[TRUNCATED]\n",
+      "The base stats for Gengar are as follows:\n",
+      "- HP: 60\n",
+      "- Attack: 65\n",
+      "- Defense: 60\n",
+      "- Special Attack: 130\n",
+      "- Special Defense: 75\n",
+      "- Speed: 110\n"
+     ]
+    }
+   ],
+   "source": [
+    "task2 = Task(\n",
+    "    instruction=(\n",
+    "        \"What are Gengar's base stats? \"\n",
+    "        \"Use the get_pokemon tool. Do not rely on prior knowledge.\"\n",
+    "    ),\n",
+    ")\n",
+    "result2 = await agent.run(task2)\n",
+    "print(result2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "fdc46ea0dbff4783afcd0a4904c160fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RecencyMemory: 2 episodes stored, recalling last 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(await agent.memories[0].summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f9e4010ec9a8410ab3b073e71a821d42",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Mewtwo\" to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Mewtwo' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Mewtwo' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Mewtwo are as follows:\n",
+      "- HP: 106\n",
+      "- Attack: 110\n",
+      "- Defense: 90\n",
+      "- Special Attack: 154\n",
+      "- Special Defense: 90\n",
+      "- Speed: 13...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Mewtwo are as follows:\n",
+      "- HP: 106\n",
+      "- Attack: 110\n",
+      "- Defense: 90\n",
+      "- Special Attack: 154\n",
+      "- Special Defense: 90\n",
+      "- Speed:...[TRUNCATED]\n",
+      "The base stats for Mewtwo are as follows:\n",
+      "- HP: 106\n",
+      "- Attack: 110\n",
+      "- Defense: 90\n",
+      "- Special Attack: 154\n",
+      "- Special Defense: 90\n",
+      "- Speed: 130\n"
+     ]
+    }
+   ],
+   "source": [
+    "task3 = Task(\n",
+    "    instruction=(\n",
+    "        \"What are Mewtwo's base stats? \"\n",
+    "        \"Use the get_pokemon tool. Do not rely on prior knowledge.\"\n",
+    "    ),\n",
+    ")\n",
+    "result3 = await agent.run(task3)\n",
+    "print(result3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "195307ead80c4a34b24981bd1bcefb6d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RecencyMemory: 3 episodes stored, recalling last 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(await agent.memories[0].summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8717d47fe7984d46bdc7955c97bf8d07",
+   "metadata": {},
+   "source": [
+    "## Part 2 — Synthesis from Recalled Episodes\n",
+    "\n",
+    "The synthesis task asks the agent to compare all three Pokémon by speed. No stats\n",
+    "are provided in the task instruction. The information is only available through\n",
+    "the recalled episodes injected into the system prompt at the start of this run.\n",
+    "A working memory means the agent can answer without calling `get_pokemon` again.\n",
+    "Watch the logs: you should see no `🛠️ Executing Tool Call` lines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "283f1670b3c54073b96c2a772d766fa1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use only ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use on...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched so far:\n",
+      "\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base sp...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched so far:\n",
+      "\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base...[TRUNCATED]\n"
+     ]
+    }
+   ],
+   "source": [
+    "task4 = Task(\n",
+    "    instruction=(\n",
+    "        \"Based on the Pokémon you have already researched, \"\n",
+    "        \"which one has the highest base speed? \"\n",
+    "        \"You do not need to call any tools. Use only what you already know.\"\n",
+    "    ),\n",
+    ")\n",
+    "result4 = await agent.run(task4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d19db3129a674ef78f1384c1c4b832a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "From the Pokémon I have researched so far:\n",
+      "\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed of 90.\n",
+      "\n",
+      "Among these, **Mewtwo** has the highest base speed of **130**.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9db20072dc646118615b9215fb1ebc2",
+   "metadata": {},
+   "source": [
+    "## Part 3 — Inspecting the Store on Disk\n",
+    "\n",
+    "`JSONMemoryStore` writes one JSON line per episode. The cell below reads the raw\n",
+    "file so you can see exactly what is persisted between tasks and what a new\n",
+    "agent instance will load on the next run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4b8658719c7a48bf8d9e2f599cc13e93",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 episode(s) on disk\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Pikachu's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <result>The base stats for Pikachu are as follows:\n",
+      "- HP: 35\n",
+      "- Attack: 55\n",
+      "- Defense: 40\n",
+      "- Special Attack: 50\n",
+      "- Special Defense: 50\n",
+      "- Speed: 90\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-17 21:59:57</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Gengar's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <result>The base stats for Gengar are as follows:\n",
+      "- HP: 60\n",
+      "- Attack: 65\n",
+      "- Defense: 60\n",
+      "- Special Attack: 130\n",
+      "- Special Defense: 75\n",
+      "- Speed: 110\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-17 22:00:38</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Mewtwo's base stats? Use the get_pokemon tool - do not rely on prior knowledge.</task>\n",
+      "    <result>The base stats for Mewtwo are as follows:\n",
+      "- HP: 106\n",
+      "- Attack: 110\n",
+      "- Defense: 90\n",
+      "- Special Attack: 154\n",
+      "- Special Defense: 90\n",
+      "- Speed: 130\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-17 22:01:03</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools - use only what you already know.</task>\n",
+      "    <result>From the Pokémon I have researched so far:\n",
+      "\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed of 90.\n",
+      "\n",
+      "Among these, **Mewtwo** has the highest base speed of **130**.\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-17 22:01:16</completed_at>\n",
+      "  </episode>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "lines = STORE_PATH.read_text().splitlines()\n",
+    "print(f\"{len(lines)} episode(s) on disk\\n\")\n",
+    "for line in lines:\n",
+    "    episode = Episode.model_validate_json(line)\n",
+    "    print(str(episode))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0485777aabcf4c64aece2a9ba10b57a5",
+   "metadata": {},
+   "source": [
+    "## Part 4 — Persistence Across Agent Restarts\n",
+    "\n",
+    "A fresh `LLMAgent` is created pointing at the same `STORE_PATH`. No state is\n",
+    "shared with the previous instance. The new agent loads its episodes entirely\n",
+    "from disk. The summary shows it starts with three episodes already in memory,\n",
+    "and it can answer the synthesis question without calling any tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cc17f94c55c64a979f54336e521243a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store2 = JSONMemoryStore(path=STORE_PATH)\n",
+    "memory2 = RecencyMemory(store=store2, n=3)\n",
+    "llm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0536293e0cd8472a97cc3cc2101868d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RecencyMemory: 4 episodes stored, recalling last 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(await agent2.memories[0].summary())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "160b2241c5234a20a11686a1167f7b50",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools - use only ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools - use on...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched the following Pokémon:\n",
+      "\n",
+      "- Mewtwo\n",
+      "- Gengar\n",
+      "- Pikachu\n",
+      "\n",
+      "Among these, **Mewtwo** has the highest base speed of...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched the following Pokémon:\n",
+      "\n",
+      "- Mewtwo\n",
+      "- Gengar\n",
+      "- Pikachu\n",
+      "\n",
+      "Among these, **Mewtwo** has the highest base speed...[TRUNCATED]\n"
+     ]
+    }
+   ],
+   "source": [
+    "task5 = Task(\n",
+    "    instruction=(\n",
+    "        \"Which Pokémon have you previously researched, and which one had \"\n",
+    "        \"the highest base speed? \"\n",
+    "        \"You do not need to call any tools. Use only what you already know.\"\n",
+    "    ),\n",
+    ")\n",
+    "result5 = await agent2.run(task5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bd6cd6a0293b491387bbd6b15cc089f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I have previously researched the following Pokémon:\n",
+      "\n",
+      "- Mewtwo\n",
+      "- Gengar\n",
+      "- Pikachu\n",
+      "\n",
+      "Among these, **Mewtwo** has the highest base speed of **130**.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2cf38070c7e490d8edbe2bb16fd9731",
+   "metadata": {},
+   "source": [
+    "## Key Takeaway\n",
+    "\n",
+    "`RecencyMemory` and `JSONMemoryStore` give the agent two things it would otherwise\n",
+    "lack:\n",
+    "\n",
+    "- **Context across tasks.** Every task after the first starts with the N most\n",
+    "  recent episodes injected into its system prompt. The agent can synthesise across\n",
+    "  past work without repeating tool calls (see Part 2 and Part 4).\n",
+    "- **Persistence across restarts.** Because `JSONMemoryStore` writes each episode\n",
+    "  to disk immediately, any new agent pointing at the same file resumes with full\n",
+    "  context. Nothing is lost when the process ends.\n",
+    "\n",
+    "The two roles are cleanly separated: `RecencyMemory` decides *what* to retrieve\n",
+    "and *how* to format it for the prompt; `JSONMemoryStore` decides *how* to persist\n",
+    "it. Swapping one does not affect the other: the same `RecencyMemory` works over\n",
+    "any `BaseMemoryStore` implementation, and the same `JSONMemoryStore` works with\n",
+    "any `BaseMemory` implementation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 18,
    "id": "38d01453b7654a53bcd8741072c0e275",
    "metadata": {},
    "outputs": [
@@ -61,8 +61,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Starting Ollama server (/usr/local/bin/ollama)...\n",
-      "✓ Ollama up and running at http://localhost:11434\n"
+      "✓ Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -126,8 +125,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "510d6f75dba1430e904e10f8dd9e7743",
+   "execution_count": null,
+   "id": "d7ce6abee05845d094ec30c32274f27f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,9 +144,24 @@
     "from llm_agents_from_scratch.memory import JSONMemoryStore, RecencyMemory\n",
     "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
     "\n",
-    "enable_console_logging(logging.INFO)\n",
-    "\n",
-    "\n",
+    "enable_console_logging(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e25de52cf5e749f09db7139fe2cde51b",
+   "metadata": {},
+   "source": [
+    "## Defining the Tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1205db265d24c4d86fe43c1b91d00a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def get_pokemon(name: str) -> str:\n",
     "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
     "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -21,7 +21,7 @@ class Episode(BaseModel):
         return (
             f"  <episode>\n"
             f"    <task>{self.task.instruction}</task>\n"
-            f"    <result>{self.result.content}</result>\n"
+            f"    <result>{self.result.content}\n    </result>\n"
             f"    <completed_at>{ts}</completed_at>\n"
             f"  </episode>"
         )

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -14,21 +14,28 @@ class JSONMemoryStore(BaseMemoryStore):
     The full file is read into memory on construction and on ``read_recent``.
 
     Attributes:
-        path (Path): Path to the JSONL file used for persistence.
+        path (Path): Full path to the backing JSONL file (``dir / filename``).
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(
+        self,
+        dir: Path,
+        filename: str = "episodes.jsonl",
+    ) -> None:
         """Initialize a JSONMemoryStore.
 
-        Loads any existing episodes from ``path`` on construction. The file
-        is created on the first ``write`` call if it does not yet exist.
+        Loads any existing episodes from ``dir / filename`` on construction.
+        The file is created on the first ``write`` call if it does not yet
+        exist.
 
         Args:
-            path (Path): Caller-supplied path to the backing JSONL file. No
-                default location is imposed by the library — the caller
-                decides where episodes are stored.
+            dir (Path): Directory in which the backing JSONL file is stored.
+                The caller decides the location; no default is imposed by the
+                library.
+            filename (str): Name of the JSONL file within ``dir``. Defaults
+                to ``"episodes.jsonl"``.
         """
-        self.path = path
+        self.path = dir / filename
         self._episodes: list[Episode] = self._load()
 
     def _load(self) -> list[Episode]:

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -21,7 +21,7 @@ def test_episode_str() -> None:
 
     assert "<episode>" in s
     assert "<task>summarise the doc</task>" in s
-    assert "<result>here is the summary</result>" in s
+    assert "<result>here is the summary\n    </result>" in s
     assert ep.completed_at.strftime("%Y-%m-%d") in s
 
 

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -24,17 +24,16 @@ def make_episode(
 
 def test_init_empty_when_file_missing(tmp_path: Path) -> None:
     """Tests store starts empty when backing file does not exist."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
     assert store._episodes == []
 
 
 def test_init_loads_existing_episodes(tmp_path: Path) -> None:
     """Tests store loads episodes from an existing JSONL file on init."""
-    path = tmp_path / "episodes.jsonll"
     ep = make_episode()
-    path.write_text(ep.model_dump_json() + "\n")
+    (tmp_path / "episodes.jsonl").write_text(ep.model_dump_json() + "\n")
 
-    store = JSONMemoryStore(path=path)
+    store = JSONMemoryStore(dir=tmp_path)
     assert len(store._episodes) == 1
     assert store._episodes[0].task.instruction == ep.task.instruction
 
@@ -42,22 +41,28 @@ def test_init_loads_existing_episodes(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_write_persists_to_disk(tmp_path: Path) -> None:
     """Tests write appends one JSON line to the JSONL file."""
-    path = tmp_path / "episodes.jsonll"
-    store = JSONMemoryStore(path=path)
+    store = JSONMemoryStore(dir=tmp_path)
     ep = make_episode()
 
     await store.write(ep)
 
-    assert path.exists()
-    lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+    assert store.path.exists()
+    lines = [ln for ln in store.path.read_text().splitlines() if ln.strip()]
     assert len(lines) == 1
     assert json.loads(lines[0])["task"]["instruction"] == ep.task.instruction  # noqa: E501
 
 
 @pytest.mark.asyncio
+async def test_custom_filename(tmp_path: Path) -> None:
+    """Tests store uses the caller-supplied filename within the directory."""
+    store = JSONMemoryStore(dir=tmp_path, filename="custom.jsonl")
+    assert store.path == tmp_path / "custom.jsonl"
+
+
+@pytest.mark.asyncio
 async def test_count(tmp_path: Path) -> None:
     """Tests count returns the number of stored episodes."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
 
     assert await store.count() == 0
     await store.write(make_episode("task 1"))
@@ -68,7 +73,7 @@ async def test_count(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_write_multiple_episodes(tmp_path: Path) -> None:
     """Tests multiple writes accumulate on disk."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
 
     await store.write(make_episode("task 1"))
     await store.write(make_episode("task 2"))
@@ -80,11 +85,10 @@ async def test_write_multiple_episodes(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_reload_restores_written_episodes(tmp_path: Path) -> None:
     """Tests a new store instance loads episodes written by a previous one."""
-    path = tmp_path / "episodes.jsonl"
-    store = JSONMemoryStore(path=path)
+    store = JSONMemoryStore(dir=tmp_path)
     await store.write(make_episode("persisted task"))
 
-    store2 = JSONMemoryStore(path=path)
+    store2 = JSONMemoryStore(dir=tmp_path)
     assert len(store2._episodes) == 1
     assert store2._episodes[0].task.instruction == "persisted task"
 
@@ -92,7 +96,7 @@ async def test_reload_restores_written_episodes(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_read_recent_returns_n_most_recent(tmp_path: Path) -> None:
     """Tests read_recent returns episodes ordered newest-first, capped at n."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
     await store.write(make_episode("oldest"))
     await store.write(make_episode("middle"))
     await store.write(make_episode("newest"))
@@ -109,7 +113,7 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
     tmp_path: Path,
 ) -> None:
     """Tests read_recent returns all episodes when n > stored count."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
     await store.write(make_episode())
 
     recent = await store.read_recent(10)
@@ -119,7 +123,7 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
 @pytest.mark.asyncio
 async def test_search_raises_not_implemented(tmp_path: Path) -> None:
     """Tests search raises NotImplementedError."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
 
     with pytest.raises(NotImplementedError):
         await store.search("query", k=3)

--- a/tests/memory/test_recency.py
+++ b/tests/memory/test_recency.py
@@ -84,7 +84,7 @@ async def test_record_delegates_to_store(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_summary(tmp_path: Path) -> None:
     """Tests summary returns episode count and recall window."""
-    store = JSONMemoryStore(path=tmp_path / "episodes.jsonl")
+    store = JSONMemoryStore(dir=tmp_path)
     memory = RecencyMemory(store=store, n=5)
 
     await store.write(make_episode("task 1"))


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch07/recency_memory.ipynb`: a worked example showing `RecencyMemory` and `JSONMemoryStore` together using the PokéAPI tool from ch04
- Fixes `Episode.__str__` to add a newline before `</result>` so the closing tag is visually distinct from multi-line content
- Adds `more-examples/**/*.jsonl` to `.gitignore`
- Adds Chapter 7 section to `mkdocs.yml` More Examples nav
- Adds Episodic Memory card to the landing page (`docs/index.md`)

## Notebook story

1. **Part 1** — three sequential Pokémon lookups; `memory.summary()` after each shows episode count growing 0 → 3
2. **Part 2** — synthesis task answered from recalled episodes, no tool calls
3. **Part 3** — raw JSONL file printed via `Episode.__str__`
4. **Part 4** — fresh agent instance pointing at the same file resumes with full context from disk

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)