### PR TITLE
feat: implement ReflectiveMemory in memory/reflective.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: implement ReflectiveMemory in memory/reflective.py (#561)
 - feat: implement `ReflectiveMemory` in `memory/reflective.py` (#527)
 - feat: add `Episode.additional_data` field and `Episode.format(mode, include)` with `EpisodeAttr` Literal type (#562)
 - feat: add `tqdm` to `notebooks` optional extra for async progress bars (#559)

--- a/src/llm_agents_from_scratch/memory/__init__.py
+++ b/src/llm_agents_from_scratch/memory/__init__.py
@@ -3,11 +3,13 @@
 from .json_store import JSONMemoryStore
 from .qdrant_store import QdrantMemoryStore
 from .recency import RecencyMemory
+from .reflective import ReflectiveMemory
 from .similarity import SimilarityMemory
 
 __all__ = [
     "JSONMemoryStore",
     "QdrantMemoryStore",
     "RecencyMemory",
+    "ReflectiveMemory",
     "SimilarityMemory",
 ]

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -75,6 +75,7 @@ class ReflectiveMemory(RecencyMemory):
             result=episode.result.content,
         )
         result = await self.llm.complete(prompt)
+        # safe to mutate — TaskHandler does not use episode after record()
         episode.additional_data = {"reflection": result.response}
         await self.store.write(episode)
 

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -75,9 +75,7 @@ class ReflectiveMemory(RecencyMemory):
             result=episode.result.content,
         )
         result = await self.llm.complete(prompt)
-        episode = episode.model_copy(
-            update={"additional_data": {"reflection": result.response}},
-        )
+        episode.additional_data = {"reflection": result.response}
         await self.store.write(episode)
 
     async def summary(self) -> str:

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -1,0 +1,81 @@
+"""Reflective episodic memory (Reflexion pattern)."""
+
+from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.base.memory import BaseMemoryStore
+from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory.recency import RecencyMemory
+
+_REFLECTION_PROMPT = """\
+You just completed the following task.
+
+Task: {instruction}
+Result: {result}
+
+In one sentence, what is the key lesson or actionable insight from this \
+experience that would help with similar tasks in the future?\
+"""
+
+
+class ReflectiveMemory(RecencyMemory):
+    """Reflexion-style episodic memory with write-time reflection.
+
+    Extends RecencyMemory with an LLM call at write time that distils a
+    short lesson from each completed episode. The lesson is stored on
+    the episode under ``additional_data["reflection"]`` and surfaced
+    automatically in recall via ``Episode.format()``.
+
+    Attributes:
+        store (BaseMemoryStore): The underlying memory store.
+        llm (BaseLLM): The LLM used to generate reflections at write
+            time.
+        n (int): Number of most recent episodes to recall.
+    """
+
+    def __init__(
+        self,
+        store: BaseMemoryStore,
+        llm: BaseLLM,
+        n: int = 3,
+    ) -> None:
+        """Initialize a ReflectiveMemory.
+
+        Args:
+            store (BaseMemoryStore): The memory store to read from and
+                write to.
+            llm (BaseLLM): The LLM used to generate a reflection after
+                each episode completes.
+            n (int): Number of most recent episodes to include in
+                recall. Defaults to 3.
+        """
+        super().__init__(store=store, n=n)
+        self.llm = llm
+
+    async def record(self, episode: Episode) -> None:
+        """Generate a reflection and persist the enriched episode.
+
+        Calls the LLM to distil a one-sentence lesson from the episode,
+        attaches it under ``additional_data["reflection"]``, then
+        delegates to the store.
+
+        Args:
+            episode (Episode): The completed episode to reflect on and
+                store.
+        """
+        prompt = _REFLECTION_PROMPT.format(
+            instruction=episode.task.instruction,
+            result=episode.result.content,
+        )
+        result = await self.llm.complete(prompt)
+        episode = episode.model_copy(
+            update={"additional_data": {"reflection": result.response}},
+        )
+        await self.store.write(episode)
+
+    async def summary(self) -> str:
+        """Return a human-readable summary of the memory and its store.
+
+        Returns:
+            str: Multi-line summary of the memory and its store.
+        """
+        store_summary = await self.store.summary()
+        return f"ReflectiveMemory (recall last {self.n}):\n{store_summary}"

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -19,6 +19,7 @@ experience that would help with similar tasks in the future?\
 class ReflectiveMemory(RecencyMemory):
     """Reflexion-style episodic memory with write-time reflection.
 
+    Implements the Reflexion pattern (https://arxiv.org/abs/2303.11366).
     Extends RecencyMemory with an LLM call at write time that distils a
     short lesson from each completed episode. The lesson is stored on
     the episode under ``additional_data["reflection"]`` and surfaced

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -30,6 +30,8 @@ class ReflectiveMemory(RecencyMemory):
         llm (BaseLLM): The LLM used to generate reflections at write
             time.
         n (int): Number of most recent episodes to recall.
+        reflection_template (str): Template used to build the
+            reflection prompt.
     """
 
     def __init__(
@@ -37,6 +39,7 @@ class ReflectiveMemory(RecencyMemory):
         store: BaseMemoryStore,
         llm: BaseLLM,
         n: int = 3,
+        reflection_template: str = REFLECTION_TEMPLATE,
     ) -> None:
         """Initialize a ReflectiveMemory.
 
@@ -47,9 +50,14 @@ class ReflectiveMemory(RecencyMemory):
                 each episode completes.
             n (int): Number of most recent episodes to include in
                 recall. Defaults to 3.
+            reflection_template (str): Template string for the
+                reflection prompt. Must contain ``{instruction}`` and
+                ``{result}`` placeholders. Defaults to
+                ``REFLECTION_TEMPLATE``.
         """
         super().__init__(store=store, n=n)
         self.llm = llm
+        self.reflection_template = reflection_template
 
     async def record(self, episode: Episode) -> None:
         """Generate a reflection and persist the enriched episode.
@@ -62,7 +70,7 @@ class ReflectiveMemory(RecencyMemory):
             episode (Episode): The completed episode to reflect on and
                 store.
         """
-        prompt = REFLECTION_TEMPLATE.format(
+        prompt = self.reflection_template.format(
             instruction=episode.task.instruction,
             result=episode.result.content,
         )

--- a/src/llm_agents_from_scratch/memory/reflective.py
+++ b/src/llm_agents_from_scratch/memory/reflective.py
@@ -5,7 +5,7 @@ from llm_agents_from_scratch.base.memory import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import Episode
 from llm_agents_from_scratch.memory.recency import RecencyMemory
 
-_REFLECTION_PROMPT = """\
+REFLECTION_TEMPLATE = """\
 You just completed the following task.
 
 Task: {instruction}
@@ -62,7 +62,7 @@ class ReflectiveMemory(RecencyMemory):
             episode (Episode): The completed episode to reflect on and
                 store.
         """
-        prompt = _REFLECTION_PROMPT.format(
+        prompt = REFLECTION_TEMPLATE.format(
             instruction=episode.task.instruction,
             result=episode.result.content,
         )

--- a/tests/memory/test_reflective.py
+++ b/tests/memory/test_reflective.py
@@ -1,0 +1,154 @@
+"""Unit tests for ReflectiveMemory."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.base.memory import BaseMemoryStore
+from llm_agents_from_scratch.data_structures import Task, TaskResult
+from llm_agents_from_scratch.data_structures.llm import CompleteResult
+from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.memory import ReflectiveMemory
+
+
+def make_episode(
+    instruction: str = "look up pikachu",
+    content: str = "pikachu is electric",
+) -> Episode:
+    task = Task(instruction=instruction)
+    return Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content=content),
+    )
+
+
+def make_llm(reflection: str = "Always verify the name first.") -> BaseLLM:
+    llm = MagicMock(spec=BaseLLM)
+    llm.complete = AsyncMock(
+        return_value=CompleteResult(response=reflection, prompt=""),
+    )
+    return llm
+
+
+def test_init_defaults() -> None:
+    store = MagicMock(spec=BaseMemoryStore)
+    llm = make_llm()
+    memory = ReflectiveMemory(store=store, llm=llm)
+
+    assert memory.store is store
+    assert memory.llm is llm
+    assert memory.n == 3  # noqa: PLR2004
+
+
+def test_init_custom_n() -> None:
+    store = MagicMock(spec=BaseMemoryStore)
+    llm = make_llm()
+    memory = ReflectiveMemory(store=store, llm=llm, n=5)
+
+    assert memory.n == 5  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_record_calls_llm_complete() -> None:
+    store = AsyncMock(spec=BaseMemoryStore)
+    llm = make_llm()
+    memory = ReflectiveMemory(store=store, llm=llm)
+    ep = make_episode()
+
+    await memory.record(ep)
+
+    llm.complete.assert_awaited_once()
+    prompt_arg = llm.complete.call_args[0][0]
+    assert ep.task.instruction in prompt_arg
+    assert ep.result.content in prompt_arg
+
+
+@pytest.mark.asyncio
+async def test_record_stores_episode_with_reflection() -> None:
+    store = AsyncMock(spec=BaseMemoryStore)
+    reflection = "Always verify the name first."
+    llm = make_llm(reflection)
+    memory = ReflectiveMemory(store=store, llm=llm)
+    ep = make_episode()
+
+    await memory.record(ep)
+
+    store.write.assert_awaited_once()
+    written: Episode = store.write.call_args[0][0]
+    assert written.additional_data is not None
+    assert written.additional_data["reflection"] == reflection
+
+
+@pytest.mark.asyncio
+async def test_summary() -> None:
+    store = AsyncMock(spec=BaseMemoryStore)
+    store.summary = AsyncMock(return_value="JSONMemoryStore: 2 episodes")
+    llm = make_llm()
+    memory = ReflectiveMemory(store=store, llm=llm, n=4)
+
+    result = await memory.summary()
+
+    assert "ReflectiveMemory" in result
+    assert "4" in result
+    assert "JSONMemoryStore" in result
+
+
+def test_episode_str_renders_additional_data_as_xml_tags() -> None:
+    task = Task(instruction="look up pikachu")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+        additional_data={"reflection": "Always verify spelling."},
+    )
+
+    output = str(ep)
+
+    assert "<reflection>Always verify spelling.</reflection>" in output
+
+
+def test_episode_str_no_extra_tags_when_additional_data_none() -> None:
+    task = Task(instruction="look up pikachu")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+    )
+
+    output = str(ep)
+
+    assert "<reflection>" not in output
+    assert "additional_data" not in output
+
+
+def test_episode_format_concat_includes_additional_data() -> None:
+    task = Task(instruction="look up pikachu")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+        additional_data={"reflection": "Always verify spelling."},
+    )
+
+    text = ep.format(mode="concat")
+
+    assert "look up pikachu" in text
+    assert "pikachu is electric" in text
+    assert "Always verify spelling." in text
+
+
+def test_episode_format_concat_excludes_completed_at_by_default() -> None:
+    task = Task(instruction="look up pikachu")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+    )
+
+    text = ep.format(mode="concat")
+
+    assert "completed_at" not in text
+    ts = ep.completed_at.strftime("%Y-%m-%d")
+    assert ts not in text

