### PR TITLE
refactor: replace EpisodeAttr/include with exclude set in Episode.format()

### DIFF
--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -76,7 +76,9 @@ class Episode(BaseModel):
 
     def _format_concat(self, exclude: set[str]) -> str:
         parts: list[str] = []
-        for f in [f for f in Episode.model_fields if f not in exclude]:
+        for f in Episode.model_fields:
+            if f in exclude:
+                continue
             val = getattr(self, f)
             if val is None:
                 continue
@@ -91,7 +93,9 @@ class Episode(BaseModel):
 
     def _format_xml(self, exclude: set[str]) -> str:
         lines = ["  <episode>"]
-        for f in [f for f in Episode.model_fields if f not in exclude]:
+        for f in Episode.model_fields:
+            if f in exclude:
+                continue
             val = getattr(self, f)
             if val is None:
                 continue

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -17,7 +17,7 @@ class RecallMode(str, Enum):
 
 
 class EpisodeFormatMode(str, Enum):
-    """Serialisation format used by ``Episode.format()``."""
+    """Serialization format used by ``Episode.format()``."""
 
     XML = "xml"
     CONCAT = "concat"
@@ -55,7 +55,7 @@ class Episode(BaseModel):
         mode: EpisodeFormatMode = EpisodeFormatMode.XML,
         exclude: set[str] | None = None,
     ) -> str:
-        """Serialise the episode for prompt injection or embedding.
+        """Serialize the episode for prompt injection or embedding.
 
         Args:
             mode (EpisodeFormatMode): ``EpisodeFormatMode.XML`` produces a
@@ -67,7 +67,7 @@ class Episode(BaseModel):
                 they add noise in most contexts.
 
         Returns:
-            str: Serialised episode string.
+            str: Serialized episode string.
         """
         excluded = exclude if exclude is not None else {"id_", "rollout"}
         if mode == EpisodeFormatMode.CONCAT:

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -79,16 +79,14 @@ class Episode(BaseModel):
         for f in Episode.model_fields:
             if f in exclude:
                 continue
-            val = getattr(self, f)
-            if val is None:
-                continue
-            if f == "metadata":
-                parts.extend(f"{k}: {v}" for k, v in val.items())
-            elif f == "completed_at":
-                ts = val.strftime("%Y-%m-%d %H:%M:%S")
-                parts.append(f"completed_at: {ts}")
-            else:
-                parts.append(f"{f}: {val}")
+            if val := getattr(self, f, None):
+                if f == "metadata":
+                    parts.extend(f"{k}: {v}" for k, v in val.items())
+                elif f == "completed_at":
+                    ts = val.strftime("%Y-%m-%d %H:%M:%S")
+                    parts.append(f"completed_at: {ts}")
+                else:
+                    parts.append(f"{f}: {val}")
         return "\n".join(parts)
 
     def _format_xml(self, exclude: set[str]) -> str:
@@ -96,17 +94,15 @@ class Episode(BaseModel):
         for f in Episode.model_fields:
             if f in exclude:
                 continue
-            val = getattr(self, f)
-            if val is None:
-                continue
-            if f == "metadata":
-                for key, v in val.items():
-                    lines.append(f"    <{key}>{v}</{key}>")
-            elif f == "completed_at":
-                ts = val.strftime("%Y-%m-%d %H:%M:%S")
-                lines.append(f"    <completed_at>{ts}</completed_at>")
-            else:
-                lines.append(f"    <{f}>{val}</{f}>")
+            if val := getattr(self, f, None):
+                if f == "metadata":
+                    for key, v in val.items():
+                        lines.append(f"    <{key}>{v}</{key}>")
+                elif f == "completed_at":
+                    ts = val.strftime("%Y-%m-%d %H:%M:%S")
+                    lines.append(f"    <completed_at>{ts}</completed_at>")
+                else:
+                    lines.append(f"    <{f}>{val}</{f}>")
         lines.append("  </episode>")
         return "\n".join(lines)
 

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -70,14 +70,13 @@ class Episode(BaseModel):
             str: Serialised episode string.
         """
         excluded = exclude if exclude is not None else {"id_", "rollout"}
-        fields = [f for f in Episode.model_fields if f not in excluded]
         if mode == EpisodeFormatMode.CONCAT:
-            return self._format_concat(fields)
-        return self._format_xml(fields)
+            return self._format_concat(excluded)
+        return self._format_xml(excluded)
 
-    def _format_concat(self, fields: list[str]) -> str:
+    def _format_concat(self, exclude: set[str]) -> str:
         parts: list[str] = []
-        for f in fields:
+        for f in [f for f in Episode.model_fields if f not in exclude]:
             val = getattr(self, f)
             if val is None:
                 continue
