### PR TITLE
examples: add ch07.ipynb with Episode construction and format modes example

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -126,21 +126,7 @@
    "id": "a1b2c3d4-0007-0000-0000-000000000008",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
-    "from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n",
-    "\n",
-    "task = Task(instruction=\"What is the capital of France?\")\n",
-    "result = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\n",
-    "episode = Episode(task=task, rollout=\"\", result=result)\n",
-    "\n",
-    "print(\"=== XML (default) ===\")\n",
-    "print(episode.format(mode=EpisodeFormatMode.XML))\n",
-    "\n",
-    "print()\n",
-    "print(\"=== CONCAT ===\")\n",
-    "print(episode.format(mode=EpisodeFormatMode.CONCAT))"
-   ]
+   "source": "from llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n\ntask = Task(instruction=\"What is the capital of France?\")\nresult = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\nepisode = Episode(task=task, rollout=\"mock rollout\", result=result)\n\nprint(\"=== XML (default) ===\")\nprint(episode.format(mode=EpisodeFormatMode.XML))\n\nprint()\nprint(\"=== CONCAT ===\")\nprint(episode.format(mode=EpisodeFormatMode.CONCAT))"
   }
  ],
  "metadata": {

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0007-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "# Chapter 7 — Episodic Memory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0007-0000-0000-000000000002",
+   "metadata": {},
+   "source": [
+    "## Setup Instructions\n",
+    "\n",
+    "To ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n",
+    "\n",
+    "```sh\n",
+    "uv run --with jupyter jupyter lab\n",
+    "```\n",
+    "\n",
+    "Alternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPi by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0007-0000-0000-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPi\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0007-0000-0000-000000000004",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0007-0000-0000-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, shutil, subprocess, time, urllib.request, urllib.error\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\"\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0007-0000-0000-000000000006",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0007-0000-0000-000000000007",
+   "metadata": {},
+   "source": [
+    "### Example 1: Constructing an Episode and Printing Format Modes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0007-0000-0000-000000000008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n",
+    "\n",
+    "task = Task(instruction=\"What is the capital of France?\")\n",
+    "result = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\n",
+    "episode = Episode(task=task, rollout=\"\", result=result)\n",
+    "\n",
+    "print(\"=== XML (default) ===\")\n",
+    "print(episode.format(mode=EpisodeFormatMode.XML))\n",
+    "\n",
+    "print()\n",
+    "print(\"=== CONCAT ===\")\n",
+    "print(episode.format(mode=EpisodeFormatMode.CONCAT))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat": 4,
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -47,10 +47,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "a1b2c3d4-0007-0000-0000-000000000005",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os, shutil, subprocess, time, urllib.request, urllib.error\n",
     "\n",
@@ -122,11 +130,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "a1b2c3d4-0007-0000-0000-000000000008",
    "metadata": {},
-   "outputs": [],
-   "source": "from llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n\ntask = Task(instruction=\"What is the capital of France?\")\nresult = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\nepisode = Episode(\n    task=task,\n    rollout=\"mock rollout\",\n    result=result,\n    metadata={\"reflection\": \"Always verify country-capital pairs before answering.\"},\n)\n\nprint(\"=== XML (default) ===\")\nprint(episode.format(mode=EpisodeFormatMode.XML))\n\nprint()\nprint(\"=== CONCAT ===\")\nprint(episode.format(mode=EpisodeFormatMode.CONCAT))"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== XML (default) ===\n",
+      "  <episode>\n",
+      "    <task>What is the capital of France?</task>\n",
+      "    <result>The capital of France is Paris.</result>\n",
+      "    <reflection>Always verify country-capital pairs before answering.</reflection>\n",
+      "    <completed_at>2026-06-07 02:06:19</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "=== CONCAT ===\n",
+      "task: What is the capital of France?\n",
+      "result: The capital of France is Paris.\n",
+      "reflection: Always verify country-capital pairs before answering.\n",
+      "completed_at: 2026-06-07 02:06:19\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n",
+    "\n",
+    "task = Task(instruction=\"What is the capital of France?\")\n",
+    "result = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\n",
+    "episode = Episode(\n",
+    "    task=task,\n",
+    "    rollout=\"mock rollout\",\n",
+    "    result=result,\n",
+    "    metadata={\"reflection\": \"Always verify country-capital pairs before answering.\"},\n",
+    ")\n",
+    "\n",
+    "print(\"=== XML (default) ===\")\n",
+    "print(episode.format(mode=EpisodeFormatMode.XML))\n",
+    "\n",
+    "print()\n",
+    "print(\"=== CONCAT ===\")\n",
+    "print(episode.format(mode=EpisodeFormatMode.CONCAT))"
+   ]
   }
  ],
  "metadata": {
@@ -143,8 +190,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat": 4,
-   "nbformat_minor": 5,
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.5"
   }

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -126,7 +126,7 @@
    "id": "a1b2c3d4-0007-0000-0000-000000000008",
    "metadata": {},
    "outputs": [],
-   "source": "from llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n\ntask = Task(instruction=\"What is the capital of France?\")\nresult = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\nepisode = Episode(task=task, rollout=\"mock rollout\", result=result)\n\nprint(\"=== XML (default) ===\")\nprint(episode.format(mode=EpisodeFormatMode.XML))\n\nprint()\nprint(\"=== CONCAT ===\")\nprint(episode.format(mode=EpisodeFormatMode.CONCAT))"
+   "source": "from llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode, EpisodeFormatMode\n\ntask = Task(instruction=\"What is the capital of France?\")\nresult = TaskResult(task_id=task.id_, content=\"The capital of France is Paris.\")\nepisode = Episode(\n    task=task,\n    rollout=\"mock rollout\",\n    result=result,\n    metadata={\"reflection\": \"Always verify country-capital pairs before answering.\"},\n)\n\nprint(\"=== XML (default) ===\")\nprint(episode.format(mode=EpisodeFormatMode.XML))\n\nprint()\nprint(\"=== CONCAT ===\")\nprint(episode.format(mode=EpisodeFormatMode.CONCAT))"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Creates `examples/ch07.ipynb` — Chapter 7 main examples notebook
- Follows the same structure as other chapter notebooks (setup, Ollama instructions, `ensure_ollama`, examples)
- Example 1: manually constructs a `Task`, `TaskResult`, and `Episode`, then prints the episode in both `EpisodeFormatMode.XML` and `EpisodeFormatMode.CONCAT`

Closes #625.

## Test plan

- [ ] Open notebook in Jupyter and run Example 1 cell — verify both format mode outputs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)