--- a/tests/memory/test_reflective.py
+++ b/tests/memory/test_reflective.py
@@ -50,6 +50,40 @@ def test_init_custom_n() -> None:
     assert memory.n == 5  # noqa: PLR2004
 
 
+def test_init_custom_reflection_template() -> None:
+    store = MagicMock(spec=BaseMemoryStore)
+    llm = make_llm()
+    template = "Task: {instruction}\nResult: {result}\nLesson:"
+    memory = ReflectiveMemory(
+        store=store,
+        llm=llm,
+        reflection_template=template,
+    )
+
+    assert memory.reflection_template == template
+
+
+@pytest.mark.asyncio
+async def test_record_uses_custom_reflection_template() -> None:
+    store = AsyncMock(spec=BaseMemoryStore)
+    llm = make_llm()
+    template = "Custom: {instruction} / {result}"
+    memory = ReflectiveMemory(
+        store=store,
+        llm=llm,
+        reflection_template=template,
+    )
+    ep = make_episode()
+
+    await memory.record(ep)
+
+    prompt_arg = llm.complete.call_args[0][0]
+    assert prompt_arg == template.format(
+        instruction=ep.task.instruction,
+        result=ep.result.content,
+    )
+
+
 @pytest.mark.asyncio
 async def test_record_calls_llm_complete() -> None:
     store = AsyncMock(spec=BaseMemoryStore)

