### PR TITLE
docs: add QdrantMemoryStore to API reference

### DIFF
--- a/docs/api_reference/memory/qdrant_store.md
+++ b/docs/api_reference/memory/qdrant_store.md
@@ -1,0 +1,3 @@
+# QdrantMemoryStore
+
+::: llm_agents_from_scratch.memory.qdrant_store

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Default Tools: api_reference/tools/default.md
     - Memory:
       - JSONMemoryStore: api_reference/memory/json_store.md
+      - QdrantMemoryStore: api_reference/memory/qdrant_store.md
     - Skills:
       - Skill: api_reference/skills/skill.md
       - Discovery: api_reference/skills/discovery.md


### PR DESCRIPTION
## Summary

- Adds `docs/api_reference/memory/qdrant_store.md` (autodoc stub matching `json_store.md` pattern)
- Registers `QdrantMemoryStore` under the Memory section in `mkdocs.yml`

Missed in #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)