### PR TITLE
feat: warn in BaseMemoryStore.search() when result count exceeds max_results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- feat: add `MaxResultsExceededWarning`; `BaseMemoryStore.search()` emits it when `_search` or `_read_recent` returns more results than `max_results` (#632)
 - refactor: make _read_recent and _search internal; dispatch in BaseMemoryStore.search() (#630)
 - refactor: remove key from BaseMemoryStore interface; move key_fn to QdrantMemoryStore (#629)
 - refactor: replace `EpisodeAttr` Literal and `include` param with `exclude: set[str] | None` in `Episode.format()`; fields iterated from `Episode.model_fields` so new fields appear automatically; `QdrantMemoryStore` migrates to `DEFAULT_EPISODE_EXCLUDE`; `error` field is now included in embeddings (#623)

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -1,5 +1,6 @@
 """Base memory store class."""
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -116,8 +117,16 @@ class BaseMemoryStore(ABC):
                 depending on ``recall_mode``.
         """
         if self.recall_mode == RecallMode.RECENT:
-            return await self._read_recent(self.max_results)
-        return await self._search(query, **kwargs)
+            results = await self._read_recent(self.max_results)
+        else:
+            results = await self._search(query, **kwargs)
+        if len(results) > self.max_results:
+            warnings.warn(
+                f"{type(self).__name__}._search returned {len(results)} results"
+                f" but max_results={self.max_results}.",
+                stacklevel=2,
+            )
+        return results
 
     @abstractmethod
     async def delete(self, id_: str) -> None:

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..data_structures import Episode
 from ..data_structures.memory import RecallMode
+from ..errors import MaxResultsExceededWarning
 
 
 class BaseMemoryStore(ABC):
@@ -124,6 +125,7 @@ class BaseMemoryStore(ABC):
             warnings.warn(
                 f"{type(self).__name__}._search returned {len(results)} results"
                 f" but max_results={self.max_results}.",
+                MaxResultsExceededWarning,
                 stacklevel=2,
             )
         return results

--- a/src/llm_agents_from_scratch/errors/__init__.py
+++ b/src/llm_agents_from_scratch/errors/__init__.py
@@ -7,6 +7,7 @@ from .core import (
 from .mcp import MCPError, MCPWarning, MissingMCPServerParamsError
 from .memory_store import (
     EpisodeNotFoundError,
+    MaxResultsExceededWarning,
     MemoryStoreError,
     MemoryStoreWarning,
 )
@@ -33,6 +34,7 @@ __all__ = [
     # memory store
     "MemoryStoreError",
     "MemoryStoreWarning",
+    "MaxResultsExceededWarning",
     "EpisodeNotFoundError",
     # agent
     "LLMAgentError",

--- a/src/llm_agents_from_scratch/errors/memory_store.py
+++ b/src/llm_agents_from_scratch/errors/memory_store.py
@@ -9,6 +9,12 @@ class MemoryStoreWarning(LLMAgentsFromScratchWarning):
     pass
 
 
+class MaxResultsExceededWarning(MemoryStoreWarning):
+    """Emitted when a store returns more results than ``max_results``."""
+
+    pass
+
+
 class MemoryStoreError(LLMAgentsFromScratchError):
     """Base error for all memory-store-related exceptions."""
 

--- a/tests/memory/test_base.py
+++ b/tests/memory/test_base.py
@@ -1,4 +1,11 @@
+import warnings
+
+import pytest
+
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
+from llm_agents_from_scratch.data_structures import Task, TaskResult
+from llm_agents_from_scratch.data_structures.memory import Episode, RecallMode
+from llm_agents_from_scratch.errors import MaxResultsExceededWarning
 
 
 def test_base_memory_store_abstract_methods() -> None:
@@ -10,3 +17,97 @@ def test_base_memory_store_abstract_methods() -> None:
     assert "_read_recent" in abstract_methods
     assert "_search" in abstract_methods
     assert "summary" in abstract_methods
+
+
+def _make_episode() -> Episode:
+    task = Task(instruction="test task")
+    return Episode(
+        task=task,
+        rollout="",
+        result=TaskResult(task_id=task.id_, content="test result"),
+    )
+
+
+class StubStore(BaseMemoryStore):
+    """Minimal concrete store for testing BaseMemoryStore.search() dispatch."""
+
+    def __init__(
+        self,
+        episodes: list[Episode],
+        recall_mode: RecallMode = RecallMode.SEARCH,
+        max_results: int = 5,
+    ) -> None:
+        super().__init__(max_results=max_results, recall_mode=recall_mode)
+        self._episodes = episodes
+
+    async def write(self, episode: Episode) -> None:
+        pass
+
+    async def _read_recent(self, n: int) -> list[Episode]:
+        return self._episodes[:n]
+
+    async def _search(self, query: str, **kwargs: object) -> list[Episode]:
+        return self._episodes
+
+    async def count(self) -> int:
+        return len(self._episodes)
+
+    async def delete(self, id_: str) -> None:
+        pass
+
+    async def update(self, episode: Episode) -> None:
+        pass
+
+    async def summary(self) -> str:
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_search_dispatches_to_search_when_recall_mode_search() -> None:
+    episodes = [_make_episode(), _make_episode()]
+    store = StubStore(episodes, recall_mode=RecallMode.SEARCH)
+
+    result = await store.search("query")
+
+    assert result == episodes
+
+
+@pytest.mark.asyncio
+async def test_search_dispatches_to_read_recent_when_recall_mode_recent() -> (
+    None
+):
+    episodes = [_make_episode(), _make_episode(), _make_episode()]
+    store = StubStore(episodes, recall_mode=RecallMode.RECENT, max_results=2)
+
+    result = await store.search("ignored")
+
+    assert result == episodes[:2]
+
+
+@pytest.mark.asyncio
+async def test_search_warns_when_results_exceed_max_results() -> None:
+    episodes = [_make_episode(), _make_episode(), _make_episode()]
+    store = StubStore(episodes, recall_mode=RecallMode.SEARCH, max_results=2)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await store.search("query")
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, MaxResultsExceededWarning)
+    assert "3" in str(caught[0].message)
+    assert "max_results=2" in str(caught[0].message)
+
+
+@pytest.mark.asyncio
+async def test_search_no_warning_when_results_within_max_results() -> None:
+    episodes = [_make_episode(), _make_episode()]
+    store = StubStore(episodes, recall_mode=RecallMode.SEARCH, max_results=5)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await store.search("query")
+
+    assert not any(
+        issubclass(w.category, MaxResultsExceededWarning) for w in caught
+    )


### PR DESCRIPTION
## Summary

- After dispatching to `_read_recent` or `_search`, emits a `warnings.warn` if `len(results) > self.max_results`
- Surfaces misbehaving `_search` implementations without breaking callers
- Warning includes the store class name and actual vs expected count

Closes #631.

## Test plan

- [x] 71 memory tests pass
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)