### PR TITLE
chore: migrate QdrantMemoryStore off deprecated add and query methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- chore: migrate QdrantMemoryStore off deprecated add and query methods (#557)
 - refactor: `JSONMemoryStore` now takes `dir` + `filename` params instead of a single `path` (#547)
 
 ### Added

--- a/more-examples/ch07/similarity_memory.ipynb
+++ b/more-examples/ch07/similarity_memory.ipynb
@@ -131,12 +131,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import asyncio\n",
     "import json\n",
     "import logging\n",
     "import urllib.error\n",
     "import urllib.parse\n",
     "import urllib.request\n",
+    "\n",
+    "from tqdm.asyncio import tqdm\n",
     "\n",
     "from llm_agents_from_scratch import LLMAgent\n",
     "from llm_agents_from_scratch.data_structures import Task\n",
@@ -259,41 +260,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Thailand's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/nerdai/Projects/llm-agents-from-scratch/.venv/lib/python3.13/site-packages/qdrant_client/common/client_warnings.py:7: UserWarning: `query` method has been deprecated and will be removed in 1.17. Instead, inference can be done internally within regular methods like `query_points` by wrapping data into `models.Document` or `models.Image`.\n",
-      "  warnings.warn(message, category, stacklevel=stacklevel)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Thailand's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Thailand's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_country\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"Thailand\", \"region\": \"Asia\", \"subregion\": \"South-Eastern Asia\", \"capital\": \"Bangkok\", \"population\": 65859640, \"area_...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Thailand is located in South-Eastern Asia, with its capital city being Bangkok. The country has a population of approximately 65,859,64...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Thailand is located in South-Eastern Asia, with its capital city being Bangkok. The country has a population of approximately 65,859...[TRUNCATED]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/nerdai/Projects/llm-agents-from-scratch/.venv/lib/python3.13/site-packages/qdrant_client/common/client_warnings.py:7: UserWarning: `add` method has been deprecated and will be removed in 1.17. Instead, inference can be done internally within regular methods like `upsert` by wrapping data into `models.Document` or `models.Image`.\n",
-      "  warnings.warn(message, category, stacklevel=stacklevel)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Thailand is located in South-Eastern Asia, with its capital city being Bangkok. The country has a population of approximately 65,859...[TRUNCATED]\n",
       "Thailand is located in South-Eastern Asia, with its capital city being Bangkok. The country has a population of approximately 65,859,640 people and covers an area of 513,120 square kilometers. The official language of Thailand is Thai, and the currency used is the Thai baht.\n"
      ]
     }
@@ -318,6 +291,13 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Looking up countries: 100%|██████████████████████████████████████| 6/6 [01:56<00:00, 19.46s/it]\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -328,26 +308,36 @@
       "- **Subregion**: South-Eastern Asia  \n",
       "- **Capital**: Hanoi  \n",
       "- **Population**: 101,343,800  \n",
-      "- **Area**: 331,212 square kilometers  \n",
+      "- **Area (km²)**: 331,212.0  \n",
       "- **Languages**: Vietnamese  \n",
       "- **Currencies**: Vietnamese đồng  \n",
       "\n",
-      "Let me know if you need further details!\n",
+      "This covers the key geographic and demographic facts about Vietnam. Let me know if you need further details!\n",
       "\n",
       "**Indonesia**\n",
       "Indonesia is located in Asia, specifically in South-Eastern Asia, with its capital city being Jakarta. The country has a population of approximately 284,438,782 people and covers an area of 1,904,569 square kilometers. The official language of Indonesia is Indonesian, and the currency used is the Indonesian rupiah.\n",
       "\n",
       "**France**\n",
-      "France is located in Europe, specifically in Western Europe. The capital city of France is Paris. The country has a population of approximately 66,351,959 people and covers an area of 543,908 square kilometers. The official language of France is French, and the currency used is the euro.\n",
+      "France is located in Europe, specifically in Western Europe. Its capital city is Paris. The country has a population of approximately 66,351,959 people and covers an area of 543,908 square kilometers. The official language of France is French, and the currency used is the euro.\n",
       "\n",
       "**Germany**\n",
