### PR TITLE
chore: migrate recency_memory.ipynb to recency_memory() factory (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: add `Memory.summary()` delegating to `store.summary()` (#595)
+- chore: migrate `more-examples/ch07/recency_memory.ipynb` to use `recency_memory()` factory (#595)
 - feat: add `memory/recipes.py` with `RecencyMemory`, `SimilarityMemory`, `ReflectiveMemory` factory functions (#593)
 - feat: `Memory.key_fn` is now optional, defaulting to `lambda ep: ep.task.instruction` (#593)
 - feat: add `recall_mode` (`RecallMode` enum) to `BaseMemoryStore` — `RecallMode.RECENT` delegates `search()` to `read_recent()`; `RecallMode.SEARCH` performs similarity lookup (#590)

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "38d01453b7654a53bcd8741072c0e275",
    "metadata": {},
    "outputs": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "d7ce6abee05845d094ec30c32274f27f",
    "metadata": {},
    "outputs": [],
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "e1205db265d24c4d86fe43c1b91d00a5",
    "metadata": {},
    "outputs": [],
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "c566c45c76b0465a855130ecfd7e6946",
    "metadata": {},
    "outputs": [],
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "3fd32b727c05411585f17b526a901dff",
    "metadata": {},
    "outputs": [],
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "f2f317d9468c403d9d1cf49d6f0752eb",
    "metadata": {},
    "outputs": [
@@ -253,9 +253,9 @@
      "text": [
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Pikachu\" to retrieve its base stats.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its base stats.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Pikachu are as follows:\n",
@@ -296,19 +296,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "5f1cfe1ed942475ba02c18b420560fae",
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'Memory' object has no attribute 'summary'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m print(\u001b[38;5;28;01mawait\u001b[39;00m agent.memories[\u001b[32m0\u001b[39m].summary())\n",
-      "\u001b[31mAttributeError\u001b[39m: 'Memory' object has no attribute 'summary'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JSONMemoryStore: 1 episodes | path=episodes.jsonl\n",
+      "  newest: 2026-06-03 00:05:34 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n",
+      "  oldest: 2026-06-03 00:05:34 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
    ],
@@ -328,9 +326,9 @@
      "text": [
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Gengar\".\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Gengar\" to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Gengar' to retrieve its base stats.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Gengar are as follows:\n",
@@ -379,10 +377,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RecencyMemory (recall last 3):\n",
       "JSONMemoryStore: 2 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:25:43 | What are Gengar's base stats? Use the get_pokemon tool. Do n\n",
-      "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
+      "  newest: 2026-06-03 00:06:33 | What are Gengar's base stats? Use the get_pokemon tool. Do n\n",
+      "  oldest: 2026-06-03 00:05:34 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
    ],
@@ -402,6 +399,9 @@
      "text": [
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Mewtwo\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Mewtwo'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Mewtwo'.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Mewtwo are as follows:\n",
@@ -450,10 +450,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RecencyMemory (recall last 3):\n",
       "JSONMemoryStore: 3 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:26:18 | What are Mewtwo's base stats? Use the get_pokemon tool. Do n\n",
-      "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
+      "  newest: 2026-06-03 00:07:14 | What are Mewtwo's base stats? Use the get_pokemon tool. Do n\n",
+      "  oldest: 2026-06-03 00:05:34 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
    ],
@@ -489,15 +488,15 @@
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched:\n",
       "\n",
-      "- **Mewtwo** has a base speed of 130.\n",
-      "- **Gengar** has a base speed of 110.\n",
-      "- **Pikachu** has a ba...[TRUNCATED]\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed of ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
       "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched:\n",
       "\n",
-      "- **Mewtwo** has a base speed of 130.\n",
-      "- **Gengar** has a base speed of 110.\n",
-      "- **Pikachu** has a...[TRUNCATED]\n"
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed ...[TRUNCATED]\n"
      ]
     }
    ],
@@ -524,11 +523,11 @@
      "text": [
       "From the Pokémon I have researched:\n",
       "\n",
-      "- **Mewtwo** has a base speed of 130.\n",
-      "- **Gengar** has a base speed of 110.\n",
-      "- **Pikachu** has a base speed of 90.\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed of 90.\n",
       "\n",
-      "Among these, **Mewtwo** has the highest base speed of **130**.\n"
+      "Mewtwo has the highest base speed among the researched Pokémon.\n"
      ]
     }
    ],
@@ -570,7 +569,7 @@
       "- Special Defense: 50\n",
       "- Speed: 90\n",
       "    </result>\n",
-      "    <completed_at>2026-05-18 22:25:18</completed_at>\n",
+      "    <completed_at>2026-06-03 00:05:34</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
@@ -583,7 +582,7 @@
       "- Special Defense: 75\n",
       "- Speed: 110\n",
       "    </result>\n",
-      "    <completed_at>2026-05-18 22:25:43</completed_at>\n",
+      "    <completed_at>2026-06-03 00:06:33</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
@@ -596,20 +595,20 @@
       "- Special Defense: 90\n",
       "- Speed: 130\n",
       "    </result>\n",
-      "    <completed_at>2026-05-18 22:26:18</completed_at>\n",
+      "    <completed_at>2026-06-03 00:07:14</completed_at>\n",
       "  </episode>\n",
       "\n",
       "  <episode>\n",
       "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
       "    <result>From the Pokémon I have researched:\n",
       "\n",
-      "- **Mewtwo** has a base speed of 130.\n",
-      "- **Gengar** has a base speed of 110.\n",
-      "- **Pikachu** has a base speed of 90.\n",
+      "- Mewtwo has a base speed of 130.\n",
+      "- Gengar has a base speed of 110.\n",
+      "- Pikachu has a base speed of 90.\n",
       "\n",
-      "Among these, **Mewtwo** has the highest base speed of **130**.\n",
+      "Mewtwo has the highest base speed among the researched Pokémon.\n",
       "    </result>\n",
-      "    <completed_at>2026-05-18 22:26:32</completed_at>\n",
+      "    <completed_at>2026-06-03 00:07:30</completed_at>\n",
       "  </episode>\n",
       "\n"
      ]
@@ -659,10 +658,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RecencyMemory (recall last 3):\n",
       "JSONMemoryStore: 4 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:26:32 | Based on the Pokémon you have already researched, which one \n",
-      "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
+      "  newest: 2026-06-03 00:07:30 | Based on the Pokémon you have already researched, which one \n",
+      "  oldest: 2026-06-03 00:05:34 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
    ],
@@ -682,21 +680,9 @@
      "text": [
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched the following Pokémon:\n",
-      "\n",
-      "- **Mewtwo**\n",
-      "- **Gengar**\n",
-      "- **Pikachu**\n",
-      "\n",
-      "Among these, **Mewtwo** had the highest b...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130.\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched the following Pokémon:\n",
-      "\n",
-      "- **Mewtwo**\n",
-      "- **Gengar**\n",
-      "- **Pikachu**\n",
-      "\n",
-      "Among these, **Mewtwo** had the highes...[TRUNCATED]\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130...[TRUNCATED]\n"
      ]
     }
    ],
@@ -721,13 +707,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I have previously researched the following Pokémon:\n",
-      "\n",
-      "- **Mewtwo**\n",
-      "- **Gengar**\n",
-      "- **Pikachu**\n",
-      "\n",
-      "Among these, **Mewtwo** had the highest base speed of **130**.\n"
+      "I have previously researched Mewtwo, Gengar, and Pikachu. Among these Pokémon, Mewtwo has the highest base speed with a value of 130.\n"
      ]
     }
    ],

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -4,25 +4,7 @@
    "cell_type": "markdown",
    "id": "e3fac0284bf040c785cee3d5d3b5bec1",
    "metadata": {},