@@ -90,9 +89,9 @@ class Episode(BaseModel):
                 parts.append(f"{f}: {val}")
         return "\n".join(parts)
 
-    def _format_xml(self, fields: list[str]) -> str:
+    def _format_xml(self, exclude: set[str]) -> str:
         lines = ["  <episode>"]
-        for f in fields:
+        for f in [f for f in Episode.model_fields if f not in exclude]:
             val = getattr(self, f)
             if val is None:
                 continue

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -3,7 +3,6 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -22,16 +21,6 @@ class EpisodeFormatMode(str, Enum):
 
     XML = "xml"
     CONCAT = "concat"
-
-
-EpisodeAttr = Literal[
-    "instruction",
-    "result",
-    "error",
-    "metadata",
-    "completed_at",
-    "rollout",
-]
 
 
 class Episode(BaseModel):
@@ -64,7 +53,7 @@ class Episode(BaseModel):
     def format(
         self,
         mode: EpisodeFormatMode = EpisodeFormatMode.XML,
-        include: list[EpisodeAttr] | None = None,
+        exclude: set[str] | None = None,
     ) -> str:
         """Serialise the episode for prompt injection or embedding.
 
@@ -73,66 +62,48 @@ class Episode(BaseModel):
                 prompt-ready XML block; ``EpisodeFormatMode.CONCAT`` produces
                 a newline-joined string for embedding. Defaults to
                 ``EpisodeFormatMode.XML``.
-            include (list[EpisodeAttr] | None): Attributes to include.
-                Defaults to ``["instruction", "result",
-                "metadata", "completed_at"]``.
+            exclude (set[str] | None): Field names to omit. Defaults to
+                ``{"id_", "rollout"}`` — both are excluded by default as
+                they add noise in most contexts.
 
         Returns:
             str: Serialised episode string.
         """
-        # rollout is excluded by default — it is long and adds noise
-        attrs = include or [
-            "instruction",
-            "result",
-            "error",
-            "metadata",
-            "completed_at",
-        ]
+        excluded = exclude if exclude is not None else {"id_", "rollout"}
+        fields = [f for f in Episode.model_fields if f not in excluded]
         if mode == EpisodeFormatMode.CONCAT:
-            return self._format_concat(attrs)
-        return self._format_xml(attrs)
+            return self._format_concat(fields)
+        return self._format_xml(fields)
 
-    def _format_concat(self, fields: list[EpisodeAttr]) -> str:
+    def _format_concat(self, fields: list[str]) -> str:
         parts: list[str] = []
         for f in fields:
-            if f == "instruction":
-                parts.append(f"instruction: {self.task.instruction}")
-            elif f == "result" and self.result:
-                parts.append(f"result: {self.result.content}")
-            elif f == "error" and self.error:
-                parts.append(f"error: {self.error}")
-            elif f == "metadata" and self.metadata:
-                parts.extend(f"{k}: {v}" for k, v in self.metadata.items())
+            val = getattr(self, f)
+            if val is None:
+                continue
+            if f == "metadata":
+                parts.extend(f"{k}: {v}" for k, v in val.items())
             elif f == "completed_at":
-                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                ts = val.strftime("%Y-%m-%d %H:%M:%S")
                 parts.append(f"completed_at: {ts}")
-            elif f == "rollout":
-                parts.append(f"rollout: {self.rollout}")
+            else:
+                parts.append(f"{f}: {val}")
         return "\n".join(parts)
 
-    def _format_xml(self, fields: list[EpisodeAttr]) -> str:
+    def _format_xml(self, fields: list[str]) -> str:
         lines = ["  <episode>"]
         for f in fields:
-            if f == "instruction":
-                lines.append(
-                    f"    <task>{self.task.instruction}</task>",
-                )
-            elif f == "result" and self.result:
-                lines.append(
-                    f"    <result>{self.result.content}\n    </result>",
-                )
-            elif f == "error" and self.error:
-                lines.append(
-                    f"    <error>{self.error}\n    </error>",
-                )
-            elif f == "metadata" and self.metadata:
-                for key, val in self.metadata.items():
-                    lines.append(f"    <{key}>{val}</{key}>")
+            val = getattr(self, f)
+            if val is None:
+                continue
+            if f == "metadata":
+                for key, v in val.items():
+                    lines.append(f"    <{key}>{v}</{key}>")
             elif f == "completed_at":
-                ts = self.completed_at.strftime("%Y-%m-%d %H:%M:%S")
+                ts = val.strftime("%Y-%m-%d %H:%M:%S")
                 lines.append(f"    <completed_at>{ts}</completed_at>")