-      "Germany is located in Europe, specifically in Western Europe. Its capital city is Berlin. The country has a population of approximately 83,491,249 people and covers an area of 357,114 square kilometers. The official language of Germany is German, and the currency used is the euro.\n",
+      "The tool has provided the following information about Germany:\n",
+      "\n",
+      "- **Region**: Europe  \n",
+      "- **Subregion**: Western Europe  \n",
+      "- **Capital**: Berlin  \n",
+      "- **Population**: 83,491,249  \n",
+      "- **Area (km²)**: 357,114.0  \n",
+      "- **Languages**: German  \n",
+      "- **Currencies**: Euro  \n",
+      "\n",
+      "Let me know if you need further details!\n",
       "\n",
       "**Kenya**\n",
-      "Kenya is located in Africa, specifically in the subregion of Eastern Africa. The capital city of Kenya is Nairobi. The country has a population of approximately 53,330,978 people and covers an area of 580,367 square kilometers. The official languages of Kenya are English and Swahili, and the currency used is the Kenyan shilling.\n",
+      "Kenya is located in Africa, specifically in the subregion of Eastern Africa. Its capital city is Nairobi. The country has a population of approximately 53,330,978 people and covers an area of 580,367 square kilometers. The official languages of Kenya are English and Swahili, and the currency used is the Kenyan shilling.\n",
       "\n",
       "**Brazil**\n",
-      "Brazil is located in the Americas, specifically in South America. Its capital city is Brasília. The country has a population of approximately 213,421,037 people and covers an area of 8,515,767 square kilometers. The official language of Brazil is Portuguese, and the currency used is the Brazilian real.\n",
+      "Brazil is located in the Americas, specifically in South America, with its capital city being Brasília. The country has a population of approximately 213,421,037 people and covers an area of 8,515,767 square kilometers. The official language of Brazil is Portuguese, and the currency used is the Brazilian real.\n",
       "\n"
      ]
     }
@@ -366,7 +356,10 @@
     "    for c in countries\n",
     "]\n",
     "\n",
-    "results = await asyncio.gather(*[agent.run(t) for t in lookup_tasks])\n",
+    "results = await tqdm.gather(\n",
+    "    *[agent.run(t) for t in lookup_tasks],\n",
+    "    desc=\"Looking up countries\",\n",
+    ")\n",
     "\n",
     "for country, result in zip(countries, results, strict=False):\n",
     "    print(f\"**{country}**\\n{result}\\n\")"
@@ -394,8 +387,8 @@
      "text": [
       "SimilarityMemory (top-3 similarity):\n",
       "QdrantMemoryStore: 7 episodes | collection=episodes\n",
-      "  newest: 2026-05-18 17:32:39 | What are Indonesia's key geographic and demographic facts? U\n",
-      "  oldest: 2026-05-18 17:30:33 | What are Thailand's key geographic and demographic facts? Us\n"
+      "  newest: 2026-05-18 23:30:49 | What are France's key geographic and demographic facts? Use \n",
+      "  oldest: 2026-05-18 23:28:50 | What are Thailand's key geographic and demographic facts? Us\n"
      ]
     }
    ],
@@ -431,9 +424,9 @@
      "text": [
       "Most recent 3 episodes (RecencyMemory baseline for any query):\n",
       "\n",
-      "  - What are Indonesia's key geographic and demographic facts? Use th\n",
+      "  - What are France's key geographic and demographic facts? Use the g\n",
       "  - What are Kenya's key geographic and demographic facts? Use the ge\n",
-      "  - What are Brazil's key geographic and demographic facts? Use the g\n"
+      "  - What are Vietnam's key geographic and demographic facts? Use the \n"
      ]
     }
    ],