-   "source": [
-    "# Episodic Memory — Research Accumulation and Persistence\n",
-    "\n",
-    "This notebook demonstrates `RecencyMemory` and `JSONMemoryStore` working together\n",
-    "to give an `LLMAgent` episodic memory that accumulates across tasks and survives\n",
-    "agent restarts.\n",
-    "\n",
-    "Two properties are illustrated:\n",
-    "\n",
-    "- **Recall across tasks.** After each task the agent records an episode.\n",
-    "  Subsequent tasks receive the most recent `n` episodes injected into their system\n",
-    "  prompt, so the agent can answer synthesis questions without repeating tool calls.\n",
-    "- **Persistence across restarts.** `JSONMemoryStore` writes episodes to a JSONL\n",
-    "  file on disk. A brand-new agent instance pointing to the same file picks up all\n",
-    "  prior episodes immediately.\n",
-    "\n",
-    "> **This notebook uses the same PokéAPI tool as `ch04/pokemon_comparison.ipynb`.**\n",
-    "> Reading that notebook first is recommended."
-   ]
+   "source": "# Episodic Memory \u2014 Research Accumulation and Persistence\n\nThis notebook demonstrates the `recency_memory()` factory, which gives an\n`LLMAgent` episodic memory that accumulates across tasks and survives agent\nrestarts.\n\nTwo properties are illustrated:\n\n- **Recall across tasks.** After each task the agent records an episode.\n  Subsequent tasks receive the most recent `max_results` episodes injected\n  into their system prompt, so the agent can answer synthesis questions\n  without repeating tool calls.\n- **Persistence across restarts.** Episodes are written to a JSONL file on\n  disk. A brand-new agent instance pointing to the same file picks up all\n  prior episodes immediately.\n\n> **This notebook uses the same Pok\u00e9API tool as `ch04/pokemon_comparison.ipynb`.**\n> Reading that notebook first is recommended."
   },
   {
    "cell_type": "code",
@@ -61,7 +43,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Ollama already running at http://localhost:11434\n"
+      "\u2713 Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -85,7 +67,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -114,7 +96,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -129,23 +111,7 @@
    "id": "d7ce6abee05845d094ec30c32274f27f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import logging\n",
-    "import urllib.error\n",
-    "import urllib.request\n",
-    "from pathlib import Path\n",
-    "\n",
-    "from llm_agents_from_scratch import LLMAgent\n",
-    "from llm_agents_from_scratch.data_structures import Task\n",
-    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
-    "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch.logger import enable_console_logging\n",
-    "from llm_agents_from_scratch.memory import JSONMemoryStore, RecencyMemory\n",
-    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
-    "\n",
-    "enable_console_logging(logging.INFO)"
-   ]
+   "source": "import json\nimport logging\nimport urllib.error\nimport urllib.request\nfrom pathlib import Path\n\nfrom llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.logger import enable_console_logging\nfrom llm_agents_from_scratch.memory.recipes import recency_memory\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\nenable_console_logging(logging.INFO)"
   },
   {
    "cell_type": "markdown",
@@ -163,7 +129,7 @@
    "outputs": [],
    "source": [
     "def get_pokemon(name: str) -> str:\n",
-    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
+    "    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n",
     "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
     "    req = urllib.request.Request(\n",
     "        url,\n",
@@ -175,7 +141,7 @@
     "    except urllib.error.HTTPError as e:\n",
     "        if e.code == 404:  # noqa: PLR2004\n",
     "            raise ValueError(\n",
-    "                f\"Pokémon '{name}' not found. \"\n",
+    "                f\"Pok\u00e9mon '{name}' not found. \"\n",
     "                \"Check the spelling and try again.\",\n",
     "            ) from e\n",
     "        raise\n",
@@ -205,15 +171,7 @@
    "cell_type": "markdown",
    "id": "b0358fe6d0724395a61f5ef940f9e47e",
    "metadata": {},
-   "source": [
-    "## Creating the Agent with Memory\n",
-    "\n",
-    "`JSONMemoryStore` manages the JSONL file at `STORE_PATH`. `RecencyMemory` wraps\n",
-    "the store and decides what to recall (the `n` most recent episodes) and how to\n",
-    "format the result for the system prompt. The agent holds the memory in its\n",
-    "`memories` list. `TaskHandler` calls `recall` at task start and `record` at\n",
-    "task end automatically."
-   ]
+   "source": "## Creating the Agent with Memory\n\n`recency_memory()` returns a `Memory` instance backed by a JSONL file at\n`STORE_DIR`. It recalls the `max_results` most recent episodes and formats\nthem for the system prompt. The agent holds the memory in its `memories`\nlist; `TaskHandler` calls `recall` at task start and `record` at task end\nautomatically."
   },
   {
    "cell_type": "code",
@@ -221,21 +179,16 @@
    "id": "3fd32b727c05411585f17b526a901dff",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "store = JSONMemoryStore(dir=STORE_DIR)\n",
-    "memory = RecencyMemory(store=store, n=3)\n",
-    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
-   ]
+   "source": "memory = recency_memory(path=STORE_DIR, max_results=3)\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
   },
   {
    "cell_type": "markdown",
    "id": "6c9d5b00b35d4f9cbba5866815f631d1",
    "metadata": {},
    "source": [
-    "## Part 1 — Building Up Episodic Memory\n",
+    "## Part 1 \u2014 Building Up Episodic Memory\n",
     "\n",
-    "Three sequential Pokémon lookups. Each task calls `get_pokemon` once and records\n",
+    "Three sequential Pok\u00e9mon lookups. Each task calls `get_pokemon` once and records\n",
     "an episode at the end. The memory summary after each task shows the store count\n",
     "growing from 0 to 3. By the time the fourth task runs, all three episodes\n",
     "will be recalled into its system prompt."
@@ -251,14 +204,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Pikachu are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Pikachu are as follows:\n",
       "- HP: 35\n",
       "- Attack: 55\n",
       "- Defense: 40\n",
@@ -266,7 +219,7 @@
       "- Special Defense: 50\n",
       "- Speed: 90\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Pikachu are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Pikachu are as follows:\n",
       "- HP: 35\n",
       "- Attack: 55\n",
       "- Defense: 40\n",
@@ -325,14 +278,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Gengar\".\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Gengar are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Gengar\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Gengar are as follows:\n",
       "- HP: 60\n",
       "- Attack: 65\n",
       "- Defense: 60\n",
@@ -340,7 +293,7 @@
       "- Special Defense: 75\n",
       "- Speed: 110\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Gengar are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Gengar are as follows:\n",
       "- HP: 60\n",
       "- Attack: 65\n",
       "- Defense: 60\n",
@@ -399,11 +352,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Mewtwo are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Mewtwo are as follows:\n",
       "- HP: 106\n",
       "- Attack: 110\n",
       "- Defense: 90\n",
@@ -411,7 +364,7 @@
       "- Special Defense: 90\n",
       "- Speed: 13...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Mewtwo are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Mewtwo are as follows:\n",
       "- HP: 106\n",
       "- Attack: 110\n",
       "- Defense: 90\n",
@@ -465,13 +418,13 @@
    "id": "8717d47fe7984d46bdc7955c97bf8d07",
    "metadata": {},
    "source": [
-    "## Part 2 — Synthesis from Recalled Episodes\n",
+    "## Part 2 \u2014 Synthesis from Recalled Episodes\n",
     "\n",
-    "The synthesis task asks the agent to compare all three Pokémon by speed. No stats\n",
+    "The synthesis task asks the agent to compare all three Pok\u00e9mon by speed. No stats\n",
     "are provided in the task instruction. The information is only available through\n",
     "the recalled episodes injected into the system prompt at the start of this run.\n",
     "A working memory means the agent can answer without calling `get_pokemon` again.\n",
-    "Watch the logs: you should see no `🛠️ Executing Tool Call` lines."
+    "Watch the logs: you should see no `\ud83d\udee0\ufe0f Executing Tool Call` lines."
    ]
   },
   {
@@ -484,15 +437,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: From the Pok\u00e9mon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
       "- **Pikachu** has a ba...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: From the Pok\u00e9mon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -503,7 +456,7 @@
    "source": [
     "task4 = Task(\n",
     "    instruction=(\n",
-    "        \"Based on the Pokémon you have already researched, \"\n",
+    "        \"Based on the Pok\u00e9mon you have already researched, \"\n",
     "        \"which one has the highest base speed? \"\n",
     "        \"You do not need to call any tools. Use only what you already know.\"\n",
     "    ),\n",
@@ -521,7 +474,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "From the Pokémon I have researched:\n",
+      "From the Pok\u00e9mon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -540,7 +493,7 @@
    "id": "c9db20072dc646118615b9215fb1ebc2",
    "metadata": {},
    "source": [
-    "## Part 3 — Inspecting the Store on Disk\n",
+    "## Part 3 \u2014 Inspecting the Store on Disk\n",
     "\n",
     "`JSONMemoryStore` writes one JSON line per episode. The cell below reads the raw\n",
     "file so you can see exactly what is persisted between tasks and what a new\n",
@@ -599,8 +552,8 @@
       "  </episode>\n",
       "\n",
       "  <episode>\n",
-      "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
-      "    <result>From the Pokémon I have researched:\n",
+      "    <task>Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
+      "    <result>From the Pok\u00e9mon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -628,7 +581,7 @@
    "id": "0485777aabcf4c64aece2a9ba10b57a5",
    "metadata": {},
    "source": [
-    "## Part 4 — Persistence Across Agent Restarts\n",
+    "## Part 4 \u2014 Persistence Across Agent Restarts\n",
     "\n",
     "A fresh `LLMAgent` is created pointing at the same `STORE_PATH`. No state is\n",
     "shared with the previous instance. The new agent loads its episodes entirely\n",
@@ -642,12 +595,7 @@
    "id": "cc17f94c55c64a979f54336e521243a2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "store2 = JSONMemoryStore(dir=STORE_DIR)\n",
-    "memory2 = RecencyMemory(store=store2, n=3)\n",
-    "llm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "agent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"
-   ]
+   "source": "memory2 = recency_memory(path=STORE_DIR, max_results=3)\nllm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"
   },
   {
    "cell_type": "code",
@@ -661,7 +609,7 @@
      "text": [
       "RecencyMemory (recall last 3):\n",
       "JSONMemoryStore: 4 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:26:32 | Based on the Pokémon you have already researched, which one \n",
+      "  newest: 2026-05-18 22:26:32 | Based on the Pok\u00e9mon you have already researched, which one \n",
       "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
@@ -680,9 +628,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched the following Pokémon:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Which Pok\u00e9mon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Which Pok\u00e9mon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I have previously researched the following Pok\u00e9mon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -690,7 +638,7 @@
       "\n",
       "Among these, **Mewtwo** had the highest b...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched the following Pokémon:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I have previously researched the following Pok\u00e9mon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -703,7 +651,7 @@
    "source": [
     "task5 = Task(\n",
     "    instruction=(\n",
-    "        \"Which Pokémon have you previously researched, and which one had \"\n",
+    "        \"Which Pok\u00e9mon have you previously researched, and which one had \"\n",
     "        \"the highest base speed? \"\n",
     "        \"You do not need to call any tools. Use only what you already know.\"\n",
     "    ),\n",
@@ -721,7 +669,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I have previously researched the following Pokémon:\n",
+      "I have previously researched the following Pok\u00e9mon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -739,25 +687,7 @@
    "cell_type": "markdown",
    "id": "b2cf38070c7e490d8edbe2bb16fd9731",
    "metadata": {},
-   "source": [
-    "## Key Takeaway\n",
-    "\n",
-    "`RecencyMemory` and `JSONMemoryStore` give the agent two things it would otherwise\n",
-    "lack:\n",
-    "\n",
-    "- **Context across tasks.** Every task after the first starts with the N most\n",
-    "  recent episodes injected into its system prompt. The agent can synthesise across\n",
-    "  past work without repeating tool calls (see Part 2 and Part 4).\n",
-    "- **Persistence across restarts.** Because `JSONMemoryStore` writes each episode\n",
-    "  to disk immediately, any new agent pointing at the same file resumes with full\n",
-    "  context. Nothing is lost when the process ends.\n",
-    "\n",
-    "The two roles are cleanly separated: `RecencyMemory` decides *what* to retrieve\n",
-    "and *how* to format it for the prompt; `JSONMemoryStore` decides *how* to persist\n",
-    "it. Swapping one does not affect the other: the same `RecencyMemory` works over\n",
-    "any `BaseMemoryStore` implementation, and the same `JSONMemoryStore` works with\n",
-    "any `BaseMemory` implementation."
-   ]
+   "source": "## Key Takeaway\n\n`recency_memory()` gives the agent two things it would otherwise lack:\n\n- **Context across tasks.** Every task after the first starts with the\n  `max_results` most recent episodes injected into its system prompt. The\n  agent can synthesise across past work without repeating tool calls (see\n  Part 2 and Part 4).\n- **Persistence across restarts.** Episodes are written to a JSONL file\n  immediately after each task. Any new agent pointing at the same path\n  resumes with full context \u2014 nothing is lost when the process ends.\n\nThe factory bundles the two layers that deliver these properties: a\nrecency-based recall strategy that selects the N most recent episodes, and\na file-backed store that handles persistence. Both are configured through\nthe factory \u2014 `path` sets the storage directory; `max_results` controls\nthe recall window."
   }
  ],
  "metadata": {

--- a/more-examples/ch07/recency_memory.ipynb
+++ b/more-examples/ch07/recency_memory.ipynb
@@ -4,7 +4,26 @@
    "cell_type": "markdown",
    "id": "e3fac0284bf040c785cee3d5d3b5bec1",
    "metadata": {},
-   "source": "# Episodic Memory \u2014 Research Accumulation and Persistence\n\nThis notebook demonstrates the `recency_memory()` factory, which gives an\n`LLMAgent` episodic memory that accumulates across tasks and survives agent\nrestarts.\n\nTwo properties are illustrated:\n\n- **Recall across tasks.** After each task the agent records an episode.\n  Subsequent tasks receive the most recent `max_results` episodes injected\n  into their system prompt, so the agent can answer synthesis questions\n  without repeating tool calls.\n- **Persistence across restarts.** Episodes are written to a JSONL file on\n  disk. A brand-new agent instance pointing to the same file picks up all\n  prior episodes immediately.\n\n> **This notebook uses the same Pok\u00e9API tool as `ch04/pokemon_comparison.ipynb`.**\n> Reading that notebook first is recommended."
+   "source": [
+    "# Episodic Memory — Research Accumulation and Persistence\n",
+    "\n",
+    "This notebook demonstrates the `recency_memory()` factory, which gives an\n",
+    "`LLMAgent` episodic memory that accumulates across tasks and survives agent\n",
+    "restarts.\n",
+    "\n",
+    "Two properties are illustrated:\n",
+    "\n",
+    "- **Recall across tasks.** After each task the agent records an episode.\n",
+    "  Subsequent tasks receive the most recent `max_results` episodes injected\n",
+    "  into their system prompt, so the agent can answer synthesis questions\n",
+    "  without repeating tool calls.\n",
+    "- **Persistence across restarts.** Episodes are written to a JSONL file on\n",
+    "  disk. A brand-new agent instance pointing to the same file picks up all\n",
+    "  prior episodes immediately.\n",
+    "\n",
+    "> **This notebook uses the same PokéAPI tool as `ch04/pokemon_comparison.ipynb`.**\n",
+    "> Reading that notebook first is recommended."
+   ]
   },
   {
    "cell_type": "code",
@@ -35,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "38d01453b7654a53bcd8741072c0e275",
    "metadata": {},
    "outputs": [
@@ -43,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2713 Ollama already running at http://localhost:11434\n"
+      "✓ Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -67,7 +86,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -96,7 +115,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -107,11 +126,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "d7ce6abee05845d094ec30c32274f27f",
    "metadata": {},
    "outputs": [],
-   "source": "import json\nimport logging\nimport urllib.error\nimport urllib.request\nfrom pathlib import Path\n\nfrom llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.logger import enable_console_logging\nfrom llm_agents_from_scratch.memory.recipes import recency_memory\nfrom llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n\nenable_console_logging(logging.INFO)"
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.memory.recipes import recency_memory\n",
+    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -123,13 +158,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "e1205db265d24c4d86fe43c1b91d00a5",
    "metadata": {},
    "outputs": [],
    "source": [
     "def get_pokemon(name: str) -> str:\n",
-    "    \"\"\"Look up a Pok\u00e9mon by name and return its types and base stats.\"\"\"\n",
+    "    \"\"\"Look up a Pokémon by name and return its types and base stats.\"\"\"\n",
     "    url = f\"https://pokeapi.co/api/v2/pokemon/{name.lower().strip()}\"\n",
     "    req = urllib.request.Request(\n",
     "        url,\n",
@@ -141,7 +176,7 @@
     "    except urllib.error.HTTPError as e:\n",
     "        if e.code == 404:  # noqa: PLR2004\n",
     "            raise ValueError(\n",
-    "                f\"Pok\u00e9mon '{name}' not found. \"\n",
+    "                f\"Pokémon '{name}' not found. \"\n",
     "                \"Check the spelling and try again.\",\n",
     "            ) from e\n",
     "        raise\n",
@@ -155,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "c566c45c76b0465a855130ecfd7e6946",
    "metadata": {},
    "outputs": [],
@@ -171,24 +206,36 @@
    "cell_type": "markdown",
    "id": "b0358fe6d0724395a61f5ef940f9e47e",
    "metadata": {},
-   "source": "## Creating the Agent with Memory\n\n`recency_memory()` returns a `Memory` instance backed by a JSONL file at\n`STORE_DIR`. It recalls the `max_results` most recent episodes and formats\nthem for the system prompt. The agent holds the memory in its `memories`\nlist; `TaskHandler` calls `recall` at task start and `record` at task end\nautomatically."
+   "source": [
+    "## Creating the Agent with Memory\n",
+    "\n",
+    "`recency_memory()` returns a `Memory` instance backed by a JSONL file at\n",
+    "`STORE_DIR`. It recalls the `max_results` most recent episodes and formats\n",
+    "them for the system prompt. The agent holds the memory in its `memories`\n",
+    "list; `TaskHandler` calls `recall` at task start and `record` at task end\n",
+    "automatically."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "3fd32b727c05411585f17b526a901dff",
    "metadata": {},
    "outputs": [],
-   "source": "memory = recency_memory(path=STORE_DIR, max_results=3)\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
+   "source": [
+    "memory = recency_memory(path=STORE_DIR, max_results=3)\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[get_pokemon_tool], memories=[memory])"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6c9d5b00b35d4f9cbba5866815f631d1",
    "metadata": {},
    "source": [
-    "## Part 1 \u2014 Building Up Episodic Memory\n",
+    "## Part 1 — Building Up Episodic Memory\n",
     "\n",
-    "Three sequential Pok\u00e9mon lookups. Each task calls `get_pokemon` once and records\n",
+    "Three sequential Pokémon lookups. Each task calls `get_pokemon` once and records\n",
     "an episode at the end. The memory summary after each task shows the store count\n",
     "growing from 0 to 3. By the time the fourth task runs, all three episodes\n",
     "will be recalled into its system prompt."
@@ -196,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "f2f317d9468c403d9d1cf49d6f0752eb",
    "metadata": {},
    "outputs": [
@@ -204,14 +251,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Pikachu\".\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Pikachu'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Pikachu are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Pikachu's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the name \"Pikachu\" to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the name 'Pikachu' to retrieve its base stats.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"pikachu\", \"types\": [\"electric\"], \"stats\": {\"hp\": 35, \"attack\": 55, \"defense\": 40, \"special-attack\": 50, \"special-def...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Pikachu are as follows:\n",
       "- HP: 35\n",
       "- Attack: 55\n",
       "- Defense: 40\n",
@@ -219,7 +266,7 @@
       "- Special Defense: 50\n",
       "- Speed: 90\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Pikachu are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Pikachu are as follows:\n",
       "- HP: 35\n",
       "- Attack: 55\n",
       "- Defense: 40\n",
@@ -249,18 +296,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "5f1cfe1ed942475ba02c18b420560fae",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RecencyMemory (recall last 3):\n",
-      "JSONMemoryStore: 1 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n",
-      "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
+     "ename": "AttributeError",
+     "evalue": "'Memory' object has no attribute 'summary'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m print(\u001b[38;5;28;01mawait\u001b[39;00m agent.memories[\u001b[32m0\u001b[39m].summary())\n",
+      "\u001b[31mAttributeError\u001b[39m: 'Memory' object has no attribute 'summary'"
      ]
     }
    ],
@@ -278,14 +326,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Gengar\".\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Gengar are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Gengar's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the get_pokemon tool with the parameter \"name\" set to \"Gengar\".\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the get_pokemon tool with the parameter 'name' set to 'Gengar'.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"gengar\", \"types\": [\"ghost\", \"poison\"], \"stats\": {\"hp\": 60, \"attack\": 65, \"defense\": 60, \"special-attack\": 130, \"spec...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Gengar are as follows:\n",
       "- HP: 60\n",
       "- Attack: 65\n",
       "- Defense: 60\n",
@@ -293,7 +341,7 @@
       "- Special Defense: 75\n",
       "- Speed: 110\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Gengar are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Gengar are as follows:\n",
       "- HP: 60\n",
       "- Attack: 65\n",
       "- Defense: 60\n",
@@ -352,11 +400,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: get_pokemon\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The base stats for Mewtwo are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What are Mewtwo's base stats? Use the get_pokemon tool. Do not rely on prior knowledge.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: get_pokemon\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\"name\": \"mewtwo\", \"types\": [\"psychic\"], \"stats\": {\"hp\": 106, \"attack\": 110, \"defense\": 90, \"special-attack\": 154, \"special-de...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The base stats for Mewtwo are as follows:\n",
       "- HP: 106\n",
       "- Attack: 110\n",
       "- Defense: 90\n",
@@ -364,7 +412,7 @@
       "- Special Defense: 90\n",
       "- Speed: 13...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The base stats for Mewtwo are as follows:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The base stats for Mewtwo are as follows:\n",
       "- HP: 106\n",
       "- Attack: 110\n",
       "- Defense: 90\n",
@@ -418,13 +466,13 @@
    "id": "8717d47fe7984d46bdc7955c97bf8d07",
    "metadata": {},
    "source": [
-    "## Part 2 \u2014 Synthesis from Recalled Episodes\n",
+    "## Part 2 — Synthesis from Recalled Episodes\n",
     "\n",
-    "The synthesis task asks the agent to compare all three Pok\u00e9mon by speed. No stats\n",
+    "The synthesis task asks the agent to compare all three Pokémon by speed. No stats\n",
     "are provided in the task instruction. The information is only available through\n",
     "the recalled episodes injected into the system prompt at the start of this run.\n",
     "A working memory means the agent can answer without calling `get_pokemon` again.\n",
-    "Watch the logs: you should see no `\ud83d\udee0\ufe0f Executing Tool Call` lines."
+    "Watch the logs: you should see no `🛠️ Executing Tool Call` lines."
    ]
   },
   {
@@ -437,15 +485,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: From the Pok\u00e9mon I have researched:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: From the Pokémon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
       "- **Pikachu** has a ba...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: From the Pok\u00e9mon I have researched:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: From the Pokémon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -456,7 +504,7 @@
    "source": [
     "task4 = Task(\n",
     "    instruction=(\n",
-    "        \"Based on the Pok\u00e9mon you have already researched, \"\n",
+    "        \"Based on the Pokémon you have already researched, \"\n",
     "        \"which one has the highest base speed? \"\n",
     "        \"You do not need to call any tools. Use only what you already know.\"\n",
     "    ),\n",
@@ -474,7 +522,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "From the Pok\u00e9mon I have researched:\n",
+      "From the Pokémon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -493,7 +541,7 @@
    "id": "c9db20072dc646118615b9215fb1ebc2",
    "metadata": {},
    "source": [
-    "## Part 3 \u2014 Inspecting the Store on Disk\n",
+    "## Part 3 — Inspecting the Store on Disk\n",
     "\n",
     "`JSONMemoryStore` writes one JSON line per episode. The cell below reads the raw\n",
     "file so you can see exactly what is persisted between tasks and what a new\n",
@@ -552,8 +600,8 @@
       "  </episode>\n",
       "\n",
       "  <episode>\n",
-      "    <task>Based on the Pok\u00e9mon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
-      "    <result>From the Pok\u00e9mon I have researched:\n",
+      "    <task>Based on the Pokémon you have already researched, which one has the highest base speed? You do not need to call any tools. Use only what you already know.</task>\n",
+      "    <result>From the Pokémon I have researched:\n",
       "\n",
       "- **Mewtwo** has a base speed of 130.\n",
       "- **Gengar** has a base speed of 110.\n",
@@ -581,7 +629,7 @@
    "id": "0485777aabcf4c64aece2a9ba10b57a5",
    "metadata": {},
    "source": [
-    "## Part 4 \u2014 Persistence Across Agent Restarts\n",
+    "## Part 4 — Persistence Across Agent Restarts\n",
     "\n",
     "A fresh `LLMAgent` is created pointing at the same `STORE_PATH`. No state is\n",
     "shared with the previous instance. The new agent loads its episodes entirely\n",
@@ -595,7 +643,11 @@
    "id": "cc17f94c55c64a979f54336e521243a2",
    "metadata": {},
    "outputs": [],
-   "source": "memory2 = recency_memory(path=STORE_DIR, max_results=3)\nllm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"
+   "source": [
+    "memory2 = recency_memory(path=STORE_DIR, max_results=3)\n",
+    "llm2 = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent2 = LLMAgent(llm=llm2, tools=[get_pokemon_tool], memories=[memory2])"
+   ]
   },
   {
    "cell_type": "code",
@@ -609,7 +661,7 @@
      "text": [
       "RecencyMemory (recall last 3):\n",
       "JSONMemoryStore: 4 episodes | path=episodes.jsonl\n",
-      "  newest: 2026-05-18 22:26:32 | Based on the Pok\u00e9mon you have already researched, which one \n",
+      "  newest: 2026-05-18 22:26:32 | Based on the Pokémon you have already researched, which one \n",
       "  oldest: 2026-05-18 22:25:18 | What are Pikachu's base stats? Use the get_pokemon tool. Do \n"
      ]
     }
@@ -628,9 +680,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Which Pok\u00e9mon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Which Pok\u00e9mon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I have previously researched the following Pok\u00e9mon:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use only w...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Which Pokémon have you previously researched, and which one had the highest base speed? You do not need to call any tools. Use onl...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have previously researched the following Pokémon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -638,7 +690,7 @@
       "\n",
       "Among these, **Mewtwo** had the highest b...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I have previously researched the following Pok\u00e9mon:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I have previously researched the following Pokémon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -651,7 +703,7 @@
    "source": [
     "task5 = Task(\n",
     "    instruction=(\n",
-    "        \"Which Pok\u00e9mon have you previously researched, and which one had \"\n",
+    "        \"Which Pokémon have you previously researched, and which one had \"\n",
     "        \"the highest base speed? \"\n",
     "        \"You do not need to call any tools. Use only what you already know.\"\n",
     "    ),\n",
@@ -669,7 +721,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I have previously researched the following Pok\u00e9mon:\n",
+      "I have previously researched the following Pokémon:\n",
       "\n",
       "- **Mewtwo**\n",
       "- **Gengar**\n",
@@ -687,7 +739,25 @@
    "cell_type": "markdown",
    "id": "b2cf38070c7e490d8edbe2bb16fd9731",
    "metadata": {},
-   "source": "## Key Takeaway\n\n`recency_memory()` gives the agent two things it would otherwise lack:\n\n- **Context across tasks.** Every task after the first starts with the\n  `max_results` most recent episodes injected into its system prompt. The\n  agent can synthesise across past work without repeating tool calls (see\n  Part 2 and Part 4).\n- **Persistence across restarts.** Episodes are written to a JSONL file\n  immediately after each task. Any new agent pointing at the same path\n  resumes with full context \u2014 nothing is lost when the process ends.\n\nThe factory bundles the two layers that deliver these properties: a\nrecency-based recall strategy that selects the N most recent episodes, and\na file-backed store that handles persistence. Both are configured through\nthe factory \u2014 `path` sets the storage directory; `max_results` controls\nthe recall window."
+   "source": [
+    "## Key Takeaway\n",
+    "\n",
+    "`recency_memory()` gives the agent two things it would otherwise lack:\n",
+    "\n",
+    "- **Context across tasks.** Every task after the first starts with the\n",
+    "  `max_results` most recent episodes injected into its system prompt. The\n",
+    "  agent can synthesise across past work without repeating tool calls (see\n",
+    "  Part 2 and Part 4).\n",
+    "- **Persistence across restarts.** Episodes are written to a JSONL file\n",
+    "  immediately after each task. Any new agent pointing at the same path\n",
+    "  resumes with full context — nothing is lost when the process ends.\n",
+    "\n",
+    "The factory bundles the two layers that deliver these properties: a\n",
+    "recency-based recall strategy that selects the N most recent episodes, and\n",
+    "a file-backed store that handles persistence. Both are configured through\n",
+    "the factory — `path` sets the storage directory; `max_results` controls\n",
+    "the recall window."
+   ]
   }
  ],
  "metadata": {

--- a/src/llm_agents_from_scratch/memory/memory.py
+++ b/src/llm_agents_from_scratch/memory/memory.py
@@ -110,6 +110,16 @@ class Memory:
 
         await self.store.write(episode, self.key_fn(episode))
 
+    async def summary(self) -> str:
+        """Return a human-readable summary of the backing store.
+
+        Delegates directly to ``store.summary()``.
+
+        Returns:
+            str: Multi-line summary of the store contents.
+        """
+        return await self.store.summary()  # type: ignore[no-any-return]
+
     async def delete(self, id_: str) -> None:
         """Delete an episode from the store by its ID.
 

--- a/src/llm_agents_from_scratch/memory/memory.py
+++ b/src/llm_agents_from_scratch/memory/memory.py
@@ -111,14 +111,26 @@ class Memory:
         await self.store.write(episode, self.key_fn(episode))
 
     async def summary(self) -> str:
-        """Return a human-readable summary of the backing store.
+        """Return a human-readable summary of this memory instance.
 
-        Delegates directly to ``store.summary()``.
+        Combines the backing store's summary with the names of the
+        configured ``key_fn`` and ``metadata_fns`` so the full
+        configuration is visible at a glance.
 
         Returns:
-            str: Multi-line summary of the store contents.
+            str: Multi-line summary of the store contents and memory
+                configuration.
         """
-        return await self.store.summary()  # type: ignore[no-any-return]
+        store_summary: str = await self.store.summary()  # type: ignore[no-any-return]
+        key_fn_name = getattr(self.key_fn, "__name__", repr(self.key_fn))
+        lines = [store_summary]
+        lines.append(f"  key_fn: {key_fn_name}")
+        if self.metadata_fns:
+            keys = ", ".join(self.metadata_fns.keys())
+            lines.append(f"  metadata_fns: {keys}")
+        else:
+            lines.append("  metadata_fns: none")
+        return "\n".join(lines)
 
     async def delete(self, id_: str) -> None:
         """Delete an episode from the store by its ID.

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -147,7 +147,7 @@ async def test_record_all_metadata_fns_called() -> None:
 
 
 @pytest.mark.asyncio
-async def test_summary_delegates_to_store() -> None:
+async def test_summary_includes_store_summary_and_config() -> None:
     store = AsyncMock()
     store.summary = AsyncMock(return_value="store summary")
     memory = Memory(store=store)
@@ -155,7 +155,24 @@ async def test_summary_delegates_to_store() -> None:
     result = await memory.summary()
 
     store.summary.assert_called_once()
-    assert result == "store summary"
+    assert "store summary" in result
+    assert "key_fn:" in result
+    assert "metadata_fns: none" in result
+
+
+@pytest.mark.asyncio
+async def test_summary_lists_metadata_fn_keys() -> None:
+    store = AsyncMock()
+    store.summary = AsyncMock(return_value="store summary")
+    memory = Memory(
+        store=store,
+        metadata_fns={"reflection": AsyncMock(), "tag": AsyncMock()},
+    )
+
+    result = await memory.summary()
+
+    assert "reflection" in result
+    assert "tag" in result
 
 
 # --- delete / update ---

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -143,6 +143,21 @@ async def test_record_all_metadata_fns_called() -> None:
     fn_b.assert_awaited_once_with(ep)
 
 
+# --- summary ---
+
+
+@pytest.mark.asyncio
+async def test_summary_delegates_to_store() -> None:
+    store = AsyncMock()
+    store.summary = AsyncMock(return_value="store summary")
+    memory = Memory(store=store)
+
+    result = await memory.summary()
+
+    store.summary.assert_called_once()
+    assert result == "store summary"
+
+
 # --- delete / update ---
 
 


### PR DESCRIPTION
## Summary

- Migrates `more-examples/ch07/recency_memory.ipynb` to use the `recency_memory()` factory from `memory/recipes.py` — replaces manual `JSONMemoryStore` + `RecencyMemory` construction with `recency_memory(path=..., max_results=...)`
- Adds `Memory.summary()` delegating to `store.summary()` so `await agent.memories[0].summary()` works

## Test plan

- [ ] All 304 existing tests pass (`make test`)
- [ ] `test_memory.py::test_summary_delegates_to_store` covers the new method
- [ ] Notebook cells render correctly with updated imports and factory usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)