### PR TITLE
fix(ci): add explicit permissions to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: get code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to `lint.yml` to address the open CodeQL code scanning alert ("Workflow does not contain permissions", #5)
- Follows least-privilege best practice for `GITHUB_TOKEN` — consistent with all other workflows in the repo (`unit_test.yml`, `release.yml`, `docs_publish.yml`)

## Test plan
- [x] Workflow only checks out code and runs linters — `contents: read` is sufficient
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)