### PR TITLE
feat: add ACM Educational Talks notebook (#604)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ omit = [
 
 [tool.ruff]
 line-length = 80
-exclude = ["examples/**/*.ipynb"]
+exclude = ["examples/**/*.ipynb", "talks/**/*.ipynb"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/talks/2026/acm-educational-talks/.agents/skills/hailstone-sequence/SKILL.md
+++ b/talks/2026/acm-educational-talks/.agents/skills/hailstone-sequence/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: hailstone-sequence
+description: Compute the complete Hailstone sequence for a given starting number by repeatedly calling the next_number tool until the value 1 is reached.
+---
+
+# Hailstone Sequence
+
+Compute the full Hailstone (Collatz) sequence from a starting number down to 1
+using the `next_number` tool.
+
+## Arguments
+
+The user must provide a **starting number** (a positive integer greater than 1).
+
+If no starting number is given, ask the user before proceeding.
+
+## Steps
+
+### 1. Initialize
+
+Set the current number `x` to the starting number provided by the user.
+
+Begin tracking the sequence as a list: `[x]`.
+
+### 2. Call the tool
+
+Call `next_number` with the current value of `x`.
+
+```
+next_number(x=<current_number>)
+```
+
+**STOP and WAIT** for the tool result before continuing.
+
+### 3. Record the result
+
+Append the returned value to the sequence list.
+
+Set `x` to the returned value.
+
+### 4. Check termination
+
+- If `x == 1`, proceed to Step 5.
+- Otherwise, go back to Step 2.
+
+**Important rules:**
+- NEVER fabricate or simulate tool call results.
+- NEVER make multiple tool calls in a single response.
+- ALWAYS wait for the actual tool response before deciding next steps.
+
+### 5. Report the result
+
+Print the complete sequence from start to finish, for example:
+
+```
+6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1
+```
+
+Also report:
+- **Starting number**
+- **Total steps taken** (number of tool calls made)
+- **Maximum value reached** in the sequence

--- a/talks/2026/acm-educational-talks/notebook.ipynb
+++ b/talks/2026/acm-educational-talks/notebook.ipynb
@@ -102,20 +102,7 @@
    "id": "acm0011",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# The LLM sees the schema and decides to request a tool call\n",
-    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
-    "\n",
-    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "\n",
-    "user_msg, response_msg = await llm.chat(\n",
-    "    \"What is the next number in the Hailstone sequence after 6?\",\n",
-    "    tools=[hailstone_tool],\n",
-    ")\n",
-    "\n",
-    "# The LLM output — not a result, a *request*\n",
-    "print(response_msg.tool_calls)"
-   ]
+   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3-coder:480b\")"
   },
   {
    "cell_type": "code",

--- a/talks/2026/acm-educational-talks/notebook.ipynb
+++ b/talks/2026/acm-educational-talks/notebook.ipynb
@@ -19,18 +19,6 @@
    "source": "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/3.svg)"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "acm0004",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dotenv import load_dotenv\n",
-    "\n",
-    "load_dotenv()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "acm0005",
    "metadata": {},
@@ -40,7 +28,7 @@
    "cell_type": "markdown",
    "id": "acm0006",
    "metadata": {},
-   "source": "## Demo 1 \u2014 \"The tool-call gap\"\n\n> *LLMs don't run tools \u2014 they request them.*"
+   "source": "## Demo 1 — \"The tool-call gap\"\n\n> *LLMs don't run tools — they request them.*"
   },
   {
    "cell_type": "code",
@@ -49,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# A tool call is just a data structure \u2014 no execution happens here\n",
+    "# A tool call is just a data structure — no execution happens here\n",
     "from llm_agents_from_scratch.data_structures.tool import ToolCall\n",
     "\n",
     "tool_call = ToolCall(\n",
@@ -96,7 +84,7 @@
    "id": "acm0011",
    "metadata": {},
    "outputs": [],
-   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)"
+   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\n\n# The LLM sees the schema and decides to request a tool call\nuser_msg, response_msg = await llm.chat(\n    \"What is the next number in the Hailstone sequence after 6?\",\n    tools=[hailstone_tool],\n)\n\n# The LLM output — not a result, a *request*\nprint(response_msg.tool_calls)"
   },
   {
    "cell_type": "code",
@@ -105,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We execute the tool \u2014 the LLM didn't\n",
+    "# We execute the tool — the LLM didn't\n",
     "tool_call = response_msg.tool_calls[0]\n",
     "tool_call_result = hailstone_tool(tool_call)\n",
     "print(tool_call_result)"
@@ -118,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Close the loop: feed the result back \u2014 this is the gap made visible\n",
+    "# Close the loop: feed the result back — this is the gap made visible\n",
     "_, final_response = await llm.continue_chat_with_tool_results(\n",
     "    tool_call_results=[tool_call_result],\n",
     "    chat_history=[user_msg, response_msg],\n",
@@ -136,7 +124,7 @@
    "cell_type": "markdown",
    "id": "acm0015",
    "metadata": {},
-   "source": "## Demo 2 \u2014 \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
+   "source": "## Demo 2 — \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
   },
   {
    "cell_type": "code",
@@ -237,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The rollout is the agent's working memory \u2014 every step recorded\n",
+    "# The rollout is the agent's working memory — every step recorded\n",
     "print(handler.rollout)"
    ]
   },
