### PR TITLE
feat: add Episode.additional_data + format(); write() accepts formatted_episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- refactor: `BaseMemoryStore.write()` accepts `formatted_episode: str | None` so memory strategies own embedding text (#562)
+- refactor: `BaseMemoryStore.write()` accepts `embedded_text: str | None` so memory strategies own embedding text (#562)
 - refactor: `episode_to_qdrant_point_struct()` takes pre-formatted `text: str`; qdrant params keyword-only (#562)
 - refactor: add `DEFAULT_EPISODE_INCLUDE` to `QdrantMemoryStore`; remove init-level format params (#562)
 - refactor: add `episode_to_qdrant_point_struct()` converter in `qdrant_utils.py` (#559)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- refactor: add `episode_format_mode` + `episode_format_include` to `QdrantMemoryStore`; add `DEFAULT_EPISODE_INCLUDE` (#562)
-- refactor: reorder `episode_to_qdrant_point_struct()` params; qdrant params keyword-only (#562)
+- refactor: `BaseMemoryStore.write()` accepts `formatted_episode: str | None` so memory strategies own embedding text (#562)
+- refactor: `episode_to_qdrant_point_struct()` takes pre-formatted `text: str`; qdrant params keyword-only (#562)
+- refactor: add `DEFAULT_EPISODE_INCLUDE` to `QdrantMemoryStore`; remove init-level format params (#562)
 - refactor: add `episode_to_qdrant_point_struct()` converter in `qdrant_utils.py` (#559)
 - chore: migrate `QdrantMemoryStore` off deprecated `add` and `query` methods (#557)
 - fix: update `recency_memory.ipynb` summary output cells to show delegated format (#556)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: add `episode_format_mode` + `episode_format_include` to `QdrantMemoryStore`; add `DEFAULT_EPISODE_INCLUDE` (#562)
+- refactor: reorder `episode_to_qdrant_point_struct()` params; qdrant params keyword-only (#562)
 - refactor: add `episode_to_qdrant_point_struct()` converter in `qdrant_utils.py` (#559)
 - chore: migrate `QdrantMemoryStore` off deprecated `add` and `query` methods (#557)
 - fix: update `recency_memory.ipynb` summary output cells to show delegated format (#556)
@@ -17,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: implement `ReflectiveMemory` in `memory/reflective.py` (#527)
+- feat: add `Episode.additional_data` field and `Episode.format(mode, include)` with `EpisodeAttr` Literal type (#562)
 - feat: add `tqdm` to `notebooks` optional extra for async progress bars (#559)
 - bonus-example: `more-examples/ch07/similarity_memory.ipynb` — SimilarityMemory + QdrantMemoryStore with REST Countries API (#554)
 - feat: implement `SimilarityMemory` and add `summary()` to `BaseMemoryStore`, `JSONMemoryStore`, and `QdrantMemoryStore` (#550)

--- a/src/llm_agents_from_scratch/base/memory.py
+++ b/src/llm_agents_from_scratch/base/memory.py
@@ -73,13 +73,13 @@ class BaseMemoryStore(ABC):
     async def write(
         self,
         episode: Episode,
-        formatted_episode: str | None = None,
+        embedded_text: str | None = None,
     ) -> None:
         """Persist an episode to the store.
 
         Args:
             episode (Episode): The completed episode to store.
-            formatted_episode (str | None): Pre-formatted text for
+            embedded_text (str | None): Pre-formatted text for
                 substrates that embed episodes (e.g. vector stores).
                 When provided, the store uses this text for embedding
                 instead of formatting the episode itself. Substrates

--- a/src/llm_agents_from_scratch/base/memory.py
+++ b/src/llm_agents_from_scratch/base/memory.py
@@ -70,11 +70,21 @@ class BaseMemoryStore(ABC):
     """
 
     @abstractmethod
-    async def write(self, episode: Episode) -> None:
+    async def write(
+        self,
+        episode: Episode,
+        formatted_episode: str | None = None,
+    ) -> None:
         """Persist an episode to the store.
 
         Args:
             episode (Episode): The completed episode to store.
+            formatted_episode (str | None): Pre-formatted text for
+                substrates that embed episodes (e.g. vector stores).
+                When provided, the store uses this text for embedding
+                instead of formatting the episode itself. Substrates
+                that do not embed (e.g. ``JSONMemoryStore``) ignore
+                this argument. Defaults to ``None``.
         """
 
     @abstractmethod

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -1,27 +1,116 @@
 """Data structures for episodic memory."""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from .agent import Task, TaskResult
 
+EpisodeField = Literal[
+    "instruction",
+    "result",
+    "additional_data",
+    "completed_at",
+    "rollout",
+]
+
+_XML_DEFAULTS: list[EpisodeField] = [
+    "instruction",
+    "result",
+    "additional_data",
+    "completed_at",
+]
+_CONCAT_DEFAULTS: list[EpisodeField] = [
+    "instruction",
+    "result",
+    "additional_data",
+]
+
 
 class Episode(BaseModel):
-    """A completed task to be stored in memory."""
+    """A completed task to be stored in memory.
+
+    Attributes:
+        task (Task): The task that was executed.
+        rollout (str): The full agent trajectory for the task.
+        result (TaskResult): The final result of the task.
+        additional_data (dict[str, str] | None): Optional key-value
+            annotations added by memory strategies at write time (e.g.
+            ``{"reflection": "..."}`` from ReflectiveMemory).
+        completed_at (datetime): Timestamp when the episode was recorded.
+    """
 
     task: Task
     rollout: str
     result: TaskResult
+    additional_data: dict[str, str] | None = None
     completed_at: datetime = Field(default_factory=datetime.now)
+
+    def format(
+        self,
+        mode: Literal["xml", "concat"] = "xml",
+        fields: list[EpisodeField] | None = None,
+    ) -> str:
+        """Serialise the episode for prompt injection or embedding.
+
+        Args:
+            mode (Literal["xml", "concat"]): ``"xml"`` produces a
+                prompt-ready XML block; ``"concat"`` produces a
+                newline-joined string for embedding. Defaults to
+                ``"xml"``.
+            fields (list[EpisodeField] | None): Fields to include.
+                Defaults to ``["instruction", "result",
+                "additional_data", "completed_at"]`` for ``"xml"`` and
+                ``["instruction", "result", "additional_data"]`` for
+                ``"concat"``.
+
+        Returns:
+            str: Serialised episode string.
+        """
+        if mode == "concat":
+            return self._format_concat(fields or _CONCAT_DEFAULTS)
+        return self._format_xml(fields or _XML_DEFAULTS)
+
+    def _format_concat(self, fields: list[EpisodeField]) -> str:
+        parts: list[str] = []
+        for f in fields:
+            if f == "instruction":
+                parts.append(self.task.instruction)
+            elif f == "result":
+                parts.append(self.result.content)
+            elif f == "additional_data" and self.additional_data:
+                parts.extend(self.additional_data.values())
+            elif f == "completed_at":
+                parts.append(
+                    self.completed_at.strftime("%Y-%m-%d %H:%M:%S"),
+                )
+            elif f == "rollout":
+                parts.append(self.rollout)
+        return "\n".join(parts)
+
+    def _format_xml(self, fields: list[EpisodeField]) -> str:
+        lines = ["  <episode>"]
+        for f in fields:
+            if f == "instruction":
+                lines.append(
+                    f"    <task>{self.task.instruction}</task>",
+                )
+            elif f == "result":
+                lines.append(
+                    f"    <result>{self.result.content}\n    </result>",
+                )
+            elif f == "additional_data" and self.additional_data:
+                for key, val in self.additional_data.items():
+                    lines.append(f"    <{key}>{val}</{key}>")
+            elif f == "completed_at":
+                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                lines.append(f"    <completed_at>{ts}</completed_at>")
+            elif f == "rollout":
+                lines.append(f"    <rollout>{self.rollout}</rollout>")
+        lines.append("  </episode>")
+        return "\n".join(lines)
 
     def __str__(self) -> str:
         """Return a prompt-ready XML string representation of the episode."""
-        ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
-        return (
-            f"  <episode>\n"
-            f"    <task>{self.task.instruction}</task>\n"
-            f"    <result>{self.result.content}\n    </result>\n"
-            f"    <completed_at>{ts}</completed_at>\n"
-            f"  </episode>"
-        )
+        return self.format(mode="xml")

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -54,6 +54,7 @@ class Episode(BaseModel):
         Returns:
             str: Serialised episode string.
         """
+        # rollout is excluded by default — it is long and adds noise
         attrs = include or [
             "instruction",
             "result",

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -49,21 +49,20 @@ class Episode(BaseModel):
                 ``"xml"``.
             include (list[EpisodeAttr] | None): Attributes to include.
                 Defaults to ``["instruction", "result",
-                "additional_data", "completed_at"]`` for ``"xml"`` and
-                ``["instruction", "result", "additional_data"]`` for
-                ``"concat"``.
+                "additional_data", "completed_at"]``.
 
         Returns:
             str: Serialised episode string.
         """
+        attrs = include or [
+            "instruction",
+            "result",
+            "additional_data",
+            "completed_at",
+        ]
         if mode == "concat":
-            return self._format_concat(
-                include or ["instruction", "result", "additional_data"],
-            )
-        return self._format_xml(
-            include
-            or ["instruction", "result", "additional_data", "completed_at"],
-        )
+            return self._format_concat(attrs)
+        return self._format_xml(attrs)
 
     def _format_concat(self, fields: list[EpisodeAttr]) -> str:
         parts: list[str] = []

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -15,18 +15,6 @@ EpisodeAttr = Literal[
     "rollout",
 ]
 
-_XML_DEFAULTS: list[EpisodeAttr] = [
-    "instruction",
-    "result",
-    "additional_data",
-    "completed_at",
-]
-_CONCAT_DEFAULTS: list[EpisodeAttr] = [
-    "instruction",
-    "result",
-    "additional_data",
-]
-
 
 class Episode(BaseModel):
     """A completed task to be stored in memory.
@@ -69,8 +57,13 @@ class Episode(BaseModel):
             str: Serialised episode string.
         """
         if mode == "concat":
-            return self._format_concat(include or _CONCAT_DEFAULTS)
-        return self._format_xml(include or _XML_DEFAULTS)
+            return self._format_concat(
+                include or ["instruction", "result", "additional_data"],
+            )
+        return self._format_xml(
+            include
+            or ["instruction", "result", "additional_data", "completed_at"],
+        )
 
     def _format_concat(self, fields: list[EpisodeAttr]) -> str:
         parts: list[str] = []

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from .agent import Task, TaskResult
 
-EpisodeField = Literal[
+EpisodeAttr = Literal[
     "instruction",
     "result",
     "additional_data",
@@ -15,13 +15,13 @@ EpisodeField = Literal[
     "rollout",
 ]
 
-_XML_DEFAULTS: list[EpisodeField] = [
+_XML_DEFAULTS: list[EpisodeAttr] = [
     "instruction",
     "result",
     "additional_data",
     "completed_at",
 ]
-_CONCAT_DEFAULTS: list[EpisodeField] = [
+_CONCAT_DEFAULTS: list[EpisodeAttr] = [
     "instruction",
     "result",
     "additional_data",
@@ -50,7 +50,7 @@ class Episode(BaseModel):
     def format(
         self,
         mode: Literal["xml", "concat"] = "xml",
-        fields: list[EpisodeField] | None = None,
+        include: list[EpisodeAttr] | None = None,
     ) -> str:
         """Serialise the episode for prompt injection or embedding.
 
@@ -59,7 +59,7 @@ class Episode(BaseModel):
                 prompt-ready XML block; ``"concat"`` produces a
                 newline-joined string for embedding. Defaults to
                 ``"xml"``.
-            fields (list[EpisodeField] | None): Fields to include.
+            include (list[EpisodeAttr] | None): Attributes to include.
                 Defaults to ``["instruction", "result",
                 "additional_data", "completed_at"]`` for ``"xml"`` and
                 ``["instruction", "result", "additional_data"]`` for
@@ -69,10 +69,10 @@ class Episode(BaseModel):
             str: Serialised episode string.
         """
         if mode == "concat":
-            return self._format_concat(fields or _CONCAT_DEFAULTS)
-        return self._format_xml(fields or _XML_DEFAULTS)
+            return self._format_concat(include or _CONCAT_DEFAULTS)
+        return self._format_xml(include or _XML_DEFAULTS)
 
-    def _format_concat(self, fields: list[EpisodeField]) -> str:
+    def _format_concat(self, fields: list[EpisodeAttr]) -> str:
         parts: list[str] = []
         for f in fields:
             if f == "instruction":
@@ -89,7 +89,7 @@ class Episode(BaseModel):
                 parts.append(self.rollout)
         return "\n".join(parts)
 
-    def _format_xml(self, fields: list[EpisodeField]) -> str:
+    def _format_xml(self, fields: list[EpisodeAttr]) -> str:
         lines = ["  <episode>"]
         for f in fields:
             if f == "instruction":

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -50,17 +50,17 @@ class JSONMemoryStore(BaseMemoryStore):
     async def write(
         self,
         episode: Episode,
-        formatted_episode: str | None = None,
+        embedded_text: str | None = None,
     ) -> None:
         """Persist an episode to the store.
 
         Appends one JSON line to the backing file. Does not rewrite existing
-        content. ``formatted_episode`` is accepted for interface compatibility
+        content. ``embedded_text`` is accepted for interface compatibility
         but ignored — this store does not embed episodes.
 
         Args:
             episode (Episode): The completed episode to store.
-            formatted_episode (str | None): Ignored.
+            embedded_text (str | None): Ignored.
         """
         self._episodes.append(episode)
         with open(self.path, "a") as f:

--- a/src/llm_agents_from_scratch/memory/json_store.py
+++ b/src/llm_agents_from_scratch/memory/json_store.py
@@ -47,14 +47,20 @@ class JSONMemoryStore(BaseMemoryStore):
                 Episode.model_validate_json(line) for line in f if line.strip()
             ]
 
-    async def write(self, episode: Episode) -> None:
+    async def write(
+        self,
+        episode: Episode,
+        formatted_episode: str | None = None,
+    ) -> None:
         """Persist an episode to the store.
 
         Appends one JSON line to the backing file. Does not rewrite existing
-        content.
+        content. ``formatted_episode`` is accepted for interface compatibility
+        but ignored — this store does not embed episodes.
 
         Args:
             episode (Episode): The completed episode to store.
+            formatted_episode (str | None): Ignored.
         """
         self._episodes.append(episode)
         with open(self.path, "a") as f:

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -1,6 +1,6 @@
 """Qdrant-backed episodic memory store."""
 
-from typing import Any, Literal
+from typing import Any
 
 from qdrant_client import QdrantClient, models
 
@@ -35,10 +35,6 @@ class QdrantMemoryStore(BaseMemoryStore):
     Attributes:
         _client (QdrantClient): The Qdrant client instance.
         _collection (str): Name of the Qdrant collection.
-        _episode_format_mode (Literal["xml", "concat"]): Episode
-            serialisation mode used when embedding at write time.
-        _episode_format_include (list[EpisodeAttr] | None): Attributes
-            included in the embedded text at write time.
     """
 
     def __init__(
@@ -46,8 +42,6 @@ class QdrantMemoryStore(BaseMemoryStore):
         collection_name: str = "episodes",
         embedding_model: str = "BAAI/bge-small-en-v1.5",
         client: QdrantClient | None = None,
-        episode_format_mode: Literal["xml", "concat"] = "concat",
-        episode_format_include: list[EpisodeAttr] | None = None,
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
@@ -65,48 +59,47 @@ class QdrantMemoryStore(BaseMemoryStore):
             client (QdrantClient | None): Pre-configured Qdrant client.
                 Defaults to an in-memory client when ``None``. The
                 client must use FastEmbed as its embedding backend.
-            episode_format_mode (Literal["xml", "concat"]): Episode
-                serialisation mode used when embedding episodes at write
-                time. Defaults to ``"concat"``.
-            episode_format_include (list[EpisodeAttr] | None): Episode
-                attributes to include in the embedded text. Defaults to
-                ``DEFAULT_EPISODE_INCLUDE``. ``completed_at`` is
-                excluded by default to prevent recency from bleeding
-                into relevance scores.
         """
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
         self._collection = collection_name
-        self._episode_format_mode: Literal["xml", "concat"] = (
-            episode_format_mode
-        )
-        self._episode_format_include: list[EpisodeAttr] = (
-            episode_format_include or DEFAULT_EPISODE_INCLUDE
-        )
         if not self._client.collection_exists(collection_name):
             self._client.create_collection(
                 collection_name=collection_name,
                 vectors_config=self._client.get_fastembed_vector_params(),
             )
 
-    async def write(self, episode: Episode) -> None:
+    async def write(
+        self,
+        episode: Episode,
+        formatted_episode: str | None = None,
+    ) -> None:
         """Embed and persist an episode to the Qdrant collection.
 
-        The embedded text is the episode's task instruction followed by
-        the result content, separated by a newline. The full serialised
-        episode and its completion timestamp are stored in the point
-        payload for later retrieval.
+        The full serialised episode and its completion timestamp are
+        stored in the point payload for later retrieval. The embedded
+        text defaults to a concat-format serialisation of
+        ``DEFAULT_EPISODE_INCLUDE`` attributes when ``formatted_episode``
+        is not provided.
 
         Args:
             episode (Episode): The completed episode to store.
+            formatted_episode (str | None): Pre-formatted text to embed.
+                When provided by the calling memory strategy, this text
+                is used directly for the vector. Defaults to ``None``,
+                in which case the store formats the episode using
+                ``DEFAULT_EPISODE_INCLUDE``.
         """
+        text = formatted_episode or episode.format(
+            mode="concat",
+            include=DEFAULT_EPISODE_INCLUDE,
+        )
         self._client.upsert(
             collection_name=self._collection,
             points=[
                 episode_to_qdrant_point_struct(
                     episode,
-                    self._episode_format_mode,
-                    self._episode_format_include,
+                    text,
                     vector_field=self._client.get_vector_field_name(),
                     model_name=self._client.embedding_model_name,
                 ),

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -10,6 +10,12 @@ from llm_agents_from_scratch.memory.qdrant_utils import (
     episode_to_qdrant_point_struct,
 )
 
+DEFAULT_EPISODE_INCLUDE: list[EpisodeAttr] = [
+    "instruction",
+    "result",
+    "additional_data",
+]
+
 
 class QdrantMemoryStore(BaseMemoryStore):
     """Episodic memory store backed by a Qdrant collection.
@@ -64,9 +70,9 @@ class QdrantMemoryStore(BaseMemoryStore):
                 time. Defaults to ``"concat"``.
             episode_format_include (list[EpisodeAttr] | None): Episode
                 attributes to include in the embedded text. Defaults to
-                ``["instruction", "result", "additional_data"]``.
-                ``completed_at`` is excluded by default to prevent
-                recency from bleeding into relevance scores.
+                ``DEFAULT_EPISODE_INCLUDE``. ``completed_at`` is
+                excluded by default to prevent recency from bleeding
+                into relevance scores.
         """
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
@@ -75,8 +81,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             episode_format_mode
         )
         self._episode_format_include: list[EpisodeAttr] = (
-            episode_format_include
-            or ["instruction", "result", "additional_data"]
+            episode_format_include or DEFAULT_EPISODE_INCLUDE
         )
         if not self._client.collection_exists(collection_name):
             self._client.create_collection(

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -99,7 +99,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             points=[
                 episode_to_qdrant_point_struct(
                     episode,
-                    text,
+                    text=text,
                     vector_field=self._client.get_vector_field_name(),
                     model_name=self._client.embedding_model_name,
                 ),

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -99,9 +99,9 @@ class QdrantMemoryStore(BaseMemoryStore):
             points=[
                 episode_to_qdrant_point_struct(
                     episode,
-                    text=text,
-                    vector_field=self._client.get_vector_field_name(),
-                    model_name=self._client.embedding_model_name,
+                    text,
+                    self._client.get_vector_field_name(),
+                    self._client.embedding_model_name,
                 ),
             ],
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -29,9 +29,9 @@ class QdrantMemoryStore(BaseMemoryStore):
     Attributes:
         _client (QdrantClient): The Qdrant client instance.
         _collection (str): Name of the Qdrant collection.
-        _mode (Literal["xml", "concat"]): Episode serialisation mode
-            used when embedding at write time.
-        _include_in_episodes (list[EpisodeAttr] | None): Attributes
+        _episode_format_mode (Literal["xml", "concat"]): Episode
+            serialisation mode used when embedding at write time.
+        _episode_format_include (list[EpisodeAttr] | None): Attributes
             included in the embedded text at write time.
     """
 
@@ -40,8 +40,8 @@ class QdrantMemoryStore(BaseMemoryStore):
         collection_name: str = "episodes",
         embedding_model: str = "BAAI/bge-small-en-v1.5",
         client: QdrantClient | None = None,
-        mode: Literal["xml", "concat"] = "concat",
-        include_in_episodes: list[EpisodeAttr] | None = None,
+        episode_format_mode: Literal["xml", "concat"] = "concat",
+        episode_format_include: list[EpisodeAttr] | None = None,
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
@@ -59,18 +59,20 @@ class QdrantMemoryStore(BaseMemoryStore):
             client (QdrantClient | None): Pre-configured Qdrant client.
                 Defaults to an in-memory client when ``None``. The
                 client must use FastEmbed as its embedding backend.
-            mode (Literal["xml", "concat"]): Episode serialisation mode
-                used when embedding episodes at write time. Defaults to
-                ``"concat"``.
-            include_in_episodes (list[EpisodeAttr] | None): Episode
+            episode_format_mode (Literal["xml", "concat"]): Episode
+                serialisation mode used when embedding episodes at write
+                time. Defaults to ``"concat"``.
+            episode_format_include (list[EpisodeAttr] | None): Episode
                 attributes to include in the embedded text. Defaults to
                 ``Episode.format()`` defaults for the given mode.
         """
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
         self._collection = collection_name
-        self._mode: Literal["xml", "concat"] = mode
-        self._include_in_episodes = include_in_episodes
+        self._episode_format_mode: Literal["xml", "concat"] = (
+            episode_format_mode
+        )
+        self._episode_format_include = episode_format_include
         if not self._client.collection_exists(collection_name):
             self._client.create_collection(
                 collection_name=collection_name,
@@ -95,8 +97,8 @@ class QdrantMemoryStore(BaseMemoryStore):
                     episode,
                     vector_field=self._client.get_vector_field_name(),
                     model_name=self._client.embedding_model_name,
-                    mode=self._mode,
-                    include=self._include_in_episodes,
+                    mode=self._episode_format_mode,
+                    include=self._episode_format_include,
                 ),
             ],
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -64,7 +64,9 @@ class QdrantMemoryStore(BaseMemoryStore):
                 time. Defaults to ``"concat"``.
             episode_format_include (list[EpisodeAttr] | None): Episode
                 attributes to include in the embedded text. Defaults to
-                ``Episode.format()`` defaults for the given mode.
+                ``["instruction", "result", "additional_data"]``.
+                ``completed_at`` is excluded by default to prevent
+                recency from bleeding into relevance scores.
         """
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
@@ -72,7 +74,10 @@ class QdrantMemoryStore(BaseMemoryStore):
         self._episode_format_mode: Literal["xml", "concat"] = (
             episode_format_mode
         )
-        self._episode_format_include = episode_format_include
+        self._episode_format_include: list[EpisodeAttr] = (
+            episode_format_include
+            or ["instruction", "result", "additional_data"]
+        )
         if not self._client.collection_exists(collection_name):
             self._client.create_collection(
                 collection_name=collection_name,

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -1,11 +1,11 @@
 """Qdrant-backed episodic memory store."""
 
-from typing import Any
+from typing import Any, Literal
 
 from qdrant_client import QdrantClient, models
 
 from llm_agents_from_scratch.base.memory import BaseMemoryStore
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeAttr
 from llm_agents_from_scratch.memory.qdrant_utils import (
     episode_to_qdrant_point_struct,
 )
@@ -16,8 +16,7 @@ class QdrantMemoryStore(BaseMemoryStore):
 
     Episodes are embedded at write time using FastEmbed and stored as
     vector points. Similarity search uses cosine distance over the
-    embedded episode text (task instruction concatenated with result
-    content).
+    embedded episode text.
 
     By default, Qdrant runs in-process with no server required. Pass a
     pre-configured ``QdrantClient`` to persist to a remote or on-disk
@@ -30,6 +29,10 @@ class QdrantMemoryStore(BaseMemoryStore):
     Attributes:
         _client (QdrantClient): The Qdrant client instance.
         _collection (str): Name of the Qdrant collection.
+        _mode (Literal["xml", "concat"]): Episode serialisation mode
+            used when embedding at write time.
+        _include_in_episodes (list[EpisodeAttr] | None): Attributes
+            included in the embedded text at write time.
     """
 
     def __init__(
@@ -37,6 +40,8 @@ class QdrantMemoryStore(BaseMemoryStore):
         collection_name: str = "episodes",
         embedding_model: str = "BAAI/bge-small-en-v1.5",
         client: QdrantClient | None = None,
+        mode: Literal["xml", "concat"] = "concat",
+        include_in_episodes: list[EpisodeAttr] | None = None,
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
@@ -54,10 +59,18 @@ class QdrantMemoryStore(BaseMemoryStore):
             client (QdrantClient | None): Pre-configured Qdrant client.
                 Defaults to an in-memory client when ``None``. The
                 client must use FastEmbed as its embedding backend.
+            mode (Literal["xml", "concat"]): Episode serialisation mode
+                used when embedding episodes at write time. Defaults to
+                ``"concat"``.
+            include_in_episodes (list[EpisodeAttr] | None): Episode
+                attributes to include in the embedded text. Defaults to
+                ``Episode.format()`` defaults for the given mode.
         """
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
         self._collection = collection_name
+        self._mode: Literal["xml", "concat"] = mode
+        self._include_in_episodes = include_in_episodes
         if not self._client.collection_exists(collection_name):
             self._client.create_collection(
                 collection_name=collection_name,
@@ -82,6 +95,8 @@ class QdrantMemoryStore(BaseMemoryStore):
                     episode,
                     vector_field=self._client.get_vector_field_name(),
                     model_name=self._client.embedding_model_name,
+                    mode=self._mode,
+                    include=self._include_in_episodes,
                 ),
             ],
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -95,10 +95,10 @@ class QdrantMemoryStore(BaseMemoryStore):
             points=[
                 episode_to_qdrant_point_struct(
                     episode,
+                    self._episode_format_mode,
+                    self._episode_format_include,
                     vector_field=self._client.get_vector_field_name(),
                     model_name=self._client.embedding_model_name,
-                    mode=self._episode_format_mode,
-                    include=self._episode_format_include,
                 ),
             ],
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_store.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_store.py
@@ -72,25 +72,25 @@ class QdrantMemoryStore(BaseMemoryStore):
     async def write(
         self,
         episode: Episode,
-        formatted_episode: str | None = None,
+        embedded_text: str | None = None,
     ) -> None:
         """Embed and persist an episode to the Qdrant collection.
 
         The full serialised episode and its completion timestamp are
         stored in the point payload for later retrieval. The embedded
         text defaults to a concat-format serialisation of
-        ``DEFAULT_EPISODE_INCLUDE`` attributes when ``formatted_episode``
+        ``DEFAULT_EPISODE_INCLUDE`` attributes when ``embedded_text``
         is not provided.
 
         Args:
             episode (Episode): The completed episode to store.
-            formatted_episode (str | None): Pre-formatted text to embed.
+            embedded_text (str | None): Pre-formatted text to embed.
                 When provided by the calling memory strategy, this text
                 is used directly for the vector. Defaults to ``None``,
                 in which case the store formats the episode using
                 ``DEFAULT_EPISODE_INCLUDE``.
         """
-        text = formatted_episode or episode.format(
+        text = embedded_text or episode.format(
             mode="concat",
             include=DEFAULT_EPISODE_INCLUDE,
         )

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -7,7 +7,6 @@ from llm_agents_from_scratch.data_structures.memory import Episode
 
 def episode_to_qdrant_point_struct(
     episode: Episode,
-    *,
     text: str,
     vector_field: str,
     model_name: str,

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -1,41 +1,35 @@
 """Qdrant data-conversion utilities for episodic memory."""
 
-from typing import Literal
-
 from qdrant_client import models
 
-from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeAttr
+from llm_agents_from_scratch.data_structures.memory import Episode
 
 
 def episode_to_qdrant_point_struct(
     episode: Episode,
-    mode: Literal["xml", "concat"] = "concat",
-    include: list[EpisodeAttr] | None = None,
-    # qdrant
+    text: str,
     *,
     vector_field: str,
     model_name: str,
 ) -> models.PointStruct:
     """Convert an episode to a Qdrant PointStruct ready for upsert.
 
+    The caller is responsible for formatting ``text`` — typically via
+    ``Episode.format()`` — so that memory strategies own the embedding
+    content decision.
+
     Args:
         episode (Episode): The completed episode to convert.
-        mode (Literal["xml", "concat"]): Episode serialisation mode
-            passed to ``Episode.format()``. Defaults to ``"concat"``.
-        include (list[EpisodeAttr] | None): Attributes to include in
-            the embedded text. Defaults to ``Episode.format()``
-            defaults for the given mode.
+        text (str): Pre-formatted text to embed as the point vector.
         vector_field (str): Name of the vector field in the Qdrant
             collection (e.g. ``"fast-bge-small-en-v1.5"``).
         model_name (str): FastEmbed model identifier used for embedding
             (e.g. ``"BAAI/bge-small-en-v1.5"``).
 
-
     Returns:
         models.PointStruct: A point ready to pass to
             ``QdrantClient.upsert()``.
     """
-    text = episode.format(mode=mode, include=include)
     return models.PointStruct(
         id=episode.task.id_,
         vector={

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -7,8 +7,8 @@ from llm_agents_from_scratch.data_structures.memory import Episode
 
 def episode_to_qdrant_point_struct(
     episode: Episode,
-    text: str,
     *,
+    text: str,
     vector_field: str,
     model_name: str,
 ) -> models.PointStruct:

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -9,24 +9,27 @@ from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeAttr
 
 def episode_to_qdrant_point_struct(
     episode: Episode,
-    vector_field: str,
-    model_name: str,
     mode: Literal["xml", "concat"] = "concat",
     include: list[EpisodeAttr] | None = None,
+    # qdrant
+    *,
+    vector_field: str,
+    model_name: str,
 ) -> models.PointStruct:
     """Convert an episode to a Qdrant PointStruct ready for upsert.
 
     Args:
         episode (Episode): The completed episode to convert.
-        vector_field (str): Name of the vector field in the Qdrant
-            collection (e.g. ``"fast-bge-small-en-v1.5"``).
-        model_name (str): FastEmbed model identifier used for embedding
-            (e.g. ``"BAAI/bge-small-en-v1.5"``).
         mode (Literal["xml", "concat"]): Episode serialisation mode
             passed to ``Episode.format()``. Defaults to ``"concat"``.
         include (list[EpisodeAttr] | None): Attributes to include in
             the embedded text. Defaults to ``Episode.format()``
             defaults for the given mode.
+        vector_field (str): Name of the vector field in the Qdrant
+            collection (e.g. ``"fast-bge-small-en-v1.5"``).
+        model_name (str): FastEmbed model identifier used for embedding
+            (e.g. ``"BAAI/bge-small-en-v1.5"``).
+
 
     Returns:
         models.PointStruct: A point ready to pass to

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -28,7 +28,7 @@ def episode_to_qdrant_point_struct(
         models.PointStruct: A point ready to pass to
             ``QdrantClient.upsert()``.
     """
-    text = f"{episode.task.instruction}\n{episode.result.content}"
+    text = episode.format(mode="concat")
     return models.PointStruct(
         id=episode.task.id_,
         vector={

--- a/src/llm_agents_from_scratch/memory/qdrant_utils.py
+++ b/src/llm_agents_from_scratch/memory/qdrant_utils.py
@@ -1,21 +1,20 @@
 """Qdrant data-conversion utilities for episodic memory."""
 
+from typing import Literal
+
 from qdrant_client import models
 
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeAttr
 
 
 def episode_to_qdrant_point_struct(
     episode: Episode,
     vector_field: str,
     model_name: str,
+    mode: Literal["xml", "concat"] = "concat",
+    include: list[EpisodeAttr] | None = None,
 ) -> models.PointStruct:
     """Convert an episode to a Qdrant PointStruct ready for upsert.
-
-    The embedded text is the episode's task instruction followed by the
-    result content, separated by a newline. XML tags and timestamps from
-    ``Episode.__str__`` are intentionally excluded — they add noise and
-    allow recency to bleed into relevance scores.
 
     Args:
         episode (Episode): The completed episode to convert.
@@ -23,12 +22,17 @@ def episode_to_qdrant_point_struct(
             collection (e.g. ``"fast-bge-small-en-v1.5"``).
         model_name (str): FastEmbed model identifier used for embedding
             (e.g. ``"BAAI/bge-small-en-v1.5"``).
+        mode (Literal["xml", "concat"]): Episode serialisation mode
+            passed to ``Episode.format()``. Defaults to ``"concat"``.
+        include (list[EpisodeAttr] | None): Attributes to include in
+            the embedded text. Defaults to ``Episode.format()``
+            defaults for the given mode.
 
     Returns:
         models.PointStruct: A point ready to pass to
             ``QdrantClient.upsert()``.
     """
-    text = episode.format(mode="concat")
+    text = episode.format(mode=mode, include=include)
     return models.PointStruct(
         id=episode.task.id_,
         vector={

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -25,6 +25,52 @@ def test_episode_str() -> None:
     assert ep.completed_at.strftime("%Y-%m-%d") in s
 
 
+def test_format_concat_completed_at() -> None:
+    task = Task(instruction="task")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="result"),
+        completed_at=datetime(2025, 6, 1, 12, 0, 0),
+    )
+    text = ep.format(mode="concat", include=["completed_at"])
+    assert "2025-06-01 12:00:00" in text
+
+
+def test_format_concat_rollout() -> None:
+    task = Task(instruction="task")
+    ep = Episode(
+        task=task,
+        rollout="step1 -> step2",
+        result=TaskResult(task_id=task.id_, content="result"),
+    )
+    text = ep.format(mode="concat", include=["rollout"])
+    assert "step1 -> step2" in text
+
+
+def test_format_xml_additional_data() -> None:
+    task = Task(instruction="task")
+    ep = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="result"),
+        additional_data={"reflection": "key lesson here"},
+    )
+    text = ep.format(mode="xml", include=["additional_data"])
+    assert "<reflection>key lesson here</reflection>" in text
+
+
+def test_format_xml_rollout() -> None:
+    task = Task(instruction="task")
+    ep = Episode(
+        task=task,
+        rollout="step1 -> step2",
+        result=TaskResult(task_id=task.id_, content="result"),
+    )
+    text = ep.format(mode="xml", include=["rollout"])
+    assert "<rollout>step1 -> step2</rollout>" in text
+
+
 def test_episode_init() -> None:
     """Tests construction of Episode."""
     mock_task = MagicMock(spec=Task)

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -57,11 +57,11 @@ def test_init_custom_params(mock_client: MagicMock) -> None:
 
 def test_init_episode_format_params(mock_client: MagicMock) -> None:
     store = QdrantMemoryStore(
-        mode="xml",
-        include_in_episodes=["instruction", "result"],
+        episode_format_mode="xml",
+        episode_format_include=["instruction", "result"],
     )
-    assert store._mode == "xml"
-    assert store._include_in_episodes == ["instruction", "result"]
+    assert store._episode_format_mode == "xml"
+    assert store._episode_format_include == ["instruction", "result"]
 
 
 def test_init_custom_client() -> None:

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -55,6 +55,15 @@ def test_init_custom_params(mock_client: MagicMock) -> None:
     assert store._collection == "my_eps"
 
 
+def test_init_episode_format_params(mock_client: MagicMock) -> None:
+    store = QdrantMemoryStore(
+        mode="xml",
+        include_in_episodes=["instruction", "result"],
+    )
+    assert store._mode == "xml"
+    assert store._include_in_episodes == ["instruction", "result"]
+
+
 def test_init_custom_client() -> None:
     custom_client = MagicMock(spec=QdrantClient)
     store = QdrantMemoryStore(client=custom_client)

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -79,13 +79,13 @@ async def test_write(mock_client: MagicMock, episode: Episode) -> None:
     assert "completed_at" in point.payload
 
 
-async def test_write_uses_formatted_episode_when_provided(
+async def test_write_uses_embedded_text_when_provided(
     mock_client: MagicMock,
     episode: Episode,
 ) -> None:
     store = QdrantMemoryStore()
     custom_text = "custom formatted text"
-    await store.write(episode, formatted_episode=custom_text)
+    await store.write(episode, embedded_text=custom_text)
 
     kw = mock_client.upsert.call_args.kwargs
     point = kw["points"][0]

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -55,6 +55,16 @@ def test_init_custom_params(mock_client: MagicMock) -> None:
     assert store._collection == "my_eps"
 
 
+def test_init_episode_format_defaults(mock_client: MagicMock) -> None:
+    store = QdrantMemoryStore()
+    assert store._episode_format_mode == "concat"
+    assert store._episode_format_include == [
+        "instruction",
+        "result",
+        "additional_data",
+    ]
+
+
 def test_init_episode_format_params(mock_client: MagicMock) -> None:
     store = QdrantMemoryStore(
         episode_format_mode="xml",

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -55,25 +55,6 @@ def test_init_custom_params(mock_client: MagicMock) -> None:
     assert store._collection == "my_eps"
 
 
-def test_init_episode_format_defaults(mock_client: MagicMock) -> None:
-    store = QdrantMemoryStore()
-    assert store._episode_format_mode == "concat"
-    assert store._episode_format_include == [
-        "instruction",
-        "result",
-        "additional_data",
-    ]
-
-
-def test_init_episode_format_params(mock_client: MagicMock) -> None:
-    store = QdrantMemoryStore(
-        episode_format_mode="xml",
-        episode_format_include=["instruction", "result"],
-    )
-    assert store._episode_format_mode == "xml"
-    assert store._episode_format_include == ["instruction", "result"]
-
-
 def test_init_custom_client() -> None:
     custom_client = MagicMock(spec=QdrantClient)
     store = QdrantMemoryStore(client=custom_client)
@@ -96,6 +77,19 @@ async def test_write(mock_client: MagicMock, episode: Episode) -> None:
     assert episode.result.content in point.vector["fast-bge-small-en-v1.5"].text
     assert "episode_json" in point.payload
     assert "completed_at" in point.payload
+
+
+async def test_write_uses_formatted_episode_when_provided(
+    mock_client: MagicMock,
+    episode: Episode,
+) -> None:
+    store = QdrantMemoryStore()
+    custom_text = "custom formatted text"
+    await store.write(episode, formatted_episode=custom_text)
+
+    kw = mock_client.upsert.call_args.kwargs
+    point = kw["points"][0]
+    assert point.vector["fast-bge-small-en-v1.5"].text == custom_text
 
 
 async def test_count(mock_client: MagicMock) -> None:

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -4,6 +4,9 @@ from llm_agents_from_scratch.memory.qdrant_utils import (
     episode_to_qdrant_point_struct,
 )
 
+_FIELD = "fast-bge-small-en-v1.5"
+_MODEL = "BAAI/bge-small-en-v1.5"
+
 
 def _make_episode(instruction: str = "look up pikachu") -> Episode:
     task = Task(instruction=instruction)
@@ -18,8 +21,9 @@ def test_id_matches_task_id() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        "some text",
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
     assert point.id == episode.task.id_
 
@@ -28,36 +32,39 @@ def test_vector_field_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        "some text",
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
-    assert "fast-bge-small-en-v1.5" in point.vector
+    assert _FIELD in point.vector  # type: ignore[operator]
 
 
 def test_document_model_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        "some text",
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
-    doc = point.vector["fast-bge-small-en-v1.5"]
-    assert doc.model == "BAAI/bge-small-en-v1.5"
+    assert point.vector[_FIELD].model == _MODEL  # type: ignore[index]
 
 
-def test_embedded_text_contains_instruction_and_result() -> None:
+def test_text_passed_through_to_document() -> None:
     episode = _make_episode()
+    text = episode.format(mode="concat", include=["instruction", "result"])
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        text,
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
-    doc = point.vector["fast-bge-small-en-v1.5"]
-    assert episode.task.instruction in doc.text
-    assert episode.result.content in doc.text
+    doc = point.vector[_FIELD]  # type: ignore[index]
+    assert episode.task.instruction in doc.text  # type: ignore[union-attr]
+    assert episode.result.content in doc.text  # type: ignore[union-attr]
 
 
-def test_embedded_text_includes_additional_data() -> None:
+def test_additional_data_in_text_when_caller_includes_it() -> None:
     task = Task(instruction="look up pikachu")
     episode = Episode(
         task=task,
@@ -65,12 +72,17 @@ def test_embedded_text_includes_additional_data() -> None:
         result=TaskResult(task_id=task.id_, content="pikachu is electric"),
         additional_data={"reflection": "Always verify the name spelling."},
     )
+    text = episode.format(
+        mode="concat",
+        include=["instruction", "result", "additional_data"],
+    )
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        text,
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
-    doc = point.vector["fast-bge-small-en-v1.5"]  # type: ignore[index]
+    doc = point.vector[_FIELD]  # type: ignore[index]
     assert "Always verify the name spelling." in doc.text  # type: ignore[union-attr]
 
 
@@ -78,8 +90,9 @@ def test_payload_contains_episode_json() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        "some text",
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
     assert "episode_json" in point.payload
     assert "completed_at" in point.payload
@@ -89,8 +102,9 @@ def test_payload_episode_json_roundtrips() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        vector_field="fast-bge-small-en-v1.5",
-        model_name="BAAI/bge-small-en-v1.5",
+        "some text",
+        vector_field=_FIELD,
+        model_name=_MODEL,
     )
     restored = Episode.model_validate_json(point.payload["episode_json"])
     assert restored.task.instruction == episode.task.instruction
@@ -101,6 +115,7 @@ def test_custom_vector_field_and_model() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
+        "some text",
         vector_field="my-custom-field",
         model_name="sentence-transformers/all-MiniLM-L6-v2",
     )

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -21,7 +21,7 @@ def test_id_matches_task_id() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -32,7 +32,7 @@ def test_vector_field_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -43,7 +43,7 @@ def test_document_model_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -55,7 +55,7 @@ def test_text_passed_through_to_document() -> None:
     text = episode.format(mode="concat", include=["instruction", "result"])
     point = episode_to_qdrant_point_struct(
         episode,
-        text,
+        text=text,
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -78,7 +78,7 @@ def test_additional_data_in_text_when_caller_includes_it() -> None:
     )
     point = episode_to_qdrant_point_struct(
         episode,
-        text,
+        text=text,
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -90,7 +90,7 @@ def test_payload_contains_episode_json() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -102,7 +102,7 @@ def test_payload_episode_json_roundtrips() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -115,11 +115,11 @@ def test_custom_vector_field_and_model() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        "some text",
+        text="some text",
         vector_field="my-custom-field",
         model_name="sentence-transformers/all-MiniLM-L6-v2",
     )
-    assert "my-custom-field" in point.vector
-    assert point.vector["my-custom-field"].model == (
+    assert "my-custom-field" in point.vector  # type: ignore[operator]
+    assert point.vector["my-custom-field"].model == (  # type: ignore[index]
         "sentence-transformers/all-MiniLM-L6-v2"
     )

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -21,7 +21,7 @@ def test_id_matches_task_id() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -32,7 +32,7 @@ def test_vector_field_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -43,7 +43,7 @@ def test_document_model_name() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -55,7 +55,7 @@ def test_text_passed_through_to_document() -> None:
     text = episode.format(mode="concat", include=["instruction", "result"])
     point = episode_to_qdrant_point_struct(
         episode,
-        text=text,
+        text,
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -78,7 +78,7 @@ def test_additional_data_in_text_when_caller_includes_it() -> None:
     )
     point = episode_to_qdrant_point_struct(
         episode,
-        text=text,
+        text,
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -90,7 +90,7 @@ def test_payload_contains_episode_json() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -102,7 +102,7 @@ def test_payload_episode_json_roundtrips() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field=_FIELD,
         model_name=_MODEL,
     )
@@ -115,7 +115,7 @@ def test_custom_vector_field_and_model() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(
         episode,
-        text="some text",
+        "some text",
         vector_field="my-custom-field",
         model_name="sentence-transformers/all-MiniLM-L6-v2",
     )

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -57,6 +57,23 @@ def test_embedded_text_contains_instruction_and_result() -> None:
     assert episode.result.content in doc.text
 
 
+def test_embedded_text_includes_additional_data() -> None:
+    task = Task(instruction="look up pikachu")
+    episode = Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="pikachu is electric"),
+        additional_data={"reflection": "Always verify the name spelling."},
+    )
+    point = episode_to_qdrant_point_struct(
+        episode,
+        vector_field="fast-bge-small-en-v1.5",
+        model_name="BAAI/bge-small-en-v1.5",
+    )
+    doc = point.vector["fast-bge-small-en-v1.5"]  # type: ignore[index]
+    assert "Always verify the name spelling." in doc.text  # type: ignore[union-attr]
+
+
 def test_payload_contains_episode_json() -> None:
     episode = _make_episode()
     point = episode_to_qdrant_point_struct(


### PR DESCRIPTION
## Summary

- Add `additional_data: dict[str, str] | None` to `Episode` for flexible write-time annotations from any memory strategy (e.g. `{"reflection": "..."}` from `ReflectiveMemory`)
- Add `Episode.format(mode, include)` with `"xml"` (prompt injection) and `"concat"` (embedding) modes; `EpisodeAttr` Literal type enforces valid attribute names; `__str__` delegates to `format("xml")`
- `BaseMemoryStore.write()` gains `formatted_episode: str | None = None` — memory strategies own the embedding text decision; stores use it if provided, ignore it if they don't embed
- `episode_to_qdrant_point_struct()` now takes a pre-formatted `text: str` (caller's responsibility); qdrant params are keyword-only
- `QdrantMemoryStore.write()` uses `formatted_episode` when provided, otherwise falls back to `DEFAULT_EPISODE_INCLUDE` in concat mode; init-level format params removed

## Test plan

- [ ] `tests/memory/test_qdrant_utils.py` — `test_additional_data_in_text_when_caller_includes_it` verifies caller controls what gets embedded
- [ ] `tests/memory/test_qdrant_store.py` — `test_write_uses_formatted_episode_when_provided` verifies override path; default path still includes instruction + result
- [ ] `make lint` and `make test` — all tests passing, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)