### PR TITLE
feat: replace Episode.format() include with exclude; drop EpisodeAttr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- feat: replace Episode.format() include with exclude; drop EpisodeAttr (#622)
 - feat: introduce FormatMode enum for Episode.format() mode param (#620)
 - feat: `Episode._format_concat` now prefixes each value with its field label (e.g. `instruction: ...`, `result: ...`); metadata entries use their key as label (#616)
 - feat: add delete() and update() to BaseMemoryStore (#609)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- feat: add delete() and update() to BaseMemoryStore (#609)
+- feat: introduce FormatMode enum for Episode.format() mode param
+# 620
 - feat: `Episode._format_concat` now prefixes each value with its field label (e.g. `instruction: ...`, `result: ...`); metadata entries use their key as label (#616)
+- feat: add delete() and update() to BaseMemoryStore (#609)
 
 ## [0.0.18] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- feat: introduce FormatMode enum for Episode.format() mode param
-# 620
+- feat: introduce FormatMode enum for Episode.format() mode param (#620)
 - feat: `Episode._format_concat` now prefixes each value with its field label (e.g. `instruction: ...`, `result: ...`); metadata entries use their key as label (#616)
 - feat: add delete() and update() to BaseMemoryStore (#609)
 

--- a/src/llm_agents_from_scratch/data_structures/__init__.py
+++ b/src/llm_agents_from_scratch/data_structures/__init__.py
@@ -1,6 +1,6 @@
 from .agent import NextStepDecision, Task, TaskResult, TaskStep, TaskStepResult
 from .llm import ChatMessage, ChatRole, CompleteResult
-from .memory import Episode, FormatMode, RecallMode
+from .memory import Episode, EpisodeFormatMode, RecallMode
 from .skill import SkillFrontmatter
 from .tool import ToolCall, ToolCallResult
 
@@ -17,7 +17,7 @@ __all__ = [
     "CompleteResult",
     # memory
     "Episode",
-    "FormatMode",
+    "EpisodeFormatMode",
     "RecallMode",
     # skill
     "SkillFrontmatter",

--- a/src/llm_agents_from_scratch/data_structures/__init__.py
+++ b/src/llm_agents_from_scratch/data_structures/__init__.py
@@ -1,6 +1,6 @@
 from .agent import NextStepDecision, Task, TaskResult, TaskStep, TaskStepResult
 from .llm import ChatMessage, ChatRole, CompleteResult
-from .memory import Episode, RecallMode
+from .memory import Episode, FormatMode, RecallMode
 from .skill import SkillFrontmatter
 from .tool import ToolCall, ToolCallResult
 
@@ -17,6 +17,7 @@ __all__ = [
     "CompleteResult",
     # memory
     "Episode",
+    "FormatMode",
     "RecallMode",
     # skill
     "SkillFrontmatter",

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -17,6 +17,13 @@ class RecallMode(str, Enum):
     SEARCH = "search"
 
 
+class FormatMode(str, Enum):
+    """Serialisation format used by ``Episode.format()``."""
+
+    XML = "xml"
+    CONCAT = "concat"
+
+
 EpisodeAttr = Literal[
     "instruction",
     "result",
@@ -56,16 +63,15 @@ class Episode(BaseModel):
 
     def format(
         self,
-        mode: Literal["xml", "concat"] = "xml",
+        mode: FormatMode = FormatMode.XML,
         include: list[EpisodeAttr] | None = None,
     ) -> str:
         """Serialise the episode for prompt injection or embedding.
 
         Args:
-            mode (Literal["xml", "concat"]): ``"xml"`` produces a
-                prompt-ready XML block; ``"concat"`` produces a
-                newline-joined string for embedding. Defaults to
-                ``"xml"``.
+            mode (FormatMode): ``FormatMode.XML`` produces a prompt-ready
+                XML block; ``FormatMode.CONCAT`` produces a newline-joined
+                string for embedding. Defaults to ``FormatMode.XML``.
             include (list[EpisodeAttr] | None): Attributes to include.
                 Defaults to ``["instruction", "result",
                 "metadata", "completed_at"]``.
@@ -81,7 +87,7 @@ class Episode(BaseModel):
             "metadata",
             "completed_at",
         ]
-        if mode == "concat":
+        if mode == FormatMode.CONCAT:
             return self._format_concat(attrs)
         return self._format_xml(attrs)
 
@@ -131,4 +137,4 @@ class Episode(BaseModel):
 
     def __str__(self) -> str:
         """Return a prompt-ready XML string representation of the episode."""
-        return self.format(mode="xml")
+        return self.format(mode=FormatMode.XML)

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -17,7 +17,7 @@ class RecallMode(str, Enum):
     SEARCH = "search"
 
 
-class FormatMode(str, Enum):
+class EpisodeFormatMode(str, Enum):
     """Serialisation format used by ``Episode.format()``."""
 
     XML = "xml"
@@ -63,15 +63,16 @@ class Episode(BaseModel):
 
     def format(
         self,
-        mode: FormatMode = FormatMode.XML,
+        mode: EpisodeFormatMode = EpisodeFormatMode.XML,
         include: list[EpisodeAttr] | None = None,
     ) -> str:
         """Serialise the episode for prompt injection or embedding.
 
         Args:
-            mode (FormatMode): ``FormatMode.XML`` produces a prompt-ready
-                XML block; ``FormatMode.CONCAT`` produces a newline-joined
-                string for embedding. Defaults to ``FormatMode.XML``.
+            mode (EpisodeFormatMode): ``EpisodeFormatMode.XML`` produces a
+                prompt-ready XML block; ``EpisodeFormatMode.CONCAT`` produces
+                a newline-joined string for embedding. Defaults to
+                ``EpisodeFormatMode.XML``.
             include (list[EpisodeAttr] | None): Attributes to include.
                 Defaults to ``["instruction", "result",
                 "metadata", "completed_at"]``.
@@ -87,7 +88,7 @@ class Episode(BaseModel):
             "metadata",
             "completed_at",
         ]
-        if mode == FormatMode.CONCAT:
+        if mode == EpisodeFormatMode.CONCAT:
             return self._format_concat(attrs)
         return self._format_xml(attrs)
 
@@ -137,4 +138,4 @@ class Episode(BaseModel):
 
     def __str__(self) -> str:
         """Return a prompt-ready XML string representation of the episode."""
-        return self.format(mode=FormatMode.XML)
+        return self.format(mode=EpisodeFormatMode.XML)

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -3,7 +3,6 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -22,16 +21,6 @@ class EpisodeFormatMode(str, Enum):
 
     XML = "xml"
     CONCAT = "concat"
-
-
-EpisodeAttr = Literal[
-    "instruction",
-    "result",
-    "error",
-    "metadata",
-    "completed_at",
-    "rollout",
-]
 
 
 class Episode(BaseModel):
@@ -64,7 +53,7 @@ class Episode(BaseModel):
     def format(
         self,
         mode: EpisodeFormatMode = EpisodeFormatMode.XML,
-        include: list[EpisodeAttr] | None = None,
+        exclude: set[str] | None = None,
     ) -> str:
         """Serialise the episode for prompt injection or embedding.
 
@@ -73,66 +62,48 @@ class Episode(BaseModel):
                 prompt-ready XML block; ``EpisodeFormatMode.CONCAT`` produces
                 a newline-joined string for embedding. Defaults to
                 ``EpisodeFormatMode.XML``.
-            include (list[EpisodeAttr] | None): Attributes to include.
-                Defaults to ``["instruction", "result",
-                "metadata", "completed_at"]``.
+            exclude (set[str] | None): Field names to omit. Defaults to
+                ``{"id_", "rollout"}`` — both are excluded by default as
+                they add noise in most contexts.
 
         Returns:
             str: Serialised episode string.
         """
-        # rollout is excluded by default — it is long and adds noise
-        attrs = include or [
-            "instruction",
-            "result",
-            "error",
-            "metadata",
-            "completed_at",
-        ]
+        excluded = exclude if exclude is not None else {"id_", "rollout"}
+        fields = [f for f in Episode.model_fields if f not in excluded]
         if mode == EpisodeFormatMode.CONCAT:
-            return self._format_concat(attrs)
-        return self._format_xml(attrs)
+            return self._format_concat(fields)
+        return self._format_xml(fields)
 
-    def _format_concat(self, fields: list[EpisodeAttr]) -> str:
+    def _format_concat(self, fields: list[str]) -> str:
         parts: list[str] = []
         for f in fields:
-            if f == "instruction":
-                parts.append(f"instruction: {self.task.instruction}")
-            elif f == "result" and self.result:
-                parts.append(f"result: {self.result.content}")
-            elif f == "error" and self.error:
-                parts.append(f"error: {self.error}")
-            elif f == "metadata" and self.metadata:
-                parts.extend(f"{k}: {v}" for k, v in self.metadata.items())
+            val = getattr(self, f)
+            if val is None:
+                continue
+            if f == "metadata":
+                parts.extend(f"{k}: {v}" for k, v in val.items())
             elif f == "completed_at":
-                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                ts = val.strftime("%Y-%m-%d %H:%M:%S")
                 parts.append(f"completed_at: {ts}")
-            elif f == "rollout":
-                parts.append(f"rollout: {self.rollout}")
+            else:
+                parts.append(f"{f}: {val}")
         return "\n".join(parts)
 
-    def _format_xml(self, fields: list[EpisodeAttr]) -> str:
+    def _format_xml(self, fields: list[str]) -> str:
         lines = ["  <episode>"]
         for f in fields:
-            if f == "instruction":
-                lines.append(
-                    f"    <task>{self.task.instruction}</task>",
-                )
-            elif f == "result" and self.result:
-                lines.append(
-                    f"    <result>{self.result.content}\n    </result>",
-                )
-            elif f == "error" and self.error:
-                lines.append(
-                    f"    <error>{self.error}\n    </error>",
-                )
-            elif f == "metadata" and self.metadata:
-                for key, val in self.metadata.items():
-                    lines.append(f"    <{key}>{val}</{key}>")
+            val = getattr(self, f)
+            if val is None:
+                continue
+            if f == "metadata":
+                for key, v in val.items():
+                    lines.append(f"    <{key}>{v}</{key}>")
             elif f == "completed_at":
-                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                ts = val.strftime("%Y-%m-%d %H:%M:%S")
                 lines.append(f"    <completed_at>{ts}</completed_at>")
-            elif f == "rollout":
-                lines.append(f"    <rollout>{self.rollout}</rollout>")
+            else:
+                lines.append(f"    <{f}>{val}</{f}>")
         lines.append("  </episode>")
         return "\n".join(lines)
 

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -7,7 +7,6 @@ from qdrant_client import QdrantClient, models
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import (
     Episode,
-    EpisodeAttr,
     RecallMode,
 )
 from llm_agents_from_scratch.errors import EpisodeNotFoundError
@@ -15,11 +14,7 @@ from llm_agents_from_scratch.memory_stores.qdrant.utils import (
     episode_to_qdrant_point_struct,
 )
 
-DEFAULT_EPISODE_INCLUDE: list[EpisodeAttr] = [
-    "instruction",
-    "result",
-    "metadata",
-]
+DEFAULT_EPISODE_EXCLUDE: set[str] = {"id_", "rollout", "completed_at"}
 
 
 class QdrantMemoryStore(BaseMemoryStore):
@@ -91,7 +86,7 @@ class QdrantMemoryStore(BaseMemoryStore):
         The full serialised episode and its completion timestamp are
         stored in the point payload for later retrieval. The key
         defaults to a concat-format serialisation of
-        ``DEFAULT_EPISODE_INCLUDE`` attributes when ``key`` is not
+        ``DEFAULT_EPISODE_EXCLUDE`` attributes when ``key`` is not
         provided.
 
         Args:
@@ -100,11 +95,10 @@ class QdrantMemoryStore(BaseMemoryStore):
                 provided by the calling memory strategy, this text is
                 used directly for the vector. Defaults to ``None``, in
                 which case the store formats the episode using
-                ``DEFAULT_EPISODE_INCLUDE``.
+                ``DEFAULT_EPISODE_EXCLUDE``.
         """
         text = key or episode.format(
-            mode="concat",
-            include=DEFAULT_EPISODE_INCLUDE,
+            exclude=DEFAULT_EPISODE_EXCLUDE,
         )
         self._client.upsert(
             collection_name=self._collection,
@@ -207,7 +201,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             key (str | None): Pre-formatted text to embed. When provided,
                 used directly for the vector. Defaults to ``None``, in
                 which case the store formats the episode using
-                ``DEFAULT_EPISODE_INCLUDE``.
+                ``DEFAULT_EPISODE_EXCLUDE``.
 
         Raises:
             EpisodeNotFoundError: If no point with ``episode.id_`` exists.
@@ -217,8 +211,7 @@ class QdrantMemoryStore(BaseMemoryStore):
                 f"Episode '{episode.id_}' not found in QdrantMemoryStore.",
             )
         text = key or episode.format(
-            mode="concat",
-            include=DEFAULT_EPISODE_INCLUDE,
+            exclude=DEFAULT_EPISODE_EXCLUDE,
         )
         self._client.upsert(
             collection_name=self._collection,

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -5,7 +5,10 @@ from llm_agents_from_scratch.data_structures import (
     Task,
     TaskResult,
 )
-from llm_agents_from_scratch.data_structures.memory import Episode, FormatMode
+from llm_agents_from_scratch.data_structures.memory import (
+    Episode,
+    EpisodeFormatMode,
+)
 
 
 def test_episode_str() -> None:
@@ -35,7 +38,7 @@ def test_format_concat_labels() -> None:
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
     text = ep.format(
-        mode=FormatMode.CONCAT,
+        mode=EpisodeFormatMode.CONCAT,
         include=[
             "instruction",
             "result",
@@ -59,7 +62,7 @@ def test_format_concat_completed_at() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(mode=FormatMode.CONCAT, include=["completed_at"])
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["completed_at"])
     assert "2025-06-01 12:00:00" in text
 
 
@@ -70,7 +73,7 @@ def test_format_concat_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=FormatMode.CONCAT, include=["rollout"])
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["rollout"])
     assert "step1 -> step2" in text
 
 
@@ -82,7 +85,7 @@ def test_format_xml_metadata() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         metadata={"reflection": "key lesson here"},
     )
-    text = ep.format(mode=FormatMode.XML, include=["metadata"])
+    text = ep.format(mode=EpisodeFormatMode.XML, include=["metadata"])
     assert "<reflection>key lesson here</reflection>" in text
 
 
@@ -93,7 +96,7 @@ def test_format_xml_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=FormatMode.XML, include=["rollout"])
+    text = ep.format(mode=EpisodeFormatMode.XML, include=["rollout"])
     assert "<rollout>step1 -> step2</rollout>" in text
 
 
@@ -101,7 +104,7 @@ def test_format_xml_error() -> None:
     task = Task(instruction="task")
     err = RuntimeError("something went wrong")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=FormatMode.XML, include=["error"])
+    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
     assert "<error>something went wrong" in text
 
 
@@ -112,7 +115,7 @@ def test_format_xml_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=FormatMode.XML, include=["error"])
+    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
     assert "<error>" not in text
 
 
@@ -120,7 +123,7 @@ def test_format_concat_error() -> None:
     task = Task(instruction="task")
     err = ValueError("bad value")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=FormatMode.CONCAT, include=["error"])
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
     assert "bad value" in text
 
 
@@ -131,7 +134,7 @@ def test_format_concat_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=FormatMode.CONCAT, include=["error"])
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
     assert text == ""
 
 

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -5,7 +5,7 @@ from llm_agents_from_scratch.data_structures import (
     Task,
     TaskResult,
 )
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, FormatMode
 
 
 def test_episode_str() -> None:
@@ -35,7 +35,7 @@ def test_format_concat_labels() -> None:
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
     text = ep.format(
-        mode="concat",
+        mode=FormatMode.CONCAT,
         include=[
             "instruction",
             "result",
@@ -59,7 +59,7 @@ def test_format_concat_completed_at() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(mode="concat", include=["completed_at"])
+    text = ep.format(mode=FormatMode.CONCAT, include=["completed_at"])
     assert "2025-06-01 12:00:00" in text
 
 
@@ -70,7 +70,7 @@ def test_format_concat_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode="concat", include=["rollout"])
+    text = ep.format(mode=FormatMode.CONCAT, include=["rollout"])
     assert "step1 -> step2" in text
 
 
@@ -82,7 +82,7 @@ def test_format_xml_metadata() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         metadata={"reflection": "key lesson here"},
     )
-    text = ep.format(mode="xml", include=["metadata"])
+    text = ep.format(mode=FormatMode.XML, include=["metadata"])
     assert "<reflection>key lesson here</reflection>" in text
 
 
@@ -93,7 +93,7 @@ def test_format_xml_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode="xml", include=["rollout"])
+    text = ep.format(mode=FormatMode.XML, include=["rollout"])
     assert "<rollout>step1 -> step2</rollout>" in text
 
 
@@ -101,7 +101,7 @@ def test_format_xml_error() -> None:
     task = Task(instruction="task")
     err = RuntimeError("something went wrong")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode="xml", include=["error"])
+    text = ep.format(mode=FormatMode.XML, include=["error"])
     assert "<error>something went wrong" in text
 
 
@@ -112,7 +112,7 @@ def test_format_xml_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode="xml", include=["error"])
+    text = ep.format(mode=FormatMode.XML, include=["error"])
     assert "<error>" not in text
 
 
@@ -120,7 +120,7 @@ def test_format_concat_error() -> None:
     task = Task(instruction="task")
     err = ValueError("bad value")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode="concat", include=["error"])
+    text = ep.format(mode=FormatMode.CONCAT, include=["error"])
     assert "bad value" in text
 
 
@@ -131,7 +131,7 @@ def test_format_concat_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode="concat", include=["error"])
+    text = ep.format(mode=FormatMode.CONCAT, include=["error"])
     assert text == ""
 
 

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -10,6 +10,8 @@ from llm_agents_from_scratch.data_structures.memory import (
     EpisodeFormatMode,
 )
 
+_ALL_FIELDS = set(Episode.model_fields)
+
 
 def test_episode_str() -> None:
     """Tests Episode.__str__ produces prompt-ready XML with key fields."""
@@ -24,7 +26,7 @@ def test_episode_str() -> None:
 
     assert "<episode>" in s
     assert "<task>summarise the doc</task>" in s
-    assert "<result>here is the summary\n    </result>" in s
+    assert "<result>here is the summary</result>" in s
     assert ep.completed_at.strftime("%Y-%m-%d") in s
 
 
@@ -37,17 +39,8 @@ def test_format_concat_labels() -> None:
         metadata={"reflection": "a lesson"},
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(
-        mode=EpisodeFormatMode.CONCAT,
-        include=[
-            "instruction",
-            "result",
-            "metadata",
-            "completed_at",
-            "rollout",
-        ],
-    )
-    assert "instruction: my task" in text
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, exclude={"id_"})
+    assert "task: my task" in text
     assert "result: my result" in text
     assert "reflection: a lesson" in text
     assert "completed_at: 2025-06-01 12:00:00" in text
@@ -62,7 +55,10 @@ def test_format_concat_completed_at() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["completed_at"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"completed_at"},
+    )
     assert "2025-06-01 12:00:00" in text
 
 
@@ -73,7 +69,10 @@ def test_format_concat_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["rollout"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"rollout"},
+    )
     assert "step1 -> step2" in text
 
 
@@ -85,7 +84,10 @@ def test_format_xml_metadata() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         metadata={"reflection": "key lesson here"},
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["metadata"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"metadata"},
+    )
     assert "<reflection>key lesson here</reflection>" in text
 
 
@@ -96,7 +98,10 @@ def test_format_xml_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["rollout"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"rollout"},
+    )
     assert "<rollout>step1 -> step2</rollout>" in text
 
 
@@ -104,7 +109,10 @@ def test_format_xml_error() -> None:
     task = Task(instruction="task")
     err = RuntimeError("something went wrong")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "<error>something went wrong" in text
 
 
@@ -115,7 +123,10 @@ def test_format_xml_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "<error>" not in text
 
 
@@ -123,7 +134,10 @@ def test_format_concat_error() -> None:
     task = Task(instruction="task")
     err = ValueError("bad value")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "bad value" in text
 
 
@@ -134,7 +148,10 @@ def test_format_concat_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert text == ""
 
 

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -1,5 +1,5 @@
 from llm_agents_from_scratch.data_structures import Task, TaskResult
-from llm_agents_from_scratch.data_structures.memory import Episode
+from llm_agents_from_scratch.data_structures.memory import Episode, FormatMode
 from llm_agents_from_scratch.memory_stores.qdrant.utils import (
     episode_to_qdrant_point_struct,
 )
@@ -52,7 +52,10 @@ def test_document_model_name() -> None:
 
 def test_text_passed_through_to_document() -> None:
     episode = _make_episode()
-    text = episode.format(mode="concat", include=["instruction", "result"])
+    text = episode.format(
+        mode=FormatMode.CONCAT,
+        include=["instruction", "result"],
+    )
     point = episode_to_qdrant_point_struct(
         episode,
         text,

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -57,7 +57,7 @@ def test_text_passed_through_to_document() -> None:
     episode = _make_episode()
     text = episode.format(
         mode=EpisodeFormatMode.CONCAT,
-        include=["instruction", "result"],
+        exclude={"id_", "rollout", "error", "metadata", "completed_at"},
     )
     point = episode_to_qdrant_point_struct(
         episode,
@@ -79,8 +79,8 @@ def test_metadata_in_text_when_caller_includes_it() -> None:
         metadata={"reflection": "Always verify the name spelling."},
     )
     text = episode.format(
-        mode="concat",
-        include=["instruction", "result", "metadata"],
+        mode=EpisodeFormatMode.CONCAT,
+        exclude={"id_", "rollout", "error", "completed_at"},
     )
     point = episode_to_qdrant_point_struct(
         episode,

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -1,5 +1,8 @@
 from llm_agents_from_scratch.data_structures import Task, TaskResult
-from llm_agents_from_scratch.data_structures.memory import Episode, FormatMode
+from llm_agents_from_scratch.data_structures.memory import (
+    Episode,
+    EpisodeFormatMode,
+)
 from llm_agents_from_scratch.memory_stores.qdrant.utils import (
     episode_to_qdrant_point_struct,
 )
@@ -53,7 +56,7 @@ def test_document_model_name() -> None:
 def test_text_passed_through_to_document() -> None:
     episode = _make_episode()
     text = episode.format(
-        mode=FormatMode.CONCAT,
+        mode=EpisodeFormatMode.CONCAT,
         include=["instruction", "result"],
     )
     point = episode_to_qdrant_point_struct(


### PR DESCRIPTION
## Summary

- Replaces `include: list[EpisodeAttr] | None` with `exclude: set[str] | None` (default `{"id_", "rollout"}`) — callers only name what they don't want; new fields appear automatically
- Drives field iteration from `Episode.model_fields` instead of a hardcoded list — `EpisodeAttr` Literal removed entirely
- Simplifies `_format_concat` / `_format_xml` loops: only `metadata` and `completed_at` need special handling; all other fields use `getattr` + f-string via `Task.__str__`, `TaskResult.__str__`, etc.
- Replaces `DEFAULT_EPISODE_INCLUDE` with `DEFAULT_EPISODE_EXCLUDE` in `QdrantMemoryStore`; `error` is now included in embedding text (was previously omitted before `result`/`error` were separated)

Closes #619
Closes #621

## Test plan

- [ ] `pytest tests/` — 311 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)