### PR TITLE
feat: add field labels to Episode._format_concat output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - feat: add delete() and update() to BaseMemoryStore (#609)
+- feat: `Episode._format_concat` now prefixes each value with its field label (e.g. `instruction: ...`, `result: ...`); metadata entries use their key as label (#616)
 
 ## [0.0.18] - 2026-06-03
 

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -89,19 +89,18 @@ class Episode(BaseModel):
         parts: list[str] = []
         for f in fields:
             if f == "instruction":
-                parts.append(self.task.instruction)
+                parts.append(f"instruction: {self.task.instruction}")
             elif f == "result" and self.result:
-                parts.append(self.result.content)
+                parts.append(f"result: {self.result.content}")
             elif f == "error" and self.error:
-                parts.append(str(self.error))
+                parts.append(f"error: {self.error}")
             elif f == "metadata" and self.metadata:
-                parts.extend(self.metadata.values())
+                parts.extend(f"{k}: {v}" for k, v in self.metadata.items())
             elif f == "completed_at":
-                parts.append(
-                    self.completed_at.strftime("%Y-%m-%d %H:%M:%S"),
-                )
+                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                parts.append(f"completed_at: {ts}")
             elif f == "rollout":
-                parts.append(self.rollout)
+                parts.append(f"rollout: {self.rollout}")
         return "\n".join(parts)
 
     def _format_xml(self, fields: list[EpisodeAttr]) -> str:

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -25,6 +25,32 @@ def test_episode_str() -> None:
     assert ep.completed_at.strftime("%Y-%m-%d") in s
 
 
+def test_format_concat_labels() -> None:
+    task = Task(instruction="my task")
+    ep = Episode(
+        task=task,
+        rollout="step1",
+        result=TaskResult(task_id=task.id_, content="my result"),
+        metadata={"reflection": "a lesson"},
+        completed_at=datetime(2025, 6, 1, 12, 0, 0),
+    )
+    text = ep.format(
+        mode="concat",
+        include=[
+            "instruction",
+            "result",
+            "metadata",
+            "completed_at",
+            "rollout",
+        ],
+    )
+    assert "instruction: my task" in text
+    assert "result: my result" in text
+    assert "reflection: a lesson" in text
+    assert "completed_at: 2025-06-01 12:00:00" in text
+    assert "rollout: step1" in text
+
+
 def test_format_concat_completed_at() -> None:
     task = Task(instruction="task")
     ep = Episode(

--- a/tests/memory/test_recipes.py
+++ b/tests/memory/test_recipes.py
@@ -1,7 +1,7 @@
 """Unit tests for memory factory functions in memory/recipes.py."""
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,20 @@ from llm_agents_from_scratch.memory.recipes import (
 )
 from llm_agents_from_scratch.memory_stores.json import JSONMemoryStore
 from llm_agents_from_scratch.memory_stores.qdrant.store import QdrantMemoryStore
+
+_QDRANT_PATCH = (
+    "llm_agents_from_scratch.memory_stores.qdrant.store.QdrantClient"
+)
+
+
+@pytest.fixture
+def mock_qdrant_client():
+    with patch(_QDRANT_PATCH) as mock_cls:
+        instance = MagicMock()
+        instance.embedding_model_name = "BAAI/bge-small-en-v1.5"
+        instance.get_vector_field_name.return_value = "fast-bge-small-en-v1.5"
+        mock_cls.return_value = instance
+        yield instance
 
 
 def make_episode() -> Episode:
@@ -57,17 +71,21 @@ def test_recency_memory_max_results(tmp_path: Path) -> None:
 # --- similarity_memory ---
 
 
-def test_similarity_memory_returns_memory() -> None:
+def test_similarity_memory_returns_memory(
+    mock_qdrant_client: MagicMock,
+) -> None:
     memory = similarity_memory()
     assert isinstance(memory, Memory)
 
 
-def test_similarity_memory_store_is_qdrant() -> None:
+def test_similarity_memory_store_is_qdrant(
+    mock_qdrant_client: MagicMock,
+) -> None:
     memory = similarity_memory()
     assert isinstance(memory.store, QdrantMemoryStore)
 
 
-def test_similarity_memory_max_results() -> None:
+def test_similarity_memory_max_results(mock_qdrant_client: MagicMock) -> None:
     memory = similarity_memory(max_results=7)
     assert memory.store.max_results == 7  # noqa: PLR2004
 
@@ -75,28 +93,36 @@ def test_similarity_memory_max_results() -> None:
 # --- reflective_memory ---
 
 
-def test_reflective_memory_returns_memory() -> None:
+def test_reflective_memory_returns_memory(
+    mock_qdrant_client: MagicMock,
+) -> None:
     memory = reflective_memory(llm=make_llm())
     assert isinstance(memory, Memory)
 
 
-def test_reflective_memory_store_is_qdrant() -> None:
+def test_reflective_memory_store_is_qdrant(
+    mock_qdrant_client: MagicMock,
+) -> None:
     memory = reflective_memory(llm=make_llm())
     assert isinstance(memory.store, QdrantMemoryStore)
 
 
-def test_reflective_memory_has_reflection_fn() -> None:
+def test_reflective_memory_has_reflection_fn(
+    mock_qdrant_client: MagicMock,
+) -> None:
     memory = reflective_memory(llm=make_llm())
     assert "reflection" in memory.metadata_fns
 
 
-def test_reflective_memory_max_results() -> None:
+def test_reflective_memory_max_results(mock_qdrant_client: MagicMock) -> None:
     memory = reflective_memory(llm=make_llm(), max_results=2)
     assert memory.store.max_results == 2  # noqa: PLR2004
 
 
 @pytest.mark.asyncio
-async def test_reflective_memory_reflect_calls_llm() -> None:
+async def test_reflective_memory_reflect_calls_llm(
+    mock_qdrant_client: MagicMock,
+) -> None:
     llm = make_llm("always call the tool first")
     memory = reflective_memory(llm=llm)
     ep = make_episode()
@@ -108,7 +134,9 @@ async def test_reflective_memory_reflect_calls_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reflective_memory_custom_template_used() -> None:
+async def test_reflective_memory_custom_template_used(
+    mock_qdrant_client: MagicMock,
+) -> None:
     custom = "Task: {instruction}\nResult: {result}\nCustom:"
     llm = make_llm("custom lesson")
     memory = reflective_memory(llm=llm, template=custom)


### PR DESCRIPTION
## Summary

- `_format_concat` now prefixes each value with its field name (e.g. `instruction: ...`, `result: ...`, `completed_at: ...`)
- Metadata entries use their existing key as the label (e.g. `reflection: use more samples`)
- Adds `test_format_concat_labels` to cover all fields in one explicit assertion

Closes #615

## Test plan

- [ ] `pytest tests/data_structures/test_memory.py` — all pass
- [ ] `pytest tests/memory/test_qdrant_utils.py` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)