@@ -459,10 +452,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a1b2c3d4e5f60023",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episodes that will be recalled for this query:\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Vietnam's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.</task>\n",
+      "    <result>The tool has returned the following information about Vietnam:\n",
+      "\n",
+      "- **Region**: Asia  \n",
+      "- **Subregion**: South-Eastern Asia  \n",
+      "- **Capital**: Hanoi  \n",
+      "- **Population**: 101,343,800  \n",
+      "- **Area (km²)**: 331,212.0  \n",
+      "- **Languages**: Vietnamese  \n",
+      "- **Currencies**: Vietnamese đồng  \n",
+      "\n",
+      "This covers the key geographic and demographic facts about Vietnam. Let me know if you need further details!\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:30:40</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Germany's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.</task>\n",
+      "    <result>The tool has provided the following information about Germany:\n",
+      "\n",
+      "- **Region**: Europe  \n",
+      "- **Subregion**: Western Europe  \n",
+      "- **Capital**: Berlin  \n",
+      "- **Population**: 83,491,249  \n",
+      "- **Area (km²)**: 357,114.0  \n",
+      "- **Languages**: German  \n",
+      "- **Currencies**: Euro  \n",
+      "\n",
+      "Let me know if you need further details!\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:30:30</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Indonesia's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.</task>\n",
+      "    <result>Indonesia is located in Asia, specifically in South-Eastern Asia, with its capital city being Jakarta. The country has a population of approximately 284,438,782 people and covers an area of 1,904,569 square kilometers. The official language of Indonesia is Indonesian, and the currency used is the Indonesian rupiah.\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:30:35</completed_at>\n",
+      "  </episode>\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "task8 = Task(\n",
     "    instruction=(\n",
@@ -503,44 +546,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which of the countries you have researched are in Southeast Asia? Summarise their key facts and compare their populations. \n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which of the countries you have researched are in Southeast Asia? Summarise their key facts and compare their populations. \n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the research, Vietnam, Indonesia, and Thailand are all located in Southeast Asia. Here is a summary of their key facts and a compa...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which of the countries you have researched are in Southeast Asia? Summarise their key facts and compare their populations. Answer fro...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which of the countries you have researched are in Southeast Asia? Summarise their key facts and compare their populations. Answer ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the information gathered, the countries in Southeast Asia are Vietnam and Indonesia. Here are their key facts and a comparison of ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the research, Vietnam, Indonesia, and Thailand are all located in Southeast Asia. Here is a summary of their key facts and a co...[TRUNCATED]\n",
-      "From the research, Vietnam, Indonesia, and Thailand are all located in Southeast Asia. Here is a summary of their key facts and a comparison of their populations:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the information gathered, the countries in Southeast Asia are Vietnam and Indonesia. Here are their key facts and a comparison ...[TRUNCATED]\n",
+      "From the information gathered, the countries in Southeast Asia are Vietnam and Indonesia. Here are their key facts and a comparison of their populations:\n",
       "\n",
-      "### Vietnam\n",
+      "### Vietnam:\n",
       "- **Region**: Asia  \n",
       "- **Subregion**: South-Eastern Asia  \n",
       "- **Capital**: Hanoi  \n",
       "- **Population**: 101,343,800  \n",
-      "- **Area**: 331,212 square kilometers  \n",
+      "- **Area (km²)**: 331,212.0  \n",
       "- **Languages**: Vietnamese  \n",
       "- **Currencies**: Vietnamese đồng  \n",
       "\n",
-      "### Indonesia\n",
+      "### Indonesia:\n",
       "- **Region**: Asia  \n",
       "- **Subregion**: South-Eastern Asia  \n",
       "- **Capital**: Jakarta  \n",
       "- **Population**: 284,438,782  \n",
-      "- **Area**: 1,904,569 square kilometers  \n",
+      "- **Area (km²)**: 1,904,569.0  \n",
       "- **Languages**: Indonesian  \n",
       "- **Currencies**: Indonesian rupiah  \n",
       "\n",
-      "### Thailand\n",
-      "- **Region**: Asia  \n",
-      "- **Subregion**: South-Eastern Asia  \n",
-      "- **Capital**: Bangkok  \n",
-      "- **Population**: 65,859,640  \n",
-      "- **Area**: 513,120 square kilometers  \n",
-      "- **Languages**: Thai  \n",
-      "- **Currencies**: Thai baht  \n",
-      "\n",
-      "### Population Comparison:\n",
-      "- **Indonesia** has the largest population among the three, with approximately **284.4 million** people.\n",
-      "- **Vietnam** has the second-largest population, with approximately **101.3 million** people.\n",
-      "- **Thailand** has the smallest population among the three, with approximately **65.9 million** people.\n"
+      "### Comparison of Populations:\n",
+      "- Indonesia has a significantly larger population than Vietnam. Indonesia's population is approximately **284.4 million**, while Vietnam's population is about **101.3 million**. This means Indonesia's population is more than **2.8 times** that of Vietnam.\n"
      ]
     }
    ],