-            elif f == "rollout":
-                lines.append(f"    <rollout>{self.rollout}</rollout>")
+            else:
+                lines.append(f"    <{f}>{val}</{f}>")
         lines.append("  </episode>")
         return "\n".join(lines)
 

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -79,7 +79,7 @@ class Episode(BaseModel):
         for f in Episode.model_fields:
             if f in exclude:
                 continue
-            if val := getattr(self, f, None):
+            if val := getattr(self, f):
                 if f == "metadata":
                     parts.extend(f"{k}: {v}" for k, v in val.items())
                 elif f == "completed_at":
@@ -94,7 +94,7 @@ class Episode(BaseModel):
         for f in Episode.model_fields:
             if f in exclude:
                 continue
-            if val := getattr(self, f, None):
+            if val := getattr(self, f):
                 if f == "metadata":
                     for key, v in val.items():
                         lines.append(f"    <{key}>{v}</{key}>")

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -7,7 +7,7 @@ from qdrant_client import QdrantClient, models
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import (
     Episode,
-    EpisodeAttr,
+    EpisodeFormatMode,
     RecallMode,
 )
 from llm_agents_from_scratch.errors import EpisodeNotFoundError
@@ -15,11 +15,7 @@ from llm_agents_from_scratch.memory_stores.qdrant.utils import (
     episode_to_qdrant_point_struct,
 )
 
-DEFAULT_EPISODE_INCLUDE: list[EpisodeAttr] = [
-    "instruction",
-    "result",
-    "metadata",
-]
+DEFAULT_EPISODE_EXCLUDE: set[str] = {"id_", "rollout", "completed_at"}
 
 
 class QdrantMemoryStore(BaseMemoryStore):
@@ -90,9 +86,8 @@ class QdrantMemoryStore(BaseMemoryStore):
 
         The full serialised episode and its completion timestamp are
         stored in the point payload for later retrieval. The key
-        defaults to a concat-format serialisation of
-        ``DEFAULT_EPISODE_INCLUDE`` attributes when ``key`` is not
-        provided.
+        defaults to a concat-format serialisation using
+        ``DEFAULT_EPISODE_EXCLUDE`` when ``key`` is not provided.
 
         Args:
             episode (Episode): The completed episode to store.
@@ -100,11 +95,11 @@ class QdrantMemoryStore(BaseMemoryStore):
                 provided by the calling memory strategy, this text is
                 used directly for the vector. Defaults to ``None``, in
                 which case the store formats the episode using
-                ``DEFAULT_EPISODE_INCLUDE``.
+                ``DEFAULT_EPISODE_EXCLUDE``.
         """
         text = key or episode.format(
-            mode="concat",
-            include=DEFAULT_EPISODE_INCLUDE,
+            mode=EpisodeFormatMode.CONCAT,
+            exclude=DEFAULT_EPISODE_EXCLUDE,
         )
         self._client.upsert(
             collection_name=self._collection,
@@ -207,7 +202,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             key (str | None): Pre-formatted text to embed. When provided,
                 used directly for the vector. Defaults to ``None``, in
                 which case the store formats the episode using
-                ``DEFAULT_EPISODE_INCLUDE``.
+                ``DEFAULT_EPISODE_EXCLUDE``.
 
         Raises:
             EpisodeNotFoundError: If no point with ``episode.id_`` exists.
@@ -217,8 +212,8 @@ class QdrantMemoryStore(BaseMemoryStore):
                 f"Episode '{episode.id_}' not found in QdrantMemoryStore.",
             )
         text = key or episode.format(
-            mode="concat",
-            include=DEFAULT_EPISODE_INCLUDE,
+            mode=EpisodeFormatMode.CONCAT,
+            exclude=DEFAULT_EPISODE_EXCLUDE,
         )
         self._client.upsert(
             collection_name=self._collection,

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -84,9 +84,9 @@ class QdrantMemoryStore(BaseMemoryStore):
     ) -> None:
         """Embed and persist an episode to the Qdrant collection.
 
-        The full serialised episode and its completion timestamp are
+        The full serialized episode and its completion timestamp are
         stored in the point payload for later retrieval. The key
-        defaults to a concat-format serialisation using
+        defaults to a concat-format Serialization using
         ``DEFAULT_EPISODE_EXCLUDE`` when ``key`` is not provided.
 
         Args:

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -10,6 +10,8 @@ from llm_agents_from_scratch.data_structures.memory import (
     EpisodeFormatMode,
 )
 
+_ALL_FIELDS = set(Episode.model_fields)
+
 
 def test_episode_str() -> None:
     """Tests Episode.__str__ produces prompt-ready XML with key fields."""
@@ -24,7 +26,7 @@ def test_episode_str() -> None:
 
     assert "<episode>" in s
     assert "<task>summarise the doc</task>" in s
