### PR TITLE
refactor: make `_read_recent` and `_search` internal; dispatch in `BaseMemoryStore.search()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: make _read_recent and _search internal; dispatch in BaseMemoryStore.search() (#630)
 - refactor: remove key from BaseMemoryStore interface; move key_fn to QdrantMemoryStore (#629)
 - refactor: replace `EpisodeAttr` Literal and `include` param with `exclude: set[str] | None` in `Episode.format()`; fields iterated from `Episode.model_fields` so new fields appear automatically; `QdrantMemoryStore` migrates to `DEFAULT_EPISODE_EXCLUDE`; `error` field is now included in embeddings (#623)
 - feat: introduce FormatMode enum for Episode.format() mode param (#620)

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -15,18 +15,19 @@ class BaseMemoryStore(ABC):
     1. **Durable persistence** — write episodes to the substrate, including
        any preprocessing required by that substrate (embedding, indexing,
        tokenization).
-    2. **Retrieval primitives** — expose `read_recent` and `search` so that
-       ``Memory`` instances can compose and score results without knowing
-       the underlying storage details.
+    2. **Retrieval primitives** — implement ``_read_recent`` and ``_search``
+       so that the concrete ``search()`` method can dispatch based on
+       ``recall_mode`` without knowing the underlying storage details.
+
+    The public retrieval interface is ``search()``. Subclasses must not
+    override it; they implement ``_read_recent`` and ``_search`` instead.
 
     Attributes:
         max_results (int): Default number of results returned by
-            ``search`` and ``read_recent`` when no explicit count is
-            supplied by the caller.
+            ``search()`` when no explicit count is supplied by the caller.
         recall_mode (RecallMode): Controls how ``search()`` retrieves
-            episodes. ``RecallMode.RECENT`` ignores the query and
-            returns the most recent episodes via ``read_recent``;
-            ``RecallMode.SEARCH`` performs a similarity lookup.
+            episodes. ``RecallMode.RECENT`` delegates to ``_read_recent``;
+            ``RecallMode.SEARCH`` delegates to ``_search``.
     """
 
     def __init__(
@@ -49,6 +50,8 @@ class BaseMemoryStore(ABC):
     async def write(self, episode: Episode) -> None:
         """Persist an episode to the store.
 
+        Subclasses must implement this method.
+
         Args:
             episode (Episode): The completed episode to store.
         """
@@ -56,6 +59,10 @@ class BaseMemoryStore(ABC):
     @abstractmethod
     async def _read_recent(self, n: int) -> list[Episode]:
         """Return the N most recently recorded episodes.
+
+        Subclasses must implement this method. It is called by the
+        concrete ``search()`` when ``recall_mode`` is
+        ``RecallMode.RECENT``.
 
         Args:
             n (int): Maximum number of episodes to return.
@@ -72,7 +79,10 @@ class BaseMemoryStore(ABC):
     ) -> list[Episode]:
         """Return the most relevant episodes for a query.
 
-        The number of results is controlled by ``self.max_results``.
+        Subclasses must implement this method. It is called by the
+        concrete ``search()`` when ``recall_mode`` is
+        ``RecallMode.SEARCH``. The number of results is controlled by
+        ``self.max_results``.
 
         Args:
             query (str): The search query (e.g. the task instruction).
@@ -88,17 +98,22 @@ class BaseMemoryStore(ABC):
         query: str,
         **kwargs: Any,
     ) -> list[Episode]:
-        """Return the most relevant episodes for a query.
+        """Return episodes according to ``recall_mode``.
 
-        The number of results is controlled by ``self.max_results``.
+        Dispatches to ``_read_recent`` when ``recall_mode`` is
+        ``RecallMode.RECENT``, or to ``_search`` when it is
+        ``RecallMode.SEARCH``. Subclasses must not override this method;
+        implement ``_read_recent`` and ``_search`` instead.
 
         Args:
             query (str): The search query (e.g. the task instruction).
+                Ignored when ``recall_mode`` is ``RecallMode.RECENT``.
             **kwargs: Optional substrate-specific search parameters
-                (e.g. filters, score thresholds).
+                forwarded to ``_search``.
 
         Returns:
-            list[Episode]: Episodes ordered by relevance to the query.
+            list[Episode]: Episodes ordered by recency or relevance
+                depending on ``recall_mode``.
         """
         if self.recall_mode == RecallMode.RECENT:
             return await self._read_recent(self.max_results)
@@ -108,7 +123,8 @@ class BaseMemoryStore(ABC):
     async def delete(self, id_: str) -> None:
         """Delete an episode by its unique identifier.
 
-        Raises ``EpisodeNotFoundError`` if no episode with ``id_`` exists.
+        Subclasses must implement this method. Raises
+        ``EpisodeNotFoundError`` if no episode with ``id_`` exists.
 
         Args:
             id_ (str): The ``Episode.id_`` of the episode to remove.
@@ -118,9 +134,9 @@ class BaseMemoryStore(ABC):
     async def update(self, episode: Episode) -> None:
         """Replace an existing episode with an updated version.
 
-        Matches the stored episode by ``episode.id_`` and replaces it
-        in-place. Raises ``EpisodeNotFoundError`` if
-        no matching episode exists.
+        Subclasses must implement this method. Matches the stored episode
+        by ``episode.id_`` and replaces it in-place. Raises
+        ``EpisodeNotFoundError`` if no matching episode exists.
 
         Args:
             episode (Episode): The updated episode. Matched by ``id_``.
@@ -130,6 +146,8 @@ class BaseMemoryStore(ABC):
     async def count(self) -> int:
         """Return the total number of episodes in the store.
 
+        Subclasses must implement this method.
+
         Returns:
             int: Episode count.
         """
@@ -138,8 +156,9 @@ class BaseMemoryStore(ABC):
     async def summary(self) -> str:
         """Return a human-readable summary of the store contents.
 
-        Describes the substrate, episode count, and the oldest and newest
-        episodes. Intended for inspection and debugging.
+        Subclasses must implement this method. Should describe the
+        substrate, episode count, and the oldest and newest episodes.
+        Intended for inspection and debugging.
 
         Returns:
             str: Multi-line summary of the store.

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -54,7 +54,7 @@ class BaseMemoryStore(ABC):
         """
 
     @abstractmethod
-    async def read_recent(self, n: int) -> list[Episode]:
+    async def _read_recent(self, n: int) -> list[Episode]:
         """Return the N most recently recorded episodes.
 
         Args:
@@ -65,14 +65,24 @@ class BaseMemoryStore(ABC):
         """
 
     @abstractmethod
-    async def count(self) -> int:
-        """Return the total number of episodes in the store.
+    async def _search(
+        self,
+        query: str,
+        **kwargs: Any,
+    ) -> list[Episode]:
+        """Return the most relevant episodes for a query.
+
+        The number of results is controlled by ``self.max_results``.
+
+        Args:
+            query (str): The search query (e.g. the task instruction).
+            **kwargs: Optional substrate-specific search parameters
+                (e.g. filters, score thresholds).
 
         Returns:
-            int: Episode count.
+            list[Episode]: Episodes ordered by relevance to the query.
         """
 
-    @abstractmethod
     async def search(
         self,
         query: str,
@@ -90,6 +100,9 @@ class BaseMemoryStore(ABC):
         Returns:
             list[Episode]: Episodes ordered by relevance to the query.
         """
+        if self.recall_mode == RecallMode.RECENT:
+            return await self._read_recent(self.max_results)
+        return await self._search(query, **kwargs)
 
     @abstractmethod
     async def delete(self, id_: str) -> None:
@@ -111,6 +124,14 @@ class BaseMemoryStore(ABC):
 
         Args:
             episode (Episode): The updated episode. Matched by ``id_``.
+        """
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Return the total number of episodes in the store.
+
+        Returns:
+            int: Episode count.
         """
 
     @abstractmethod

--- a/src/llm_agents_from_scratch/memory_stores/json.py
+++ b/src/llm_agents_from_scratch/memory_stores/json.py
@@ -69,7 +69,7 @@ class JSONMemoryStore(BaseMemoryStore):
         with open(self.path, "a") as f:
             f.write(episode.model_dump_json() + "\n")
 
-    async def read_recent(self, n: int) -> list[Episode]:
+    async def _read_recent(self, n: int) -> list[Episode]:
         """Return the N most recently recorded episodes.
 
         Reads all episodes from the in-memory list. A production
@@ -174,32 +174,25 @@ class JSONMemoryStore(BaseMemoryStore):
             f"Episode '{episode.id_}' not found in JSONMemoryStore.",
         )
 
-    async def search(
+    async def _search(
         self,
         query: str,
         **kwargs: Any,
     ) -> list[Episode]:
-        """Return episodes according to ``recall_mode``.
+        """Raise ``NotImplementedError`` — this store does not embed episodes.
 
-        When ``recall_mode="recent"`` (the default), the query is ignored
-        and the most recent episodes are returned via ``read_recent``.
-        ``recall_mode="search"`` raises ``NotImplementedError`` — this store
-        does not support similarity search.
+        Called by the base ``search()`` when ``recall_mode`` is
+        ``RecallMode.SEARCH``. ``JSONMemoryStore`` does not support
+        similarity search; use a vector-backed store instead.
 
         Args:
-            query (str): The search query. Ignored when
-                ``recall_mode="recent"``.
+            query (str): Ignored.
             **kwargs: Ignored.
 
-        Returns:
-            list[Episode]: Episodes ordered by recency.
-
         Raises:
-            NotImplementedError: When ``recall_mode="search"``. Use a
-                vector-backed store for similarity search.
+            NotImplementedError: Always. Use a vector-backed store for
+                similarity search.
         """
-        if self.recall_mode == RecallMode.RECENT:
-            return await self.read_recent(self.max_results)
         raise NotImplementedError(
             "JSONMemoryStore does not support similarity search. "
             "Use a vector-backed store instead.",

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -113,7 +113,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             ],
         )
 
-    async def read_recent(self, n: int) -> list[Episode]:
+    async def _read_recent(self, n: int) -> list[Episode]:
         """Return the N most recently recorded episodes.
 
         Fetches all points from the collection and sorts by the stored
@@ -231,7 +231,7 @@ class QdrantMemoryStore(BaseMemoryStore):
             f" | collection={self._collection}",
         ]
         if total > 0:
-            episodes = await self.read_recent(total)
+            episodes = await self._read_recent(total)
             newest = episodes[0]
             oldest = episodes[-1]
             lines.append(
@@ -244,32 +244,25 @@ class QdrantMemoryStore(BaseMemoryStore):
             )
         return "\n".join(lines)
 
-    async def search(
+    async def _search(
         self,
         query: str,
         **kwargs: Any,
     ) -> list[Episode]:
-        """Return episodes according to ``recall_mode``.
+        """Return the top ``max_results`` episodes most similar to ``query``.
 
-        When ``recall_mode="recent"``, the query is ignored and the most
-        recent episodes are returned via ``read_recent``. When
-        ``recall_mode="search"`` (the default), the top ``max_results``
-        episodes most semantically similar to the query are returned.
+        Called by the base ``search()`` when ``recall_mode`` is
+        ``RecallMode.SEARCH``. Uses cosine similarity over FastEmbed vectors.
 
         Args:
             query (str): The search query (e.g. the task instruction).
-                Ignored when ``recall_mode="recent"``.
             **kwargs: Additional keyword arguments forwarded to
-                ``QdrantClient.query_points()`` when
-                ``recall_mode="search"`` (e.g. ``query_filter``,
-                ``score_threshold``).
+                ``QdrantClient.query_points()``
+                (e.g. ``query_filter``, ``score_threshold``).
 
         Returns:
-            list[Episode]: Episodes ordered by recency or cosine
-                similarity depending on ``recall_mode``.
+            list[Episode]: Episodes ordered by cosine similarity.
         """
-        if self.recall_mode == RecallMode.RECENT:
-            return await self.read_recent(self.max_results)
         results = self._client.query_points(
             collection_name=self._collection,
             query=models.Document(

--- a/tests/memory/test_base.py
+++ b/tests/memory/test_base.py
@@ -7,6 +7,6 @@ def test_base_memory_store_abstract_methods() -> None:
 
     assert "write" in abstract_methods
     assert "count" in abstract_methods
-    assert "read_recent" in abstract_methods
-    assert "search" in abstract_methods
+    assert "_read_recent" in abstract_methods
+    assert "_search" in abstract_methods
     assert "summary" in abstract_methods

--- a/tests/memory/test_json_store.py
+++ b/tests/memory/test_json_store.py
@@ -102,7 +102,7 @@ async def test_read_recent_returns_n_most_recent(tmp_path: Path) -> None:
     await store.write(make_episode("middle"))
     await store.write(make_episode("newest"))
 
-    recent = await store.read_recent(2)
+    recent = await store._read_recent(2)
 
     assert len(recent) == 2  # noqa: PLR2004
     assert recent[0].task.instruction == "newest"
@@ -117,7 +117,7 @@ async def test_read_recent_returns_all_when_n_exceeds_count(
     store = JSONMemoryStore(dir=tmp_path)
     await store.write(make_episode())
 
-    recent = await store.read_recent(10)
+    recent = await store._read_recent(10)
     assert len(recent) == 1
 
 
@@ -229,7 +229,7 @@ async def test_update_replaces_episode(tmp_path: Path) -> None:
     )
     await store.update(updated)
 
-    episodes = await store.read_recent(1)
+    episodes = await store._read_recent(1)
     assert episodes[0].result.content == "updated content"
 
 
@@ -248,7 +248,7 @@ async def test_update_persists_to_file(tmp_path: Path) -> None:
     await store.update(updated)
 
     reloaded = JSONMemoryStore(dir=tmp_path)
-    episodes = await reloaded.read_recent(1)
+    episodes = await reloaded._read_recent(1)
     assert episodes[0].result.content == "updated"
 
 

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -103,7 +103,7 @@ async def test_count(mock_client: MagicMock) -> None:
 async def test_read_recent_empty(mock_client: MagicMock) -> None:
     mock_client.count.return_value.count = 0
     store = QdrantMemoryStore()
-    assert await store.read_recent(3) == []
+    assert await store._read_recent(3) == []
 
 
 async def test_read_recent(mock_client: MagicMock, episode: Episode) -> None:
@@ -116,7 +116,7 @@ async def test_read_recent(mock_client: MagicMock, episode: Episode) -> None:
     mock_client.scroll.return_value = ([record], None)
 
     store = QdrantMemoryStore()
-    result = await store.read_recent(5)
+    result = await store._read_recent(5)
 
     assert len(result) == 1
     assert result[0].task.instruction == episode.task.instruction
@@ -152,7 +152,7 @@ async def test_read_recent_sorted_newest_first(
     mock_client.scroll.return_value = (records, None)
 
     store = QdrantMemoryStore()
-    result = await store.read_recent(2)
+    result = await store._read_recent(2)
 
     assert result[0].task.instruction == "newer task"
     assert result[1].task.instruction == "older task"
@@ -184,7 +184,7 @@ async def test_read_recent_respects_n_limit(mock_client: MagicMock) -> None:
 
     n = 3
     store = QdrantMemoryStore()
-    result = await store.read_recent(n)
+    result = await store._read_recent(n)
 
     assert len(result) == n
 


### PR DESCRIPTION
## Summary

- Renames abstract `read_recent` / `search` to `_read_recent` / `_search` — these are substrate-specific implementation details, not public API
- Adds a concrete `search()` on `BaseMemoryStore` that handles `recall_mode` dispatch, removing the duplicated `if self.recall_mode == RecallMode.RECENT` block from both `QdrantMemoryStore` and `JSONMemoryStore`
- `JSONMemoryStore._search` now simply raises `NotImplementedError` — no dispatch logic needed
- Updates all docstrings to note which methods subclasses must implement
- Updates tests accordingly (`_read_recent`, `_search` abstract method assertions)

## Test plan

- [x] 71 memory tests pass
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)