### PR TITLE
fix: update docs for memory_stores/ restructure and add ch07 symlinks

### DIFF
--- a/docs/api_reference/memory/json_store.md
+++ b/docs/api_reference/memory/json_store.md
@@ -1,3 +1,3 @@
 # JSONMemoryStore
 
-::: llm_agents_from_scratch.memory.json_store
+::: llm_agents_from_scratch.memory_stores.json

--- a/docs/api_reference/memory/qdrant_store.md
+++ b/docs/api_reference/memory/qdrant_store.md
@@ -1,3 +1,3 @@
 # QdrantMemoryStore
 
-::: llm_agents_from_scratch.memory.qdrant_store
+::: llm_agents_from_scratch.memory_stores.qdrant.store

--- a/docs/more-examples/ch07/recency_memory.ipynb
+++ b/docs/more-examples/ch07/recency_memory.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch07/recency_memory.ipynb

--- a/docs/more-examples/ch07/similarity_memory.ipynb
+++ b/docs/more-examples/ch07/similarity_memory.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch07/similarity_memory.ipynb


### PR DESCRIPTION
## Summary
- Fix `ERROR: mkdocstrings could not find llm_agents_from_scratch.memory.json_store` — update API reference to new module paths (`memory_stores.json`, `memory_stores.qdrant.store`)
- Fix missing ch07 notebook warnings — add `docs/more-examples/ch07/` symlinks for `recency_memory.ipynb` and `similarity_memory.ipynb`

## Test plan
- [ ] `uv run --group docs mkdocs build` — builds cleanly with no ERRORs or notebook warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)