### PR TITLE
feat: add id_ UUID field to Episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- feat: add `id_` UUID field to `Episode` (#588)
+
 ### Changed
 
 - refactor: move `BaseMemoryStore` to `base/memory_store.py`; `base/memory.py` now contains only `BaseMemory` (#587)

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -1,5 +1,6 @@
 """Data structures for episodic memory."""
 
+import uuid
 from datetime import datetime
 from typing import Literal
 
@@ -20,6 +21,7 @@ class Episode(BaseModel):
     """A completed task to be stored in memory.
 
     Attributes:
+        id_ (str): Unique identifier for the episode (UUID4).
         task (Task): The task that was executed.
         rollout (str): The full agent trajectory for the task.
         result (TaskResult): The final result of the task.
@@ -29,6 +31,7 @@ class Episode(BaseModel):
         completed_at (datetime): Timestamp when the episode was recorded.
     """
 
+    id_: str = Field(default_factory=lambda: str(uuid.uuid4()))
     task: Task
     rollout: str
     result: TaskResult

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/utils.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/utils.py
@@ -30,7 +30,7 @@ def episode_to_qdrant_point_struct(
             ``QdrantClient.upsert()``.
     """
     return models.PointStruct(
-        id=episode.task.id_,
+        id=episode.id_,
         vector={
             vector_field: models.Document(text=text, model=model_name),
         },

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -70,7 +70,7 @@ async def test_write(mock_client: MagicMock, episode: Episode) -> None:
     kw = mock_client.upsert.call_args.kwargs
     assert kw["collection_name"] == "episodes"
     point = kw["points"][0]
-    assert point.id == episode.task.id_
+    assert point.id == episode.id_
     assert (
         episode.task.instruction in point.vector["fast-bge-small-en-v1.5"].text
     )

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -25,7 +25,7 @@ def test_id_matches_task_id() -> None:
         vector_field=_FIELD,
         model_name=_MODEL,
     )
-    assert point.id == episode.task.id_
+    assert point.id == episode.id_
 
 
 def test_vector_field_name() -> None:


### PR DESCRIPTION
Closes #584

## Summary
- Add `id_: str = Field(default_factory=lambda: str(uuid.uuid4()))` to `Episode`, following the existing convention used by `Task` and `TaskStep`
- Qdrant point ID updated from `episode.task.id_` to `episode.id_`
- JSONL round-trip gets `id_` for free via `model_dump_json()` / `model_validate_json()`

## Test plan
- [ ] `pytest tests/` — 299 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)