### PR TITLE
feat: SimilarityMemory + summary() chain across stores and memories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: implement `SimilarityMemory` and add `summary()` to `BaseMemoryStore`, `JSONMemoryStore`, and `QdrantMemoryStore` (#550)
 - feat: implement QdrantMemoryStore (#548)
 - feat: add count() to store (#545)
 - feat: implement `RecencyMemory` in `memory/recency.py` (#543)

--- a/docs/api_reference/memory/recency.md
+++ b/docs/api_reference/memory/recency.md
@@ -1,0 +1,3 @@
+# RecencyMemory
+
+::: llm_agents_from_scratch.memory.recency

--- a/docs/api_reference/memory/similarity.md
+++ b/docs/api_reference/memory/similarity.md
@@ -1,0 +1,3 @@
+# SimilarityMemory
+
+::: llm_agents_from_scratch.memory.similarity

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,8 @@ nav:
     - Memory:
       - JSONMemoryStore: api_reference/memory/json_store.md
       - QdrantMemoryStore: api_reference/memory/qdrant_store.md
+      - RecencyMemory: api_reference/memory/recency.md
+      - SimilarityMemory: api_reference/memory/similarity.md
     - Skills:
       - Skill: api_reference/skills/skill.md
       - Discovery: api_reference/skills/discovery.md

--- a/more-examples/ch05/goodnews_mcp.ipynb
+++ b/more-examples/ch05/goodnews_mcp.ipynb
@@ -370,7 +370,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llm-agents-from-scratch",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/src/llm_agents_from_scratch/base/memory.py
+++ b/src/llm_agents_from_scratch/base/memory.py
@@ -114,3 +114,14 @@ class BaseMemoryStore(ABC):
         Returns:
             list[Episode]: Episodes ordered by relevance to the query.
         """
+
+    @abstractmethod
+    async def summary(self) -> str:
+        """Return a human-readable summary of the store contents.
+
+        Describes the substrate, episode count, and the oldest and newest
+        episodes. Intended for inspection and debugging.
+
+        Returns:
+            str: Multi-line summary of the store.
+        """

--- a/src/llm_agents_from_scratch/memory/__init__.py
+++ b/src/llm_agents_from_scratch/memory/__init__.py
@@ -3,5 +3,11 @@
 from .json_store import JSONMemoryStore
 from .qdrant_store import QdrantMemoryStore
 from .recency import RecencyMemory
+from .similarity import SimilarityMemory
 
-__all__ = ["JSONMemoryStore", "QdrantMemoryStore", "RecencyMemory"]
+__all__ = [
+    "JSONMemoryStore",
+    "QdrantMemoryStore",
+    "RecencyMemory",
+    "SimilarityMemory",
+]

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -86,6 +86,34 @@ class JSONMemoryStore(BaseMemoryStore):
         """
         return len(self._episodes)
 
+    async def summary(self) -> str:
+        """Return a human-readable summary of the store contents.
+
+        Includes the backing file path, total episode count, and the
+        instruction and timestamp of the newest and oldest episodes.
+
+        Returns:
+            str: Multi-line summary of the store.
+        """
+        total = len(self._episodes)
+        lines = [f"JSONMemoryStore: {total} episodes | path={self.path}"]
+        if total > 0:
+            by_time = sorted(
+                self._episodes,
+                key=lambda e: e.completed_at,
+            )
+            oldest = by_time[0]
+            newest = by_time[-1]
+            lines.append(
+                f"  newest: {str(newest.completed_at)[:19]}"
+                f" | {newest.task.instruction[:60]}",
+            )
+            lines.append(
+                f"  oldest: {str(oldest.completed_at)[:19]}"
+                f" | {oldest.task.instruction[:60]}",
+            )
+        return "\n".join(lines)
+
     async def search(
         self,
         query: str,

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -131,6 +131,34 @@ class QdrantMemoryStore(BaseMemoryStore):
         """
         return int(self._client.count(self._collection).count)
 
+    async def summary(self) -> str:
+        """Return a human-readable summary of the store contents.
+
+        Includes the collection name, total episode count, and the
+        instruction and timestamp of the newest and oldest episodes.
+
+        Returns:
+            str: Multi-line summary of the store.
+        """
+        total = await self.count()
+        lines = [
+            f"QdrantMemoryStore: {total} episodes"
+            f" | collection={self._collection}",
+        ]
+        if total > 0:
+            episodes = await self.read_recent(total)
+            newest = episodes[0]
+            oldest = episodes[-1]
+            lines.append(
+                f"  newest: {str(newest.completed_at)[:19]}"
+                f" | {newest.task.instruction[:60]}",
+            )
+            lines.append(
+                f"  oldest: {str(oldest.completed_at)[:19]}"
+                f" | {oldest.task.instruction[:60]}",
+            )
+        return "\n".join(lines)
+
     async def search(
         self,
         query: str,

--- a/src/llm_agents_from_scratch/memory/recency.py
+++ b/src/llm_agents_from_scratch/memory/recency.py
@@ -54,12 +54,13 @@ class RecencyMemory(BaseMemory):
         await self.store.write(episode)
 
     async def summary(self) -> str:
-        """Return a short summary of the memory store contents.
+        """Return a human-readable summary of the memory and its store.
+
+        Describes the recall strategy (last N), then delegates to the
+        store for substrate-level facts (count, oldest, newest).
 
         Returns:
-            str: Episode count and recall window size.
+            str: Multi-line summary of the memory and its store.
         """
-        total = await self.store.count()
-        return (
-            f"RecencyMemory: {total} episodes stored, recalling last {self.n}"
-        )
+        store_summary = await self.store.summary()
+        return f"RecencyMemory (recall last {self.n}):\n{store_summary}"

--- a/src/llm_agents_from_scratch/memory/similarity.py
+++ b/src/llm_agents_from_scratch/memory/similarity.py
@@ -1,0 +1,87 @@
+"""Similarity-based episodic memory."""
+
+from typing import Any
+
+from llm_agents_from_scratch.base.memory import BaseMemory, BaseMemoryStore
+from llm_agents_from_scratch.data_structures import Task
+from llm_agents_from_scratch.data_structures.memory import Episode
+
+
+class SimilarityMemory(BaseMemory):
+    """Similarity-based episodic memory.
+
+    Recalls the K most semantically similar past episodes using the
+    store's vector search. At write time, episodes are passed to the
+    store as-is; embedding is handled by the store.
+
+    Attributes:
+        store (BaseMemoryStore): The underlying vector memory store.
+        k (int): Number of most similar episodes to recall.
+        search_kwargs (dict[str, Any]): Extra keyword arguments forwarded
+            to ``store.search()`` on every recall (e.g. score thresholds
+            or payload filters for Qdrant).
+    """
+
+    def __init__(
+        self,
+        store: BaseMemoryStore,
+        k: int = 3,
+        search_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a SimilarityMemory.
+
+        Args:
+            store (BaseMemoryStore): A vector-backed memory store that
+                implements ``search()``.
+            k (int): Number of most similar episodes to include in
+                recall. Defaults to 3.
+            search_kwargs (dict[str, Any] | None): Optional keyword
+                arguments forwarded to ``store.search()`` on each
+                recall. Defaults to an empty dict.
+        """
+        self.store = store
+        self.k = k
+        self.search_kwargs = search_kwargs or {}
+
+    async def recall(self, task: Task) -> str:
+        """Retrieve the K most semantically similar past episodes.
+
+        Uses the task instruction as the search query.
+
+        Args:
+            task (Task): The incoming task whose instruction is used as
+                the similarity query.
+
+        Returns:
+            str: Newline-separated episode strings, or empty string if
+                no similar episodes are found.
+        """
+        episodes = await self.store.search(
+            query=task.instruction,
+            k=self.k,
+            **self.search_kwargs,
+        )
+        if not episodes:
+            return ""
+        return "\n".join(str(ep) for ep in episodes)
+
+    async def record(self, episode: Episode) -> None:
+        """Persist a completed episode to the store.
+
+        Args:
+            episode (Episode): The completed episode to store.
+        """
+        await self.store.write(episode)
+
+    async def summary(self) -> str:
+        """Return a human-readable summary of the memory and its store.
+
+        Describes the retrieval strategy (top-K similarity), then
+        delegates to the store for substrate-level facts (count,
+        oldest, newest).
+
+        Returns:
+            str: Multi-line summary of the memory and its store.
+        """
+        store_summary = await self.store.summary()
+        return f"SimilarityMemory (top-{self.k} similarity):\n{store_summary}"

--- a/tests/memory/test_base.py
+++ b/tests/memory/test_base.py
@@ -18,3 +18,4 @@ def test_base_memory_store_abstract_methods() -> None:
     assert "count" in abstract_methods
     assert "read_recent" in abstract_methods
     assert "search" in abstract_methods
+    assert "summary" in abstract_methods

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -127,3 +127,28 @@ async def test_search_raises_not_implemented(tmp_path: Path) -> None:
 
     with pytest.raises(NotImplementedError):
         await store.search("query", k=3)
+
+
+@pytest.mark.asyncio
+async def test_summary_empty(tmp_path: Path) -> None:
+    """Tests summary reports zero episodes when store is empty."""
+    store = JSONMemoryStore(dir=tmp_path)
+
+    summary = await store.summary()
+
+    assert "JSONMemoryStore" in summary
+    assert "0" in summary
+
+
+@pytest.mark.asyncio
+async def test_summary_includes_newest_and_oldest(tmp_path: Path) -> None:
+    """Tests summary includes newest and oldest episode instructions."""
+    store = JSONMemoryStore(dir=tmp_path)
+    await store.write(make_episode("oldest task"))
+    await store.write(make_episode("newest task"))
+
+    summary = await store.summary()
+
+    assert "2" in summary
+    assert "oldest task" in summary
+    assert "newest task" in summary

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -192,3 +192,31 @@ async def test_search_empty(mock_client: MagicMock) -> None:
     store = QdrantMemoryStore()
     results = await store.search("anything", k=5)
     assert results == []
+
+
+async def test_summary_empty(mock_client: MagicMock) -> None:
+    mock_client.count.return_value.count = 0
+    store = QdrantMemoryStore()
+    summary = await store.summary()
+    assert "QdrantMemoryStore" in summary
+    assert "0" in summary
+
+
+async def test_summary_with_episodes(
+    mock_client: MagicMock,
+    episode: Episode,
+) -> None:
+    ep_json = episode.model_dump_json()
+    ts = episode.completed_at.timestamp()
+    record = MagicMock()
+    record.payload = {"episode_json": ep_json, "completed_at": ts}
+
+    mock_client.count.return_value.count = 1
+    mock_client.scroll.return_value = ([record], None)
+
+    store = QdrantMemoryStore()
+    summary = await store.summary()
+
+    assert "QdrantMemoryStore" in summary
+    assert "1" in summary
+    assert episode.task.instruction[:20] in summary

--- a/tests/memory/test_recency.py
+++ b/tests/memory/test_recency.py
@@ -83,7 +83,7 @@ async def test_record_delegates_to_store(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_summary(tmp_path: Path) -> None:
-    """Tests summary returns episode count and recall window."""
+    """Tests summary includes recall window and delegates store facts."""
     store = JSONMemoryStore(dir=tmp_path)
     memory = RecencyMemory(store=store, n=5)
 
@@ -92,5 +92,7 @@ async def test_summary(tmp_path: Path) -> None:
 
     summary = await memory.summary()
 
-    assert "2" in summary
     assert "5" in summary
+    assert "RecencyMemory" in summary
+    assert "JSONMemoryStore" in summary
+    assert "2" in summary

--- a/tests/memory/test_similarity.py
+++ b/tests/memory/test_similarity.py
@@ -1,0 +1,124 @@
+"""Unit tests for SimilarityMemory."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llm_agents_from_scratch.base.memory import BaseMemoryStore
+from llm_agents_from_scratch.data_structures import Task, TaskResult
+from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory import SimilarityMemory
+
+
+def make_episode(
+    instruction: str = "do something",
+    content: str = "done",
+) -> Episode:
+    task = Task(instruction=instruction)
+    return Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content=content),
+    )
+
+
+def test_init_defaults() -> None:
+    """Tests SimilarityMemory initialises with k=3 and empty kwargs."""
+    store = MagicMock(spec=BaseMemoryStore)
+    memory = SimilarityMemory(store=store)
+
+    assert memory.store is store
+    assert memory.k == 3  # noqa: PLR2004
+    assert memory.search_kwargs == {}
+
+
+def test_init_custom_params() -> None:
+    """Tests SimilarityMemory accepts custom k and search_kwargs."""
+    store = MagicMock(spec=BaseMemoryStore)
+    memory = SimilarityMemory(
+        store=store,
+        k=5,
+        search_kwargs={"score_threshold": 0.8},
+    )
+
+    assert memory.k == 5  # noqa: PLR2004
+    assert memory.search_kwargs == {"score_threshold": 0.8}
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_formatted_episodes() -> None:
+    """Tests recall returns newline-joined episode strings."""
+    ep1 = make_episode("task one", "result one")
+    ep2 = make_episode("task two", "result two")
+
+    store = AsyncMock(spec=BaseMemoryStore)
+    store.search.return_value = [ep1, ep2]
+    memory = SimilarityMemory(store=store, k=2)
+
+    result = await memory.recall(Task(instruction="relevant query"))
+
+    store.search.assert_awaited_once_with(
+        query="relevant query",
+        k=2,
+    )
+    assert str(ep1) in result
+    assert str(ep2) in result
+
+
+@pytest.mark.asyncio
+async def test_recall_forwards_search_kwargs() -> None:
+    """Tests recall forwards search_kwargs to store.search."""
+    store = AsyncMock(spec=BaseMemoryStore)
+    store.search.return_value = []
+    memory = SimilarityMemory(
+        store=store,
+        k=3,
+        search_kwargs={"score_threshold": 0.9},
+    )
+
+    await memory.recall(Task(instruction="query"))
+
+    store.search.assert_awaited_once_with(
+        query="query",
+        k=3,
+        score_threshold=0.9,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_empty_string_when_no_episodes() -> None:
+    """Tests recall returns empty string when search finds nothing."""
+    store = AsyncMock(spec=BaseMemoryStore)
+    store.search.return_value = []
+    memory = SimilarityMemory(store=store)
+
+    result = await memory.recall(Task(instruction="query"))
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_record_delegates_to_store() -> None:
+    """Tests record writes the episode to the store."""
+    store = AsyncMock(spec=BaseMemoryStore)
+    memory = SimilarityMemory(store=store)
+    ep = make_episode()
+
+    await memory.record(ep)
+
+    store.write.assert_awaited_once_with(ep)
+
+
+@pytest.mark.asyncio
+async def test_summary_delegates_to_store() -> None:
+    """Tests summary includes k and delegates to store.summary."""
+    store = AsyncMock(spec=BaseMemoryStore)
+    store.summary.return_value = "store details"
+    memory = SimilarityMemory(store=store, k=4)
+
+    summary = await memory.summary()
+
+    store.summary.assert_awaited_once()
+    assert "4" in summary
+    assert "SimilarityMemory" in summary
+    assert "store details" in summary


### PR DESCRIPTION
## Summary

- Adds `summary()` abstract method to `BaseMemoryStore` — substrate-level facts (count, newest/oldest episode)
- Implements `JSONMemoryStore.summary()` and `QdrantMemoryStore.summary()`
- Adds `SimilarityMemory` with Google-style docstrings and delegating `summary()`
- Updates `RecencyMemory.summary()` to delegate to the store
- Exports `SimilarityMemory` from `memory/__init__.py`
- Adds `RecencyMemory` and `SimilarityMemory` pages to the API reference docs

## Test plan

- [ ] `pytest tests/memory/ -v` — 41 tests pass
- [ ] `make lint` — ruff + mypy clean
- [ ] `BaseMemoryStore.summary` in abstract methods assertion (`test_base.py`)
- [ ] New `test_similarity.py` covers init, recall, record, summary
- [ ] `JSONMemoryStore` and `QdrantMemoryStore` summary tests added

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)