-    assert "<result>here is the summary\n    </result>" in s
+    assert "<result>here is the summary</result>" in s
     assert ep.completed_at.strftime("%Y-%m-%d") in s
 
 
@@ -37,17 +39,8 @@ def test_format_concat_labels() -> None:
         metadata={"reflection": "a lesson"},
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(
-        mode=EpisodeFormatMode.CONCAT,
-        include=[
-            "instruction",
-            "result",
-            "metadata",
-            "completed_at",
-            "rollout",
-        ],
-    )
-    assert "instruction: my task" in text
+    text = ep.format(mode=EpisodeFormatMode.CONCAT, exclude={"id_"})
+    assert "task: my task" in text
     assert "result: my result" in text
     assert "reflection: a lesson" in text
     assert "completed_at: 2025-06-01 12:00:00" in text
@@ -62,7 +55,10 @@ def test_format_concat_completed_at() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         completed_at=datetime(2025, 6, 1, 12, 0, 0),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["completed_at"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"completed_at"},
+    )
     assert "2025-06-01 12:00:00" in text
 
 
@@ -73,7 +69,10 @@ def test_format_concat_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["rollout"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"rollout"},
+    )
     assert "step1 -> step2" in text
 
 
@@ -85,7 +84,10 @@ def test_format_xml_metadata() -> None:
         result=TaskResult(task_id=task.id_, content="result"),
         metadata={"reflection": "key lesson here"},
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["metadata"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"metadata"},
+    )
     assert "<reflection>key lesson here</reflection>" in text
 
 
@@ -96,7 +98,10 @@ def test_format_xml_rollout() -> None:
         rollout="step1 -> step2",
         result=TaskResult(task_id=task.id_, content="result"),
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["rollout"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"rollout"},
+    )
     assert "<rollout>step1 -> step2</rollout>" in text
 
 
@@ -104,7 +109,10 @@ def test_format_xml_error() -> None:
     task = Task(instruction="task")
     err = RuntimeError("something went wrong")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "<error>something went wrong" in text
 
 
@@ -115,7 +123,10 @@ def test_format_xml_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=EpisodeFormatMode.XML, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.XML,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "<error>" not in text
 
 
@@ -123,7 +134,10 @@ def test_format_concat_error() -> None:
     task = Task(instruction="task")
     err = ValueError("bad value")
     ep = Episode(task=task, rollout="", error=err)
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert "bad value" in text
 
 
@@ -134,7 +148,10 @@ def test_format_concat_error_omitted_when_none() -> None:
         rollout="",
         result=TaskResult(task_id=task.id_, content="ok"),
     )
-    text = ep.format(mode=EpisodeFormatMode.CONCAT, include=["error"])
+    text = ep.format(
+        mode=EpisodeFormatMode.CONCAT,
+        exclude=_ALL_FIELDS - {"error"},
+    )
     assert text == ""
 
 

--- a/tests/memory/test_qdrant_utils.py
+++ b/tests/memory/test_qdrant_utils.py
@@ -57,7 +57,7 @@ def test_text_passed_through_to_document() -> None:
     episode = _make_episode()
     text = episode.format(
         mode=EpisodeFormatMode.CONCAT,
-        include=["instruction", "result"],
+        exclude={"id_", "rollout", "error", "metadata", "completed_at"},
     )
     point = episode_to_qdrant_point_struct(
         episode,
@@ -79,8 +79,8 @@ def test_metadata_in_text_when_caller_includes_it() -> None:
         metadata={"reflection": "Always verify the name spelling."},
     )
     text = episode.format(
-        mode="concat",
-        include=["instruction", "result", "metadata"],
+        mode=EpisodeFormatMode.CONCAT,
+        exclude={"id_", "rollout", "error", "completed_at"},
     )
     point = episode_to_qdrant_point_struct(
         episode,


### PR DESCRIPTION
## Summary

- Drops `EpisodeAttr` Literal type entirely — field iteration now driven by `Episode.model_fields`
- Replaces `include: list[EpisodeAttr]` with `exclude: set[str] | None` (default `{"id_", "rollout"}`) in `Episode.format()`
- New fields added to `Episode` appear in output automatically; callers opt out instead of in
- `QdrantMemoryStore` migrates from `DEFAULT_EPISODE_INCLUDE` to `DEFAULT_EPISODE_EXCLUDE = {"id_", "rollout", "completed_at"}`; `error` field is now included in embeddings (was wrongly excluded before result/error were separated)
- Tests rewritten using `exclude=_ALL_FIELDS - {"field"}` pattern to isolate fields

Closes #619, closes #621.

## Test plan

- [x] `tests/data_structures/test_memory.py` — all 11 tests pass
- [x] `tests/memory/test_qdrant_utils.py` — all 8 tests pass
- [x] `make lint` — ruff, mypy, all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)