### PR TITLE
feat: add recall_mode to BaseMemoryStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- feat: add `recall_mode` to `BaseMemoryStore` — `"recent"` delegates `search()` to `read_recent()`; `"search"` performs similarity lookup (#590)
+- feat: add `recall_mode` (`RecallMode` enum) to `BaseMemoryStore` — `RecallMode.RECENT` delegates `search()` to `read_recent()`; `RecallMode.SEARCH` performs similarity lookup (#590)
+- feat: add `RecallMode(str, Enum)` to `data_structures.memory` (#590)
 - feat: add `id_` UUID field to `Episode` (#588)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: add `recall_mode` to `BaseMemoryStore` — `"recent"` delegates `search()` to `read_recent()`; `"search"` performs similarity lookup (#590)
 - feat: add `id_` UUID field to `Episode` (#588)
 
 ### Changed

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -1,7 +1,7 @@
 """Base memory store class."""
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Literal
 
 from ..data_structures import Episode
 
@@ -22,16 +22,28 @@ class BaseMemoryStore(ABC):
         max_results (int): Default number of results returned by
             ``search`` and ``read_recent`` when no explicit count is
             supplied by the caller.
+        recall_mode (Literal["recent", "search"]): Controls how
+            ``search()`` retrieves episodes. ``"recent"`` ignores the
+            query and returns the most recent episodes via
+            ``read_recent``; ``"search"`` performs a similarity lookup.
     """
 
-    def __init__(self, max_results: int = 5) -> None:
+    def __init__(
+        self,
+        max_results: int = 5,
+        recall_mode: Literal["recent", "search"] = "search",
+    ) -> None:
         """Initialise shared store state.
 
         Args:
             max_results (int): Default maximum number of episodes
                 returned by retrieval operations. Defaults to 5.
+            recall_mode (Literal["recent", "search"]): Retrieval
+                strategy used by ``search()``. Defaults to
+                ``"search"``.
         """
         self.max_results = max_results
+        self.recall_mode = recall_mode
 
     @abstractmethod
     async def write(

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -1,9 +1,10 @@
 """Base memory store class."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from typing import Any
 
 from ..data_structures import Episode
+from ..data_structures.memory import RecallMode
 
 
 class BaseMemoryStore(ABC):
@@ -22,25 +23,24 @@ class BaseMemoryStore(ABC):
         max_results (int): Default number of results returned by
             ``search`` and ``read_recent`` when no explicit count is
             supplied by the caller.
-        recall_mode (Literal["recent", "search"]): Controls how
-            ``search()`` retrieves episodes. ``"recent"`` ignores the
-            query and returns the most recent episodes via
-            ``read_recent``; ``"search"`` performs a similarity lookup.
+        recall_mode (RecallMode): Controls how ``search()`` retrieves
+            episodes. ``RecallMode.RECENT`` ignores the query and
+            returns the most recent episodes via ``read_recent``;
+            ``RecallMode.SEARCH`` performs a similarity lookup.
     """
 
     def __init__(
         self,
         max_results: int = 5,
-        recall_mode: Literal["recent", "search"] = "search",
+        recall_mode: RecallMode = RecallMode.SEARCH,
     ) -> None:
         """Initialise shared store state.
 
         Args:
             max_results (int): Default maximum number of episodes
                 returned by retrieval operations. Defaults to 5.
-            recall_mode (Literal["recent", "search"]): Retrieval
-                strategy used by ``search()``. Defaults to
-                ``"search"``.
+            recall_mode (RecallMode): Retrieval strategy used by
+                ``search()``. Defaults to ``RecallMode.SEARCH``.
         """
         self.max_results = max_results
         self.recall_mode = recall_mode

--- a/src/llm_agents_from_scratch/data_structures/__init__.py
+++ b/src/llm_agents_from_scratch/data_structures/__init__.py
@@ -1,6 +1,6 @@
 from .agent import NextStepDecision, Task, TaskResult, TaskStep, TaskStepResult
 from .llm import ChatMessage, ChatRole, CompleteResult
-from .memory import Episode
+from .memory import Episode, RecallMode
 from .skill import SkillFrontmatter
 from .tool import ToolCall, ToolCallResult
 
@@ -17,6 +17,7 @@ __all__ = [
     "CompleteResult",
     # memory
     "Episode",
+    "RecallMode",
     # skill
     "SkillFrontmatter",
     # tool

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -2,11 +2,20 @@
 
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from .agent import Task, TaskResult
+
+
+class RecallMode(str, Enum):
+    """Retrieval strategy used by ``BaseMemoryStore.search()``."""
+
+    RECENT = "recent"
+    SEARCH = "search"
+
 
 EpisodeAttr = Literal[
     "instruction",

--- a/src/llm_agents_from_scratch/memory_stores/json.py
+++ b/src/llm_agents_from_scratch/memory_stores/json.py
@@ -1,7 +1,7 @@
 """JSONL-file-backed episodic memory store."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import Episode
@@ -23,6 +23,7 @@ class JSONMemoryStore(BaseMemoryStore):
         dir: Path,
         filename: str = "episodes.jsonl",
         max_results: int = 5,
+        recall_mode: Literal["recent", "search"] = "recent",
     ) -> None:
         """Initialize a JSONMemoryStore.
 
@@ -38,8 +39,11 @@ class JSONMemoryStore(BaseMemoryStore):
                 to ``"episodes.jsonl"``.
             max_results (int): Default maximum number of episodes returned
                 by retrieval operations. Defaults to 5.
+            recall_mode (Literal["recent", "search"]): Retrieval strategy
+                used by ``search()``. Defaults to ``"recent"`` since this
+                store does not support similarity search.
         """
-        super().__init__(max_results=max_results)
+        super().__init__(max_results=max_results, recall_mode=recall_mode)
         self.path = dir / filename
         self._episodes: list[Episode] = self._load()
 
@@ -129,16 +133,27 @@ class JSONMemoryStore(BaseMemoryStore):
         query: str,
         **kwargs: Any,
     ) -> list[Episode]:
-        """Not implemented — similarity search is deferred to vector store.
+        """Return episodes according to ``recall_mode``.
+
+        When ``recall_mode="recent"`` (the default), the query is ignored
+        and the most recent episodes are returned via ``read_recent``.
+        ``recall_mode="search"`` raises ``NotImplementedError`` — this store
+        does not support similarity search.
 
         Args:
-            query (str): The search query.
+            query (str): The search query. Ignored when
+                ``recall_mode="recent"``.
             **kwargs: Ignored.
 
+        Returns:
+            list[Episode]: Episodes ordered by recency.
+
         Raises:
-            NotImplementedError: Always. Use a vector-backed store for
-                similarity search.
+            NotImplementedError: When ``recall_mode="search"``. Use a
+                vector-backed store for similarity search.
         """
+        if self.recall_mode == "recent":
+            return await self.read_recent(self.max_results)
         raise NotImplementedError(
             "JSONMemoryStore does not support similarity search. "
             "Use a vector-backed store instead.",

--- a/src/llm_agents_from_scratch/memory_stores/json.py
+++ b/src/llm_agents_from_scratch/memory_stores/json.py
@@ -1,10 +1,10 @@
 """JSONL-file-backed episodic memory store."""
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, RecallMode
 
 
 class JSONMemoryStore(BaseMemoryStore):
@@ -23,7 +23,7 @@ class JSONMemoryStore(BaseMemoryStore):
         dir: Path,
         filename: str = "episodes.jsonl",
         max_results: int = 5,
-        recall_mode: Literal["recent", "search"] = "recent",
+        recall_mode: RecallMode = RecallMode.RECENT,
     ) -> None:
         """Initialize a JSONMemoryStore.
 
@@ -39,9 +39,9 @@ class JSONMemoryStore(BaseMemoryStore):
                 to ``"episodes.jsonl"``.
             max_results (int): Default maximum number of episodes returned
                 by retrieval operations. Defaults to 5.
-            recall_mode (Literal["recent", "search"]): Retrieval strategy
-                used by ``search()``. Defaults to ``"recent"`` since this
-                store does not support similarity search.
+            recall_mode (RecallMode): Retrieval strategy used by
+                ``search()``. Defaults to ``RecallMode.RECENT`` since
+                this store does not support similarity search.
         """
         super().__init__(max_results=max_results, recall_mode=recall_mode)
         self.path = dir / filename
@@ -152,7 +152,7 @@ class JSONMemoryStore(BaseMemoryStore):
             NotImplementedError: When ``recall_mode="search"``. Use a
                 vector-backed store for similarity search.
         """
-        if self.recall_mode == "recent":
+        if self.recall_mode == RecallMode.RECENT:
             return await self.read_recent(self.max_results)
         raise NotImplementedError(
             "JSONMemoryStore does not support similarity search. "

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -1,6 +1,6 @@
 """Qdrant-backed episodic memory store."""
 
-from typing import Any
+from typing import Any, Literal
 
 from qdrant_client import QdrantClient, models
 
@@ -43,6 +43,7 @@ class QdrantMemoryStore(BaseMemoryStore):
         embedding_model: str = "BAAI/bge-small-en-v1.5",
         client: QdrantClient | None = None,
         max_results: int = 5,
+        recall_mode: Literal["recent", "search"] = "search",
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
@@ -62,8 +63,10 @@ class QdrantMemoryStore(BaseMemoryStore):
                 client must use FastEmbed as its embedding backend.
             max_results (int): Default maximum number of episodes
                 returned by ``search``. Defaults to 5.
+            recall_mode (Literal["recent", "search"]): Retrieval strategy
+                used by ``search()``. Defaults to ``"search"``.
         """
-        super().__init__(max_results=max_results)
+        super().__init__(max_results=max_results, recall_mode=recall_mode)
         self._client = client or QdrantClient(":memory:")
         self._client.set_model(embedding_model)
         self._collection = collection_name
@@ -187,22 +190,27 @@ class QdrantMemoryStore(BaseMemoryStore):
         query: str,
         **kwargs: Any,
     ) -> list[Episode]:
-        """Return the most semantically similar episodes for a query.
+        """Return episodes according to ``recall_mode``.
 
-        Embeds the query using the same FastEmbed model used at write
-        time and retrieves the top ``max_results`` points by cosine
-        similarity.
+        When ``recall_mode="recent"``, the query is ignored and the most
+        recent episodes are returned via ``read_recent``. When
+        ``recall_mode="search"`` (the default), the top ``max_results``
+        episodes most semantically similar to the query are returned.
 
         Args:
             query (str): The search query (e.g. the task instruction).
+                Ignored when ``recall_mode="recent"``.
             **kwargs: Additional keyword arguments forwarded to
-                ``QdrantClient.query_points()`` (e.g. ``query_filter``,
+                ``QdrantClient.query_points()`` when
+                ``recall_mode="search"`` (e.g. ``query_filter``,
                 ``score_threshold``).
 
         Returns:
-            list[Episode]: Episodes ordered by cosine similarity to the
-                query.
+            list[Episode]: Episodes ordered by recency or cosine
+                similarity depending on ``recall_mode``.
         """
+        if self.recall_mode == "recent":
+            return await self.read_recent(self.max_results)
         results = self._client.query_points(
             collection_name=self._collection,
             query=models.Document(

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -1,11 +1,15 @@
 """Qdrant-backed episodic memory store."""
 
-from typing import Any, Literal
+from typing import Any
 
 from qdrant_client import QdrantClient, models
 
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
-from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeAttr
+from llm_agents_from_scratch.data_structures.memory import (
+    Episode,
+    EpisodeAttr,
+    RecallMode,
+)
 from llm_agents_from_scratch.memory_stores.qdrant.utils import (
     episode_to_qdrant_point_struct,
 )
@@ -43,7 +47,7 @@ class QdrantMemoryStore(BaseMemoryStore):
         embedding_model: str = "BAAI/bge-small-en-v1.5",
         client: QdrantClient | None = None,
         max_results: int = 5,
-        recall_mode: Literal["recent", "search"] = "search",
+        recall_mode: RecallMode = RecallMode.SEARCH,
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
@@ -63,8 +67,8 @@ class QdrantMemoryStore(BaseMemoryStore):
                 client must use FastEmbed as its embedding backend.
             max_results (int): Default maximum number of episodes
                 returned by ``search``. Defaults to 5.
-            recall_mode (Literal["recent", "search"]): Retrieval strategy
-                used by ``search()``. Defaults to ``"search"``.
+            recall_mode (RecallMode): Retrieval strategy used by
+                ``search()``. Defaults to ``RecallMode.SEARCH``.
         """
         super().__init__(max_results=max_results, recall_mode=recall_mode)
         self._client = client or QdrantClient(":memory:")
@@ -209,7 +213,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             list[Episode]: Episodes ordered by recency or cosine
                 similarity depending on ``recall_mode``.
         """
-        if self.recall_mode == "recent":
+        if self.recall_mode == RecallMode.RECENT:
             return await self.read_recent(self.max_results)
         results = self._client.query_points(
             collection_name=self._collection,

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -121,12 +121,30 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
 
 
 @pytest.mark.asyncio
-async def test_search_raises_not_implemented(tmp_path: Path) -> None:
-    """Tests search raises NotImplementedError."""
-    store = JSONMemoryStore(dir=tmp_path)
+async def test_search_returns_recent_by_default(tmp_path: Path) -> None:
+    """Tests search delegates to read_recent when recall_mode='recent'."""
+    store = JSONMemoryStore(dir=tmp_path, max_results=2)
+    ep1 = make_episode("first")
+    ep2 = make_episode("second")
+    ep3 = make_episode("third")
+    await store.write(ep1)
+    await store.write(ep2)
+    await store.write(ep3)
+
+    results = await store.search("ignored query")
+
+    assert len(results) == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_search_raises_not_implemented_when_search_mode(
+    tmp_path: Path,
+) -> None:
+    """Tests search raises NotImplementedError when recall_mode='search'."""
+    store = JSONMemoryStore(dir=tmp_path, recall_mode="search")
 
     with pytest.raises(NotImplementedError):
-        await store.search("query", k=3)
+        await store.search("query")
 
 
 @pytest.mark.asyncio

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from llm_agents_from_scratch.data_structures import Task, TaskResult
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, RecallMode
 from llm_agents_from_scratch.memory import JSONMemoryStore
 
 
@@ -141,7 +141,7 @@ async def test_search_raises_not_implemented_when_search_mode(
     tmp_path: Path,
 ) -> None:
     """Tests search raises NotImplementedError when recall_mode='search'."""
-    store = JSONMemoryStore(dir=tmp_path, recall_mode="search")
+    store = JSONMemoryStore(dir=tmp_path, recall_mode=RecallMode.SEARCH)
 
     with pytest.raises(NotImplementedError):
         await store.search("query")

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -5,7 +5,7 @@ import pytest
 from qdrant_client import QdrantClient
 
 from llm_agents_from_scratch.data_structures import Task, TaskResult
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, RecallMode
 from llm_agents_from_scratch.memory_stores.qdrant.store import QdrantMemoryStore
 
 
@@ -212,6 +212,26 @@ async def test_search_empty(mock_client: MagicMock) -> None:
     store = QdrantMemoryStore()
     results = await store.search("anything")
     assert results == []
+
+
+async def test_search_uses_read_recent_when_recall_mode_recent(
+    mock_client: MagicMock,
+    episode: Episode,
+) -> None:
+    mock_client.count.return_value.count = 1
+    mock_point = MagicMock()
+    mock_point.payload = {
+        "episode_json": episode.model_dump_json(),
+        "completed_at": episode.completed_at.timestamp(),
+    }
+    mock_client.scroll.return_value = ([mock_point], None)
+
+    store = QdrantMemoryStore(recall_mode=RecallMode.RECENT, max_results=5)
+    results = await store.search("ignored query")
+
+    mock_client.query_points.assert_not_called()
+    assert len(results) == 1
+    assert results[0].id_ == episode.id_
 
 
 async def test_summary_empty(mock_client: MagicMock) -> None:


### PR DESCRIPTION
Closes #589

## Summary
- Add `recall_mode: Literal["recent", "search"]` to `BaseMemoryStore.__init__`
- `search()` branches on `self.recall_mode` internally — `Memory.recall()` stays unchanged, always calling `store.search(task.instruction)`
- `JSONMemoryStore` defaults to `recall_mode="recent"`; `search()` delegates to `read_recent()` instead of raising `NotImplementedError`
- `QdrantMemoryStore` defaults to `recall_mode="search"`; existing vector lookup behaviour unchanged but also supports `recall_mode="recent"`

## Test plan
- [ ] `pytest tests/` — 300 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)