@@ -565,10 +597,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "a1b2c3d4e5f60027",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episodes that will be recalled for this query:\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are Germany's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.</task>\n",
+      "    <result>The tool has provided the following information about Germany:\n",
+      "\n",
+      "- **Region**: Europe  \n",
+      "- **Subregion**: Western Europe  \n",
+      "- **Capital**: Berlin  \n",
+      "- **Population**: 83,491,249  \n",
+      "- **Area (km²)**: 357,114.0  \n",
+      "- **Languages**: German  \n",
+      "- **Currencies**: Euro  \n",
+      "\n",
+      "Let me know if you need further details!\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:30:30</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>Which of the countries you have researched are in Southeast Asia? Summarise their key facts and compare their populations. Answer from the country information you have already gathered. No tools are needed.</task>\n",
+      "    <result>From the information gathered, the countries in Southeast Asia are Vietnam and Indonesia. Here are their key facts and a comparison of their populations:\n",
+      "\n",
+      "### Vietnam:\n",
+      "- **Region**: Asia  \n",
+      "- **Subregion**: South-Eastern Asia  \n",
+      "- **Capital**: Hanoi  \n",
+      "- **Population**: 101,343,800  \n",
+      "- **Area (km²)**: 331,212.0  \n",
+      "- **Languages**: Vietnamese  \n",
+      "- **Currencies**: Vietnamese đồng  \n",
+      "\n",
+      "### Indonesia:\n",
+      "- **Region**: Asia  \n",
+      "- **Subregion**: South-Eastern Asia  \n",
+      "- **Capital**: Jakarta  \n",
+      "- **Population**: 284,438,782  \n",
+      "- **Area (km²)**: 1,904,569.0  \n",
+      "- **Languages**: Indonesian  \n",
+      "- **Currencies**: Indonesian rupiah  \n",
+      "\n",
+      "### Comparison of Populations:\n",
+      "- Indonesia has a significantly larger population than Vietnam. Indonesia's population is approximately **284.4 million**, while Vietnam's population is about **101.3 million**. This means Indonesia's population is more than **2.8 times** that of Vietnam.\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:39:39</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>What are France's key geographic and demographic facts? Use the get_country tool. Do not rely on prior knowledge.</task>\n",
+      "    <result>France is located in Europe, specifically in Western Europe. Its capital city is Paris. The country has a population of approximately 66,351,959 people and covers an area of 543,908 square kilometers. The official language of France is French, and the currency used is the euro.\n",
+      "    </result>\n",
+      "    <completed_at>2026-05-18 23:30:49</completed_at>\n",
+      "  </episode>\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "task9 = Task(\n",
     "    instruction=(\n",
@@ -607,39 +700,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which of the countries you have researched are in Western Europe? How do they compare in population and area? You do not need to call...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which of the countries you have researched are in Western Europe? How do they compare in population and area? You do not need to c...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the research, Germany and France are located in Western Europe. Here is a comparison of their populations and areas:\n",
-      "\n",
-      "### Germany\n",
-      "...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which of the countries you have researched are in Western Europe? How do they compare in population and area? Answer from the country...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which of the countries you have researched are in Western Europe? How do they compare in population and area? Answer from the coun...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the information gathered, the countries in Western Europe are Germany and France. Here are their key facts and a comparison of the...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the research, Germany and France are located in Western Europe. Here is a comparison of their populations and areas:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the information gathered, the countries in Western Europe are Germany and France. Here are their key facts and a comparison of ...[TRUNCATED]\n",
+      "From the information gathered, the countries in Western Europe are Germany and France. Here are their key facts and a comparison of their populations and areas:\n",
       "\n",
-      "### Germa...[TRUNCATED]\n",
-      "From the research, Germany and France are located in Western Europe. Here is a comparison of their populations and areas:\n",
-      "\n",
-      "### Germany\n",
+      "### Germany:\n",
       "- **Region**: Europe  \n",
       "- **Subregion**: Western Europe  \n",
       "- **Capital**: Berlin  \n",
       "- **Population**: 83,491,249  \n",
-      "- **Area**: 357,114 square kilometers  \n",
-      "- **Language**: German  \n",
-      "- **Currency**: Euro  \n",
+      "- **Area (km²)**: 357,114.0  \n",
+      "- **Languages**: German  \n",
+      "- **Currencies**: Euro  \n",
       "\n",
-      "### France\n",
+      "### France:\n",
       "- **Region**: Europe  \n",
       "- **Subregion**: Western Europe  \n",
       "- **Capital**: Paris  \n",
       "- **Population**: 66,351,959  \n",
-      "- **Area**: 543,908 square kilometers  \n",
-      "- **Language**: French  \n",
-      "- **Currency**: Euro  \n",
+      "- **Area (km²)**: 543,908.0  \n",
+      "- **Languages**: French  \n",
+      "- **Currencies**: Euro  \n",
       "\n",
       "### Comparison:\n",
-      "- **Population**: Germany has a larger population than France (83,491,249 vs. 66,351,959).\n",
-      "- **Area**: France has a larger area than Germany (543,908 square kilometers vs. 357,114 square kilometers).\n"
+      "- **Population**: Germany has a larger population than France. Germany's population is approximately **83.5 million**, while France's population is about **66.4 million**. This means Germany's population is about **1.26 times** that of France.\n",
+      "- **Area**: France has a larger area than Germany. France covers **543,908 km²**, while Germany covers **357,114 km²**. This means France's area is about **1.52 times** that of Germany.\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ notebook-utils = [
   "pandas>=2.3.3"
 ]
 notebooks = [
-  "ipython>=8.37.0"
+  "ipython>=8.37.0",
+  "tqdm>=4.0.0"
 ]
 openai = [
   "openai>=2.9.0"

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from qdrant_client import QdrantClient
+from qdrant_client import QdrantClient, models
 
 from llm_agents_from_scratch.base.memory import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import Episode
@@ -75,16 +75,23 @@ class QdrantMemoryStore(BaseMemoryStore):
         # Embed only semantic content — XML tags and timestamps from
         # Episode.__str__ add noise and let recency bleed into relevance.
         text = f"{episode.task.instruction}\n{episode.result.content}"
-        self._client.add(
+        self._client.upsert(
             collection_name=self._collection,
-            documents=[text],
-            metadata=[
-                {
-                    "episode_json": episode.model_dump_json(),
-                    "completed_at": episode.completed_at.timestamp(),
-                },
+            points=[
+                models.PointStruct(
+                    id=episode.task.id_,
+                    vector={
+                        self._client.get_vector_field_name(): models.Document(
+                            text=text,
+                            model=self._client.embedding_model_name,
+                        ),
+                    },
+                    payload={
+                        "episode_json": episode.model_dump_json(),
+                        "completed_at": episode.completed_at.timestamp(),
+                    },
+                ),
             ],
-            ids=[episode.task.id_],
         )
 
     async def read_recent(self, n: int) -> list[Episode]:
@@ -174,21 +181,26 @@ class QdrantMemoryStore(BaseMemoryStore):
             query (str): The search query (e.g. the task instruction).
             k (int): Maximum number of episodes to return.
             **kwargs: Additional keyword arguments forwarded to
-                ``QdrantClient.query()`` (e.g. ``query_filter``,
+                ``QdrantClient.query_points()`` (e.g. ``query_filter``,
                 ``score_threshold``).
 
         Returns:
             list[Episode]: Episodes ordered by cosine similarity to the
                 query.
         """
-        results = self._client.query(
+        results = self._client.query_points(
             collection_name=self._collection,
-            query_text=query,
+            query=models.Document(
+                text=query,
+                model=self._client.embedding_model_name,
+            ),
+            using=self._client.get_vector_field_name(),
             limit=k,
+            with_payload=True,
             **kwargs,
-        )
+        ).points
         return [
-            Episode.model_validate_json(r.metadata["episode_json"])
+            Episode.model_validate_json(r.payload["episode_json"])
             for r in results
-            if r.metadata and "episode_json" in r.metadata
+            if r.payload and "episode_json" in r.payload
         ]

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -25,6 +25,8 @@ def mock_client():
         "llm_agents_from_scratch.memory.qdrant_store.QdrantClient",
     ) as mock_cls:
         instance = MagicMock()
+        instance.embedding_model_name = "BAAI/bge-small-en-v1.5"
+        instance.get_vector_field_name.return_value = "fast-bge-small-en-v1.5"
         mock_cls.return_value = instance
         yield instance
 
@@ -64,14 +66,17 @@ async def test_write(mock_client: MagicMock, episode: Episode) -> None:
     store = QdrantMemoryStore()
     await store.write(episode)
 
-    mock_client.add.assert_called_once()
-    kw = mock_client.add.call_args.kwargs
+    mock_client.upsert.assert_called_once()
+    kw = mock_client.upsert.call_args.kwargs
     assert kw["collection_name"] == "episodes"
-    assert episode.task.instruction in kw["documents"][0]
-    assert episode.result.content in kw["documents"][0]
-    assert kw["ids"] == [episode.task.id_]
-    assert "episode_json" in kw["metadata"][0]
-    assert "completed_at" in kw["metadata"][0]
+    point = kw["points"][0]
+    assert point.id == episode.task.id_
+    assert (
+        episode.task.instruction in point.vector["fast-bge-small-en-v1.5"].text
+    )
+    assert episode.result.content in point.vector["fast-bge-small-en-v1.5"].text
+    assert "episode_json" in point.payload
+    assert "completed_at" in point.payload
 
 
 async def test_count(mock_client: MagicMock) -> None:
@@ -171,24 +176,26 @@ async def test_read_recent_respects_n_limit(mock_client: MagicMock) -> None:
 
 
 async def test_search(mock_client: MagicMock, episode: Episode) -> None:
-    mock_result = MagicMock()
-    mock_result.metadata = {"episode_json": episode.model_dump_json()}
-    mock_client.query.return_value = [mock_result]
+    mock_point = MagicMock()
+    mock_point.payload = {"episode_json": episode.model_dump_json()}
+    mock_client.query_points.return_value.points = [mock_point]
 
     store = QdrantMemoryStore()
-    results = await store.search("electric type pokemon", k=3)
+    k = 3
+    results = await store.search("electric type pokemon", k=k)
 
-    mock_client.query.assert_called_once_with(
-        collection_name="episodes",
-        query_text="electric type pokemon",
-        limit=3,
-    )
+    mock_client.query_points.assert_called_once()
+    kw = mock_client.query_points.call_args.kwargs
+    assert kw["collection_name"] == "episodes"
+    assert kw["query"].text == "electric type pokemon"
+    assert kw["using"] == "fast-bge-small-en-v1.5"
+    assert kw["limit"] == k
     assert len(results) == 1
     assert results[0].task.instruction == episode.task.instruction
 
 
 async def test_search_empty(mock_client: MagicMock) -> None:
-    mock_client.query.return_value = []
+    mock_client.query_points.return_value.points = []
     store = QdrantMemoryStore()
     results = await store.search("anything", k=5)
     assert results == []

--- a/uv.lock
+++ b/uv.lock
@@ -1474,6 +1474,7 @@ notebook-utils = [
 notebooks = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tqdm" },
 ]
 openai = [
     { name = "openai" },
@@ -1513,6 +1514,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "qdrant-client", extras = ["fastembed"], specifier = ">=1.14.0" },
+    { name = "tqdm", marker = "extra == 'notebooks'", specifier = ">=4.0.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]
 provides-extras = ["notebook-utils", "notebooks", "openai"]


### PR DESCRIPTION
## Summary

- Replace deprecated `client.add()` with `client.upsert()` using `models.PointStruct` and `models.Document`
- Replace deprecated `client.query()` with `client.query_points()` using `models.Document`; access results via `.payload` (ScoredPoint) instead of `.metadata` (QueryResponse)
- Update tests to mock `embedding_model_name` and `get_vector_field_name` on the client fixture

Closes #553

## Test plan

- [ ] All 14 `tests/memory/test_qdrant_store.py` tests pass
- [ ] No deprecation warnings when running `more-examples/ch07/similarity_memory.ipynb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)