@@ -250,7 +238,7 @@
    "source": [
     "import asyncio\n",
     "\n",
-    "# Same agent, two tasks, running concurrently \u2014 the surprise\n",
+    "# Same agent, two tasks, running concurrently — the surprise\n",
     "task_a = Task(instruction=instruction_template.format(x=3))\n",
     "task_b = Task(instruction=instruction_template.format(x=7))\n",
     "\n",
@@ -260,10 +248,10 @@
     "await asyncio.gather(handler_a.background_task, handler_b.background_task)\n",
     "\n",
     "print(\n",
-    "    f\"Task A ({3}) \u2014 steps: {handler_a.step_counter}, result: {handler_a.result()}\"\n",
+    "    f\"Task A ({3}) — steps: {handler_a.step_counter}, result: {handler_a.result()}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Task B ({7}) \u2014 steps: {handler_b.step_counter}, result: {handler_b.result()}\"\n",
+    "    f\"Task B ({7}) — steps: {handler_b.step_counter}, result: {handler_b.result()}\"\n",
     ")"
    ]
   },
@@ -277,7 +265,7 @@
    "cell_type": "markdown",
    "id": "acm0024",
    "metadata": {},
-   "source": "## Demo 3 \u2014 \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
+   "source": "## Demo 3 — \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
   },
   {
    "cell_type": "code",
@@ -286,7 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Any MCP server, any transport \u2014 same interface\n",
+    "# Any MCP server, any transport — same interface\n",
     "from pathlib import Path\n",
     "\n",
     "from mcp import StdioServerParameters\n",
@@ -322,7 +310,7 @@
    "outputs": [],
    "source": [
     "# Real-world MCP: GitHub's server over streamable HTTP\n",
-    "# Pre-run this cell \u2014 live network dependency\n",
+    "# Pre-run this cell — live network dependency\n",
     "import getpass\n",
     "import os\n",
     "\n",
@@ -386,7 +374,7 @@
    "cell_type": "markdown",
    "id": "acm0032",
    "metadata": {},
-   "source": "## Demo 4 \u2014 \"Giving the agent a playbook\"\n\n> *Not what it can do \u2014 how it thinks.*"
+   "source": "## Demo 4 — \"Giving the agent a playbook\"\n\n> *Not what it can do — how it thinks.*"
   },
   {
    "cell_type": "markdown",
@@ -417,7 +405,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Pause here \u2014 this is the agent's instruction set, written in plain text\n",
+    "# Pause here — this is the agent's instruction set, written in plain text\n",
     "skill = skills[\"hailstone-sequence\"]\n",
     "print(skill.read_body())"
    ]
@@ -429,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Activate the skill \u2014 the programmatic slash command\n",
+    "# Activate the skill — the programmatic slash command\n",
     "handler = llm_agent.run_with_skill(\n",
     "    skill_name=\"hailstone-sequence\",\n",
     "    prompt=\"Compute the Hailstone sequence starting from 12.\",\n",
@@ -450,7 +438,7 @@
    "cell_type": "markdown",
    "id": "acm0039",
    "metadata": {},
-   "source": "## Demo 5 \u2014 \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
+   "source": "## Demo 5 — \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
   },
   {
    "cell_type": "markdown",
@@ -466,7 +454,7 @@
    "outputs": [],
    "source": [
     "# reflective_memory: after each task the LLM distils a one-sentence lesson\n",
-    "# FastEmbed model is pre-cached \u2014 no download delay during the demo\n",
+    "# FastEmbed model is pre-cached — no download delay during the demo\n",
     "from llm_agents_from_scratch.memory.recipes import reflective_memory\n",
     "\n",
     "memory = reflective_memory(llm=llm, max_results=1)\n",
@@ -480,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First run \u2014 no prior experience\n",
+    "# First run — no prior experience\n",
     "task = Task(instruction=instruction_template.format(x=6))\n",
     "handler = agent_with_memory.run(task, max_steps=15)\n",
     "print(handler.result())"
@@ -493,7 +481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The money shot \u2014 episode stored with the reflection\n",
+    "# The money shot — episode stored with the reflection\n",
     "episodes = await memory.store.read_recent(1)\n",
     "print(str(episodes[0]))"
    ]
@@ -505,7 +493,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Second run \u2014 agent starts with the lesson from Run 1 in its system prompt\n",
+    "# Second run — agent starts with the lesson from Run 1 in its system prompt\n",
     "task2 = Task(instruction=instruction_template.format(x=6))\n",
     "handler2 = agent_with_memory.run(task2, max_steps=15)\n",
     "print(handler2.result())"

--- a/talks/2026/acm-educational-talks/notebook.ipynb
+++ b/talks/2026/acm-educational-talks/notebook.ipynb
@@ -4,31 +4,59 @@
    "cell_type": "markdown",
    "id": "acm0001",
    "metadata": {},
-   "source": "![Slide 1](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/1.svg)"
+   "source": [
+    "![Slide 1](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/1.svg)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "acm0002",
    "metadata": {},
-   "source": "![Slide 2](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/2.svg)"
+   "source": [
+    "![Slide 2](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/2.svg)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "acm0003",
    "metadata": {},
-   "source": "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/3.svg)"
+   "source": [
+    "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/3.svg)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "acm0005",
    "metadata": {},
-   "source": "![Slide 4](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/4.svg)"
+   "source": [
+    "![Slide 4](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/4.svg)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "acm0006",
    "metadata": {},
-   "source": "## Demo 1 — \"The tool-call gap\"\n\n> *LLMs don't run tools — they request them.*"
+   "source": [
+    "## Demo 1 — \"The tool-call gap\"\n",
+    "\n",
+    "> *LLMs don't run tools — they request them.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0010",
+   "metadata": {},
+   "source": [
+    "![Slide 5](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/5.svg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0014",
+   "metadata": {},
+   "source": [
+    "![Slide 6](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/6.svg)"
+   ]
   },
   {
    "cell_type": "code",
@@ -73,18 +101,25 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "acm0010",
-   "metadata": {},
-   "source": "![Slide 5](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/5.svg)"
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "acm0011",
    "metadata": {},
    "outputs": [],
-   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\n\n# The LLM sees the schema and decides to request a tool call\nuser_msg, response_msg = await llm.chat(\n    \"What is the next number in the Hailstone sequence after 6?\",\n    tools=[hailstone_tool],\n)\n\n# The LLM output — not a result, a *request*\nprint(response_msg.tool_calls)"
+   "source": [
+    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "\n",
+    "# The LLM sees the schema and decides to request a tool call\n",
+    "user_msg, response_msg = await llm.chat(\n",
+    "    \"What is the next number in the Hailstone sequence after 6?\",\n",
+    "    tools=[hailstone_tool],\n",
+    ")\n",
+    "\n",
+    "# The LLM output — not a result, a *request*\n",
+    "print(response_msg.tool_calls)"
+   ]
   },
   {
    "cell_type": "code",
@@ -116,15 +151,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acm0014",
+   "id": "acm0015",
    "metadata": {},
-   "source": "![Slide 6](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/6.svg)"
+   "source": [
+    "## Demo 2 — \"Closing the loop\"\n",
+    "\n",
+    "> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "acm0015",
+   "id": "acm0023",
    "metadata": {},
-   "source": "## Demo 2 — \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
+   "source": [
+    "![Slide 7](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/7.svg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0027",
+   "metadata": {},
+   "source": [
+    "![Slide 8](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/8.svg)"
+   ]
   },
   {
    "cell_type": "code",
@@ -257,15 +306,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acm0023",
+   "id": "acm0024",
    "metadata": {},
-   "source": "![Slide 7](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/7.svg)"
+   "source": [
+    "## Demo 3 — \"Tools as a protocol\"\n",
+    "\n",
+    "> *The entire tool ecosystem in one line.*"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "acm0024",
+   "id": "acm0031",
    "metadata": {},
-   "source": "## Demo 3 — \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
+   "source": [
+    "![Slide 9](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/9.svg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0033",
+   "metadata": {},
+   "source": [
+    "![Slide 10](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/10.svg)"
+   ]
   },
   {
    "cell_type": "code",
@@ -295,12 +358,6 @@
     "print(f\"Description: {mcp_tools[0].description}\")\n",
     "print(f\"Schema:      {mcp_tools[0].parameters_json_schema}\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acm0027",
-   "metadata": {},
-   "source": "![Slide 8](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/8.svg)"
   },
   {
    "cell_type": "code",
@@ -366,21 +423,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acm0031",
-   "metadata": {},
-   "source": "![Slide 9](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/9.svg)"
-  },
-  {
-   "cell_type": "markdown",
    "id": "acm0032",
    "metadata": {},
-   "source": "## Demo 4 — \"Giving the agent a playbook\"\n\n> *Not what it can do — how it thinks.*"
+   "source": [
+    "## Demo 4 — \"Giving the agent a playbook\"\n",
+    "\n",
+    "> *Not what it can do — how it thinks.*"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "acm0033",
+   "id": "acm0038",
    "metadata": {},
-   "source": "![Slide 10](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/10.svg)"
+   "source": [
+    "![Slide 11](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/11.svg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0040",
+   "metadata": {},
+   "source": [
+    "![Slide 12](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/12.svg)"
+   ]
   },
   {
    "cell_type": "code",
@@ -430,21 +495,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acm0038",
-   "metadata": {},
-   "source": "![Slide 11](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/11.svg)"
-  },
-  {
-   "cell_type": "markdown",
    "id": "acm0039",
    "metadata": {},
-   "source": "## Demo 5 — \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
+   "source": [
+    "## Demo 5 — \"Giving the agent a past\"\n",
+    "\n",
+    "> *The rollout is working memory for one task. What about memory across tasks?*"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "acm0040",
+   "id": "acm0045",
    "metadata": {},
-   "source": "![Slide 12](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/12.svg)"
+   "source": [
+    "![Slide 13](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/13.svg)"
+   ]
   },
   {
    "cell_type": "code",
@@ -501,15 +566,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acm0045",
-   "metadata": {},
-   "source": "![Slide 13](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/13.svg)"
-  },
-  {
-   "cell_type": "markdown",
    "id": "acm0046",
    "metadata": {},
-   "source": "![Slide 14](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/14.svg)"
+   "source": [
+    "![Slide 14](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/14.svg)"
+   ]
   }
  ],
  "metadata": {

--- a/talks/2026/acm-educational-talks/notebook.ipynb
+++ b/talks/2026/acm-educational-talks/notebook.ipynb
@@ -1,0 +1,577 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "acm0001",
+   "metadata": {},
+   "source": "![Slide 1](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/1.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0002",
+   "metadata": {},
+   "source": "![Slide 2](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/2.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0003",
+   "metadata": {},
+   "source": "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/3.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0005",
+   "metadata": {},
+   "source": "![Slide 4](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/4.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0006",
+   "metadata": {},
+   "source": "## Demo 1 — \"The tool-call gap\"\n\n> *LLMs don't run tools — they request them.*"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0007",
+   "metadata": {},
+   "source": "![Slide 5](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/5.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A tool call is just a data structure — no execution happens here\n",
+    "from llm_agents_from_scratch.data_structures.tool import ToolCall\n",
+    "\n",
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"hailstone_step\",\n",
+    "    arguments={\"x\": 6},\n",
+    ")\n",
+    "tool_call"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SimpleFunctionTool: turn any Python function into an LLM-compatible tool\n",
+    "from llm_agents_from_scratch.tools.simple_function import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def hailstone_step(x: int) -> int:\n",
+    "    \"\"\"Performs a single step of the Hailstone sequence.\"\"\"\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "hailstone_tool = SimpleFunctionTool(hailstone_step)\n",
+    "\n",
+    "print(f\"Name:        {hailstone_tool.name}\")\n",
+    "print(f\"Description: {hailstone_tool.description}\")\n",
+    "print(f\"Schema:      {hailstone_tool.parameters_json_schema}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0010",
+   "metadata": {},
+   "source": "![Slide 6](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/6.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0011",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The LLM sees the schema and decides to request a tool call\n",
+    "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "\n",
+    "user_msg, response_msg = await llm.chat(\n",
+    "    \"What is the next number in the Hailstone sequence after 6?\",\n",
+    "    tools=[hailstone_tool],\n",
+    ")\n",
+    "\n",
+    "# The LLM output — not a result, a *request*\n",
+    "print(response_msg.tool_calls)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We execute the tool — the LLM didn't\n",
+    "tool_call = response_msg.tool_calls[0]\n",
+    "tool_call_result = hailstone_tool(tool_call)\n",
+    "print(tool_call_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the loop: feed the result back — this is the gap made visible\n",
+    "_, final_response = await llm.continue_chat_with_tool_results(\n",
+    "    tool_call_results=[tool_call_result],\n",
+    "    chat_history=[user_msg, response_msg],\n",
+    ")\n",
+    "print(final_response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0014",
+   "metadata": {},
+   "source": "![Slide 7](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/7.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0015",
+   "metadata": {},
+   "source": "## Demo 2 — \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0016",
+   "metadata": {},
+   "source": "![Slide 8](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/8.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0017",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "\n",
+    "enable_console_logging(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obfuscated tool: the agent must reason, not pattern-match the name\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "from llm_agents_from_scratch.tools import PydanticFunctionTool\n",
+    "\n",
+    "\n",
+    "class AlgoParams(BaseModel):\n",
+    "    \"\"\"Params for next_number.\"\"\"\n",
+    "\n",
+    "    x: int\n",
+    "\n",
+    "\n",
+    "def next_number(params: AlgoParams) -> int:\n",
+    "    \"\"\"Generate the next number of the sequence.\"\"\"\n",
+    "    if params.x % 2 == 0:\n",
+    "        return params.x // 2\n",
+    "    return 3 * params.x + 1\n",
+    "\n",
+    "\n",
+    "tool = PydanticFunctionTool(next_number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0019",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "\n",
+    "llm_agent = LLMAgent(llm=llm, tools=[tool])\n",
+    "\n",
+    "instruction_template = \"\"\"\n",
+    "You are given a tool, `next_number`, that generates the next number in the\n",
+    "sequence given the current number.\n",
+    "\n",
+    "Start with the number x={x}.\n",
+    "\n",
+    "<rules>\n",
+    "CALL `next_number` on the current number x\n",
+    "STOP AND WAIT for the result.\n",
+    "REPEAT this step-by-step process until the number 1 is reached.\n",
+    "FINAL RESULT: When you receive the number 1, provide the complete sequence you\n",
+    "observed from start to finish (including the starting number x and ending number 1).\n",
+    "</rules>\n",
+    "\n",
+    "<warnings>\n",
+    "NEVER fabricate or simulate tool call results\n",
+    "NEVER make multiple tool calls in one response\n",
+    "STOP and WAIT - ALWAYS wait for the actual tool response before deciding next steps\n",
+    "</warnings>\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "task = Task(instruction=instruction_template.format(x=6))\n",
+    "handler = llm_agent.run(task, max_steps=15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0020",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Done:        {handler.done()}\")\n",
+    "print(f\"Steps taken: {handler.step_counter}\")\n",
+    "print(f\"\\nResult: {handler.result()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0021",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The rollout is the agent's working memory — every step recorded\n",
+    "print(handler.rollout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0022",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "# Same agent, two tasks, running concurrently — the surprise\n",
+    "task_a = Task(instruction=instruction_template.format(x=3))\n",
+    "task_b = Task(instruction=instruction_template.format(x=7))\n",
+    "\n",
+    "handler_a = llm_agent.run(task_a, max_steps=20)\n",
+    "handler_b = llm_agent.run(task_b, max_steps=20)\n",
+    "\n",
+    "await asyncio.gather(handler_a.background_task, handler_b.background_task)\n",
+    "\n",
+    "print(\n",
+    "    f\"Task A ({3}) — steps: {handler_a.step_counter}, result: {handler_a.result()}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Task B ({7}) — steps: {handler_b.step_counter}, result: {handler_b.result()}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0023",
+   "metadata": {},
+   "source": "![Slide 9](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/9.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0024",
+   "metadata": {},
+   "source": "## Demo 3 — \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0025",
+   "metadata": {},
+   "source": "![Slide 10](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/10.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0026",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Any MCP server, any transport — same interface\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from mcp import StdioServerParameters\n",
+    "\n",
+    "from llm_agents_from_scratch.tools.mcp import MCPToolProvider\n",
+    "\n",
+    "server_path = Path.cwd().parent / \"extra/mcp-hailstone\"\n",
+    "server_params = StdioServerParameters(\n",
+    "    command=\"uv\",\n",
+    "    args=[\"run\", \"--with\", \"mcp\", \"mcp\", \"run\", \"main.py\"],\n",
+    "    cwd=server_path,\n",
+    ")\n",
+    "provider = MCPToolProvider(name=\"hailstone\", stdio_params=server_params)\n",
+    "\n",
+    "mcp_tools = await provider.get_tools()\n",
+    "print(f\"Discovered {len(mcp_tools)} tool(s)\")\n",
+    "print(f\"\\nName:        {mcp_tools[0].name}\")\n",
+    "print(f\"Description: {mcp_tools[0].description}\")\n",
+    "print(f\"Schema:      {mcp_tools[0].parameters_json_schema}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0027",
+   "metadata": {},
+   "source": "![Slide 11](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/11.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0028",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Real-world MCP: GitHub's server over streamable HTTP\n",
+    "# Pre-run this cell — live network dependency\n",
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"GITHUB_PAT\"] = getpass.getpass(\"GitHub PAT: \")\n",
+    "\n",
+    "github_mcp_provider = MCPToolProvider(\n",
+    "    name=\"github_mcp\",\n",
+    "    streamable_http_url=\"https://api.githubcopilot.com/mcp/\",\n",
+    "    streamable_http_headers={\n",
+    "        \"Authorization\": f\"Bearer {os.environ['GITHUB_PAT']}\",\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0029",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch import LLMAgentBuilder\n",
+    "\n",
+    "github_agent = (\n",
+    "    await LLMAgentBuilder()\n",
+    "    .with_llm(llm)\n",
+    "    .with_mcp_provider(github_mcp_provider)\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "for t in github_agent.tools:\n",
+    "    print(f\"{t.name}: {(t.description or '')[:60]}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0030",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Self-referential: the agent fetches the latest release of this very repo\n",
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Use the get_latest_release tool to get the latest release for the \"\n",
+    "        \"GitHub repo with owner 'nerdai' and repo 'llm-agents-from-scratch'.\"\n",
+    "    ),\n",
+    ")\n",
+    "handler = github_agent.run(task, max_steps=10)\n",
+    "result = handler.exception() or handler.result()\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0031",
+   "metadata": {},
+   "source": "![Slide 12](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/12.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0032",
+   "metadata": {},
+   "source": "## Demo 4 — \"Giving the agent a playbook\"\n\n> *Not what it can do — how it thinks.*"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0033",
+   "metadata": {},
+   "source": "![Slide 13](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/13.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0034",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch.data_structures.skill import SkillScope\n",
+    "from llm_agents_from_scratch.skills.discovery import discover_skills\n",
+    "\n",
+    "skills = discover_skills([SkillScope.PROJECT])\n",
+    "print(f\"Discovered {len(skills)} skill(s):\")\n",
+    "for name, skill in skills.items():\n",
+    "    print(f\"  {name}: {skill.frontmatter.description}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pause here — this is the agent's instruction set, written in plain text\n",
+    "skill = skills[\"hailstone-sequence\"]\n",
+    "print(skill.read_body())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0036",
+   "metadata": {},
+   "source": "![Slide 14](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/14.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0037",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Activate the skill — the programmatic slash command\n",
+    "handler = llm_agent.run_with_skill(\n",
+    "    skill_name=\"hailstone-sequence\",\n",
+    "    prompt=\"Compute the Hailstone sequence starting from 12.\",\n",
+    "    max_steps=25,\n",
+    ")\n",
+    "result = handler.exception() or handler.result()\n",
+    "print(f\"Steps taken: {handler.step_counter}\")\n",
+    "print(f\"\\nResult:\\n{result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0038",
+   "metadata": {},
+   "source": "![Slide 15](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/15.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0039",
+   "metadata": {},
+   "source": "## Demo 5 — \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0040",
+   "metadata": {},
+   "source": "![Slide 16](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/16.svg)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0041",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reflective_memory: after each task the LLM distils a one-sentence lesson\n",
+    "# FastEmbed model is pre-cached — no download delay during the demo\n",
+    "from llm_agents_from_scratch.memory.recipes import reflective_memory\n",
+    "\n",
+    "memory = reflective_memory(llm=llm, max_results=1)\n",
+    "agent_with_memory = LLMAgent(llm=llm, tools=[tool], memories=[memory])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0042",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First run — no prior experience\n",
+    "task = Task(instruction=instruction_template.format(x=6))\n",
+    "handler = agent_with_memory.run(task, max_steps=15)\n",
+    "print(handler.result())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0043",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The money shot — episode stored with the reflection\n",
+    "episodes = await memory.store.read_recent(1)\n",
+    "print(str(episodes[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acm0044",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Second run — agent starts with the lesson from Run 1 in its system prompt\n",
+    "task2 = Task(instruction=instruction_template.format(x=6))\n",
+    "handler2 = agent_with_memory.run(task2, max_steps=15)\n",
+    "print(handler2.result())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0045",
+   "metadata": {},
+   "source": "![Slide 17](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/17.svg)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acm0046",
+   "metadata": {},
+   "source": "![Slide 18](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/18.svg)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/talks/2026/acm-educational-talks/notebook.ipynb
+++ b/talks/2026/acm-educational-talks/notebook.ipynb
@@ -4,19 +4,19 @@
    "cell_type": "markdown",
    "id": "acm0001",
    "metadata": {},
-   "source": "![Slide 1](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/1.svg)"
+   "source": "![Slide 1](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/1.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0002",
    "metadata": {},
-   "source": "![Slide 2](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/2.svg)"
+   "source": "![Slide 2](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/2.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0003",
    "metadata": {},
-   "source": "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/3.svg)"
+   "source": "![Slide 3](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/3.svg)"
   },
   {
    "cell_type": "code",
@@ -34,19 +34,13 @@
    "cell_type": "markdown",
    "id": "acm0005",
    "metadata": {},
-   "source": "![Slide 4](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/4.svg)"
+   "source": "![Slide 4](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/4.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0006",
    "metadata": {},
-   "source": "## Demo 1 — \"The tool-call gap\"\n\n> *LLMs don't run tools — they request them.*"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acm0007",
-   "metadata": {},
-   "source": "![Slide 5](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/5.svg)"
+   "source": "## Demo 1 \u2014 \"The tool-call gap\"\n\n> *LLMs don't run tools \u2014 they request them.*"
   },
   {
    "cell_type": "code",
@@ -55,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# A tool call is just a data structure — no execution happens here\n",
+    "# A tool call is just a data structure \u2014 no execution happens here\n",
     "from llm_agents_from_scratch.data_structures.tool import ToolCall\n",
     "\n",
     "tool_call = ToolCall(\n",
@@ -94,7 +88,7 @@
    "cell_type": "markdown",
    "id": "acm0010",
    "metadata": {},
-   "source": "![Slide 6](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/6.svg)"
+   "source": "![Slide 5](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/5.svg)"
   },
   {
    "cell_type": "code",
@@ -102,7 +96,7 @@
    "id": "acm0011",
    "metadata": {},
    "outputs": [],
-   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3-coder:480b\")"
+   "source": "from llm_agents_from_scratch.llms.ollama import OllamaLLM\n\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)"
   },
   {
    "cell_type": "code",
@@ -111,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We execute the tool — the LLM didn't\n",
+    "# We execute the tool \u2014 the LLM didn't\n",
     "tool_call = response_msg.tool_calls[0]\n",
     "tool_call_result = hailstone_tool(tool_call)\n",
     "print(tool_call_result)"
@@ -124,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Close the loop: feed the result back — this is the gap made visible\n",
+    "# Close the loop: feed the result back \u2014 this is the gap made visible\n",
     "_, final_response = await llm.continue_chat_with_tool_results(\n",
     "    tool_call_results=[tool_call_result],\n",
     "    chat_history=[user_msg, response_msg],\n",
@@ -136,19 +130,13 @@
    "cell_type": "markdown",
    "id": "acm0014",
    "metadata": {},
-   "source": "![Slide 7](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/7.svg)"
+   "source": "![Slide 6](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/6.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0015",
    "metadata": {},
-   "source": "## Demo 2 — \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acm0016",
-   "metadata": {},
-   "source": "![Slide 8](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/8.svg)"
+   "source": "## Demo 2 \u2014 \"Closing the loop\"\n\n> *Wrapping the tool-call loop in `LLMAgent` + `TaskHandler` is what makes it an agent.*"
   },
   {
    "cell_type": "code",
@@ -249,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The rollout is the agent's working memory — every step recorded\n",
+    "# The rollout is the agent's working memory \u2014 every step recorded\n",
     "print(handler.rollout)"
    ]
   },
@@ -262,7 +250,7 @@
    "source": [
     "import asyncio\n",
     "\n",
-    "# Same agent, two tasks, running concurrently — the surprise\n",
+    "# Same agent, two tasks, running concurrently \u2014 the surprise\n",
     "task_a = Task(instruction=instruction_template.format(x=3))\n",
     "task_b = Task(instruction=instruction_template.format(x=7))\n",
     "\n",
@@ -272,10 +260,10 @@
     "await asyncio.gather(handler_a.background_task, handler_b.background_task)\n",
     "\n",
     "print(\n",
-    "    f\"Task A ({3}) — steps: {handler_a.step_counter}, result: {handler_a.result()}\"\n",
+    "    f\"Task A ({3}) \u2014 steps: {handler_a.step_counter}, result: {handler_a.result()}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Task B ({7}) — steps: {handler_b.step_counter}, result: {handler_b.result()}\"\n",
+    "    f\"Task B ({7}) \u2014 steps: {handler_b.step_counter}, result: {handler_b.result()}\"\n",
     ")"
    ]
   },
@@ -283,19 +271,13 @@
    "cell_type": "markdown",
    "id": "acm0023",
    "metadata": {},
-   "source": "![Slide 9](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/9.svg)"
+   "source": "![Slide 7](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/7.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0024",
    "metadata": {},
-   "source": "## Demo 3 — \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acm0025",
-   "metadata": {},
-   "source": "![Slide 10](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/10.svg)"
+   "source": "## Demo 3 \u2014 \"Tools as a protocol\"\n\n> *The entire tool ecosystem in one line.*"
   },
   {
    "cell_type": "code",
@@ -304,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Any MCP server, any transport — same interface\n",
+    "# Any MCP server, any transport \u2014 same interface\n",
     "from pathlib import Path\n",
     "\n",
     "from mcp import StdioServerParameters\n",
@@ -330,7 +312,7 @@
    "cell_type": "markdown",
    "id": "acm0027",
    "metadata": {},
-   "source": "![Slide 11](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/11.svg)"
+   "source": "![Slide 8](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/8.svg)"
   },
   {
    "cell_type": "code",
@@ -340,7 +322,7 @@
    "outputs": [],
    "source": [
     "# Real-world MCP: GitHub's server over streamable HTTP\n",
-    "# Pre-run this cell — live network dependency\n",
+    "# Pre-run this cell \u2014 live network dependency\n",
     "import getpass\n",
     "import os\n",
     "\n",
@@ -398,19 +380,19 @@
    "cell_type": "markdown",
    "id": "acm0031",
    "metadata": {},
-   "source": "![Slide 12](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/12.svg)"
+   "source": "![Slide 9](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/9.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0032",
    "metadata": {},
-   "source": "## Demo 4 — \"Giving the agent a playbook\"\n\n> *Not what it can do — how it thinks.*"
+   "source": "## Demo 4 \u2014 \"Giving the agent a playbook\"\n\n> *Not what it can do \u2014 how it thinks.*"
   },
   {
    "cell_type": "markdown",
    "id": "acm0033",
    "metadata": {},
-   "source": "![Slide 13](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/13.svg)"
+   "source": "![Slide 10](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/10.svg)"
   },
   {
    "cell_type": "code",
@@ -435,16 +417,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Pause here — this is the agent's instruction set, written in plain text\n",
+    "# Pause here \u2014 this is the agent's instruction set, written in plain text\n",
     "skill = skills[\"hailstone-sequence\"]\n",
     "print(skill.read_body())"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acm0036",
-   "metadata": {},
-   "source": "![Slide 14](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/14.svg)"
   },
   {
    "cell_type": "code",
@@ -453,7 +429,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Activate the skill — the programmatic slash command\n",
+    "# Activate the skill \u2014 the programmatic slash command\n",
     "handler = llm_agent.run_with_skill(\n",
     "    skill_name=\"hailstone-sequence\",\n",
     "    prompt=\"Compute the Hailstone sequence starting from 12.\",\n",
@@ -468,19 +444,19 @@
    "cell_type": "markdown",
    "id": "acm0038",
    "metadata": {},
-   "source": "![Slide 15](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/15.svg)"
+   "source": "![Slide 11](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/11.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0039",
    "metadata": {},
-   "source": "## Demo 5 — \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
+   "source": "## Demo 5 \u2014 \"Giving the agent a past\"\n\n> *The rollout is working memory for one task. What about memory across tasks?*"
   },
   {
    "cell_type": "markdown",
    "id": "acm0040",
    "metadata": {},
-   "source": "![Slide 16](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/16.svg)"
+   "source": "![Slide 12](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/12.svg)"
   },
   {
    "cell_type": "code",
@@ -490,7 +466,7 @@
    "outputs": [],
    "source": [
     "# reflective_memory: after each task the LLM distils a one-sentence lesson\n",
-    "# FastEmbed model is pre-cached — no download delay during the demo\n",
+    "# FastEmbed model is pre-cached \u2014 no download delay during the demo\n",
     "from llm_agents_from_scratch.memory.recipes import reflective_memory\n",
     "\n",
     "memory = reflective_memory(llm=llm, max_results=1)\n",
@@ -504,7 +480,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First run — no prior experience\n",
+    "# First run \u2014 no prior experience\n",
     "task = Task(instruction=instruction_template.format(x=6))\n",
     "handler = agent_with_memory.run(task, max_steps=15)\n",
     "print(handler.result())"
@@ -517,7 +493,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The money shot — episode stored with the reflection\n",
+    "# The money shot \u2014 episode stored with the reflection\n",
     "episodes = await memory.store.read_recent(1)\n",
     "print(str(episodes[0]))"
    ]
@@ -529,7 +505,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Second run — agent starts with the lesson from Run 1 in its system prompt\n",
+    "# Second run \u2014 agent starts with the lesson from Run 1 in its system prompt\n",
     "task2 = Task(instruction=instruction_template.format(x=6))\n",
     "handler2 = agent_with_memory.run(task2, max_steps=15)\n",
     "print(handler2.result())"
@@ -539,13 +515,13 @@
    "cell_type": "markdown",
    "id": "acm0045",
    "metadata": {},
-   "source": "![Slide 17](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/17.svg)"
+   "source": "![Slide 13](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/13.svg)"
   },
   {
    "cell_type": "markdown",
    "id": "acm0046",
    "metadata": {},
-   "source": "![Slide 18](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-educational-talks/18.svg)"
+   "source": "![Slide 14](https://d3ddy8balm3goa.cloudfront.net/talks/2026/acm-tech-talks/14.svg)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

New talk notebook for **"Inside an LLM Agent: A From-Scratch Walkthrough"** (ACM Educational Talks).

5 demos built on the Hailstone sequence as a running thread:

1. **The tool-call gap** — `ToolCall` data structure → `SimpleFunctionTool` → LLM elicits a tool call → `continue_chat_with_tool_results` makes the gap visible
2. **Closing the loop** — `LLMAgent` + `TaskHandler` automates the loop; `handler.rollout` = working memory; concurrent runs with `asyncio.gather`
3. **Tools as a protocol** — `MCPToolProvider` (stdio) → GitHub MCP over HTTP → agent fetches latest release of the repo being demoed
4. **Giving the agent a playbook** — `discover_skills()` → print skill body live → `run_with_skill()`
5. **Giving the agent a past** — `reflective_memory()` → first run → print episode with `<reflection>` tag (money shot) → second run with lesson injected

Slides reference `acm-tech-talks/1.svg` … `14.svg` on CloudFront (already uploaded).

Also excludes `talks/**/*.ipynb` from ruff linting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)