### PR TITLE
refactor: add episode_to_qdrant_point_struct() converter in qdrant_utils.py

### DIFF
--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -6,6 +6,9 @@ from qdrant_client import QdrantClient, models
 
 from llm_agents_from_scratch.base.memory import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory.qdrant_utils import (
+    episode_to_qdrant_point_struct,
+)
 
 
 class QdrantMemoryStore(BaseMemoryStore):
@@ -72,24 +75,13 @@ class QdrantMemoryStore(BaseMemoryStore):
         Args:
             episode (Episode): The completed episode to store.
         """
-        # Embed only semantic content — XML tags and timestamps from
-        # Episode.__str__ add noise and let recency bleed into relevance.
-        text = f"{episode.task.instruction}\n{episode.result.content}"
         self._client.upsert(
             collection_name=self._collection,
             points=[
-                models.PointStruct(
-                    id=episode.task.id_,
-                    vector={
-                        self._client.get_vector_field_name(): models.Document(
-                            text=text,
-                            model=self._client.embedding_model_name,
-                        ),
-                    },
-                    payload={
-                        "episode_json": episode.model_dump_json(),
-                        "completed_at": episode.completed_at.timestamp(),
-                    },
+                episode_to_qdrant_point_struct(
+                    episode,
+                    vector_field=self._client.get_vector_field_name(),
+                    model_name=self._client.embedding_model_name,
                 ),
             ],
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -1,0 +1,41 @@
+"""Qdrant data-conversion utilities for episodic memory."""
+
+from qdrant_client import models
+
+from llm_agents_from_scratch.data_structures.memory import Episode
+
+
+def episode_to_qdrant_point_struct(
+    episode: Episode,
+    vector_field: str,
+    model_name: str,
+) -> models.PointStruct:
+    """Convert an episode to a Qdrant PointStruct ready for upsert.
+
+    The embedded text is the episode's task instruction followed by the
+    result content, separated by a newline. XML tags and timestamps from
+    ``Episode.__str__`` are intentionally excluded — they add noise and
+    allow recency to bleed into relevance scores.
+
+    Args:
+        episode (Episode): The completed episode to convert.
+        vector_field (str): Name of the vector field in the Qdrant
+            collection (e.g. ``"fast-bge-small-en-v1.5"``).
+        model_name (str): FastEmbed model identifier used for embedding
+            (e.g. ``"BAAI/bge-small-en-v1.5"``).
+
+    Returns:
+        models.PointStruct: A point ready to pass to
+            ``QdrantClient.upsert()``.
+    """
+    text = f"{episode.task.instruction}\n{episode.result.content}"
+    return models.PointStruct(
+        id=episode.task.id_,
+        vector={
+            vector_field: models.Document(text=text, model=model_name),
+        },
+        payload={
+            "episode_json": episode.model_dump_json(),
+            "completed_at": episode.completed_at.timestamp(),
+        },
+    )

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -1,0 +1,93 @@
+from llm_agents_from_scratch.data_structures import Task, TaskResult
+from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory.qdrant_utils import (
+    episode_to_qdrant_point_struct,
+)
+
+
+def _make_episode(instruction: str = "look up pikachu") -> Episode:
+    task = Task(instruction=instruction)
+    return Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+    )
+
+
+def test_id_matches_task_id() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    assert point.id == episode.task.id_
+
+
+def test_vector_field_name() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    assert "fast-bge-small-en-v1.5" in point.vector
+
+
+def test_document_model_name() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    doc = point.vector["fast-bge-small-en-v1.5"]
+    assert doc.model == "BAAI/bge-small-en-v1.5"
+
+
+def test_embedded_text_contains_instruction_and_result() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    doc = point.vector["fast-bge-small-en-v1.5"]
+    assert episode.task.instruction in doc.text
+    assert episode.result.content in doc.text
+
+
+def test_payload_contains_episode_json() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    assert "episode_json" in point.payload
+    assert "completed_at" in point.payload
+
+
+def test_payload_episode_json_roundtrips() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    restored = Episode.model_validate_json(point.payload["episode_json"])
+    assert restored.task.instruction == episode.task.instruction
+    assert restored.result.content == episode.result.content
+
+
+def test_custom_vector_field_and_model() -> None:
+    episode = _make_episode()
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="my-custom-field",
+        model_name="sentence-transformers/all-MiniLM-L6-v2",
+    )
+    assert "my-custom-field" in point.vector
+    assert point.vector["my-custom-field"].model == (
+        "sentence-transformers/all-MiniLM-L6-v2"
+    )


### PR DESCRIPTION
## Summary

- Add `memory/qdrant_utils.py` with `episode_to_qdrant_point_struct(episode, vector_field, model_name)` — mirrors the data-converter pattern in `llms/ollama/utils.py`
- `QdrantMemoryStore.write()` delegates `PointStruct` construction to the converter, removing Qdrant-specific data-structure concerns from the store class
- 7 unit tests covering id, vector field name, model name, embedded text content, payload shape, JSON roundtrip, and custom params

Closes #558

## Test plan

- [ ] `pytest tests/memory/test_qdrant_utils.py` — 7 new converter tests pass
- [ ] `pytest tests/memory/test_qdrant_store.py` — all 14 store tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)