--- a/tests/memory/test_reflective.py
+++ b/tests/memory/test_reflective.py
@@ -139,7 +139,7 @@ def test_episode_format_concat_includes_additional_data() -> None:
     assert "Always verify spelling." in text
 
 
-def test_episode_format_concat_excludes_completed_at_by_default() -> None:
+def test_episode_format_concat_default_includes_completed_at() -> None:
     task = Task(instruction="look up pikachu")
     ep = Episode(
         task=task,
@@ -149,6 +149,5 @@ def test_episode_format_concat_excludes_completed_at_by_default() -> None:
 
     text = ep.format(mode="concat")
 
-    assert "completed_at" not in text
-    ts = ep.completed_at.strftime("%Y-%m-%d")
-    assert ts not in text
+    ts = ep.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+    assert ts in text


### PR DESCRIPTION
## Summary

- Implement `ReflectiveMemory(RecencyMemory)` — calls `llm.complete()` at write time to distil a one-sentence lesson from each completed episode
- Lesson is stored under `additional_data["reflection"]` on the episode before writing to the store
- `recall()` surfaces reflections automatically via `Episode.__str__()` (XML mode), which includes `additional_data` keys as XML tags

Depends on #562.

## Test plan

- [ ] `tests/memory/test_reflective.py` — init defaults/custom n, LLM called with instruction+result in prompt, store receives episode with `additional_data["reflection"]` set, summary format
- [ ] `tests/memory/test_reflective.py` — `Episode.__str__` renders `additional_data` keys as XML tags; no extra tags when `None`; `format(mode="concat")` includes values
- [ ] `make lint` and `make test` — all tests passing, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)