### PR TITLE
refactor: migrate QdrantMemoryStore to AsyncQdrantClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- nit: rename _collection to_collection_name in QdrantMemoryStore (#637)
+- refactor: migrate `QdrantMemoryStore` to `AsyncQdrantClient`; collection creation moved to lazy `_ensure_collection()` with `_collection_ready` flag (#638)
+- nit: rename `_collection` to `_collection_name` in `QdrantMemoryStore` (#637)
 - feat: add `MaxResultsExceededWarning`; `BaseMemoryStore.search()` emits it when `_search` or `_read_recent` returns more results than `max_results` (#632)
 - refactor: make _read_recent and _search internal; dispatch in BaseMemoryStore.search() (#630)
 - refactor: remove key from BaseMemoryStore interface; move key_fn to QdrantMemoryStore (#629)

--- a/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
+++ b/src/llm_agents_from_scratch/memory_stores/qdrant/store.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Callable
 
-from qdrant_client import QdrantClient, models
+from qdrant_client import AsyncQdrantClient, models
 
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
 from llm_agents_from_scratch.data_structures.memory import (
@@ -26,7 +26,7 @@ class QdrantMemoryStore(BaseMemoryStore):
     embedded episode text.
 
     By default, Qdrant runs in-process with no server required. Pass a
-    pre-configured ``QdrantClient`` to persist to a remote or on-disk
+    pre-configured ``AsyncQdrantClient`` to persist to a remote or on-disk
     instance instead.
 
     Note: This is a minimal integration. Advanced Qdrant features such
@@ -34,8 +34,8 @@ class QdrantMemoryStore(BaseMemoryStore):
     exposed. Use the ``_client`` attribute directly for full API access.
 
     Attributes:
-        _client (QdrantClient): The Qdrant client instance.
-        _collection (str): Name of the Qdrant collection.
+        _client (AsyncQdrantClient): The Qdrant client instance.
+        _collection_name (str): Name of the Qdrant collection.
         _key_fn (Callable[[Episode], str]): Callable that extracts the
             text used for embedding from an episode.
     """
@@ -44,17 +44,16 @@ class QdrantMemoryStore(BaseMemoryStore):
         self,
         collection_name: str = "episodes",
         embedding_model: str = "BAAI/bge-small-en-v1.5",
-        client: QdrantClient | None = None,
+        client: AsyncQdrantClient | None = None,
         max_results: int = 5,
         recall_mode: RecallMode = RecallMode.SEARCH,
         key_fn: Callable[[Episode], str] | None = None,
     ) -> None:
         """Initialize a QdrantMemoryStore.
 
-        Creates a Qdrant collection configured for cosine similarity over
-        FastEmbed vectors. Embedding runs locally via ONNX Runtime; no
-        external embedding service is required. The model is downloaded
-        on first use and cached locally.
+        The Qdrant collection is created lazily on the first operation
+        via ``_ensure_collection()``. No async calls are made in
+        ``__init__``.
 
         Args:
             collection_name (str): Name of the Qdrant collection.
@@ -62,9 +61,10 @@ class QdrantMemoryStore(BaseMemoryStore):
             embedding_model (str): FastEmbed model name used to embed
                 episode text at write time and queries at search time.
                 Defaults to ``"BAAI/bge-small-en-v1.5"``.
-            client (QdrantClient | None): Pre-configured Qdrant client.
-                Defaults to an in-memory client when ``None``. The
-                client must use FastEmbed as its embedding backend.
+            client (AsyncQdrantClient | None): Pre-configured async
+                Qdrant client. Defaults to an in-memory client when
+                ``None``. The client must use FastEmbed as its embedding
+                backend.
             max_results (int): Default maximum number of episodes
                 returned by ``search``. Defaults to 5.
             recall_mode (RecallMode): Retrieval strategy used by
@@ -75,20 +75,31 @@ class QdrantMemoryStore(BaseMemoryStore):
                 ``DEFAULT_EPISODE_EXCLUDE``.
         """
         super().__init__(max_results=max_results, recall_mode=recall_mode)
-        self._client = client or QdrantClient(":memory:")
+        self._client = client or AsyncQdrantClient(":memory:")
         self._client.set_model(embedding_model)
         self._collection_name = collection_name
+        self._collection_ready = False
         self._key_fn: Callable[[Episode], str] = key_fn or (
             lambda ep: ep.format(
                 mode=EpisodeFormatMode.CONCAT,
                 exclude=DEFAULT_EPISODE_EXCLUDE,
             )
         )
-        if not self._client.collection_exists(collection_name):
-            self._client.create_collection(
-                collection_name=collection_name,
+
+    async def _ensure_collection(self) -> None:
+        """Create the Qdrant collection if it does not yet exist.
+
+        No-op after the first successful call (guarded by
+        ``_collection_ready``).
+        """
+        if self._collection_ready:
+            return
+        if not await self._client.collection_exists(self._collection_name):
+            await self._client.create_collection(
+                collection_name=self._collection_name,
                 vectors_config=self._client.get_fastembed_vector_params(),
             )
+        self._collection_ready = True
 
     async def write(self, episode: Episode) -> None:
         """Embed and persist an episode to the Qdrant collection.
@@ -100,8 +111,9 @@ class QdrantMemoryStore(BaseMemoryStore):
         Args:
             episode (Episode): The completed episode to store.
         """
+        await self._ensure_collection()
         text = self._key_fn(episode)
-        self._client.upsert(
+        await self._client.upsert(
             collection_name=self._collection_name,
             points=[
                 episode_to_qdrant_point_struct(
@@ -125,10 +137,11 @@ class QdrantMemoryStore(BaseMemoryStore):
         Returns:
             list[Episode]: Episodes ordered from most recent to oldest.
         """
-        total = int(self._client.count(self._collection_name).count)
+        await self._ensure_collection()
+        total = int((await self._client.count(self._collection_name)).count)
         if total == 0:
             return []
-        points, _ = self._client.scroll(
+        points, _ = await self._client.scroll(
             collection_name=self._collection_name,
             with_payload=True,
             limit=total,
@@ -155,11 +168,12 @@ class QdrantMemoryStore(BaseMemoryStore):
         Returns:
             int: Episode count.
         """
-        return int(self._client.count(self._collection_name).count)
+        await self._ensure_collection()
+        return int((await self._client.count(self._collection_name)).count)
 
-    def _point_exists(self, id_: str) -> bool:
+    async def _point_exists(self, id_: str) -> bool:
         """Return True if a point with ``id_`` exists in the collection."""
-        hits = self._client.retrieve(
+        hits = await self._client.retrieve(
             collection_name=self._collection_name,
             ids=[id_],
         )
@@ -169,7 +183,8 @@ class QdrantMemoryStore(BaseMemoryStore):
         """Delete an episode by its unique identifier.
 
         Raises ``EpisodeNotFoundError`` if no point with ``id_`` exists
-        in the collection. Otherwise removes it via ``QdrantClient.delete``.
+        in the collection. Otherwise removes it via
+        ``AsyncQdrantClient.delete``.
 
         Args:
             id_ (str): The ``Episode.id_`` of the episode to remove.
@@ -177,11 +192,12 @@ class QdrantMemoryStore(BaseMemoryStore):
         Raises:
             EpisodeNotFoundError: If no point with ``id_`` exists.
         """
-        if not self._point_exists(id_):
+        await self._ensure_collection()
+        if not await self._point_exists(id_):
             raise EpisodeNotFoundError(
                 f"Episode '{id_}' not found in QdrantMemoryStore.",
             )
-        self._client.delete(
+        await self._client.delete(
             collection_name=self._collection_name,
             points_selector=models.PointIdsList(points=[id_]),
         )
@@ -199,12 +215,13 @@ class QdrantMemoryStore(BaseMemoryStore):
         Raises:
             EpisodeNotFoundError: If no point with ``episode.id_`` exists.
         """
-        if not self._point_exists(episode.id_):
+        await self._ensure_collection()
+        if not await self._point_exists(episode.id_):
             raise EpisodeNotFoundError(
                 f"Episode '{episode.id_}' not found in QdrantMemoryStore.",
             )
         text = self._key_fn(episode)
-        self._client.upsert(
+        await self._client.upsert(
             collection_name=self._collection_name,
             points=[
                 episode_to_qdrant_point_struct(
@@ -257,22 +274,25 @@ class QdrantMemoryStore(BaseMemoryStore):
         Args:
             query (str): The search query (e.g. the task instruction).
             **kwargs: Additional keyword arguments forwarded to
-                ``QdrantClient.query_points()``
+                ``AsyncQdrantClient.query_points()``
                 (e.g. ``query_filter``, ``score_threshold``).
 
         Returns:
             list[Episode]: Episodes ordered by cosine similarity.
         """
-        results = self._client.query_points(
-            collection_name=self._collection_name,
-            query=models.Document(
-                text=query,
-                model=self._client.embedding_model_name,
-            ),
-            using=self._client.get_vector_field_name(),
-            limit=self.max_results,
-            with_payload=True,
-            **kwargs,
+        await self._ensure_collection()
+        results = (
+            await self._client.query_points(
+                collection_name=self._collection_name,
+                query=models.Document(
+                    text=query,
+                    model=self._client.embedding_model_name,
+                ),
+                using=self._client.get_vector_field_name(),
+                limit=self.max_results,
+                with_payload=True,
+                **kwargs,
+            )
         ).points
         return [
             Episode.model_validate_json(r.payload["episode_json"])

--- a/tests/memory/test_qdrant_store.py
+++ b/tests/memory/test_qdrant_store.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from qdrant_client import QdrantClient, models
+from qdrant_client import AsyncQdrantClient, models
 
 from llm_agents_from_scratch.data_structures import Task, TaskResult
 from llm_agents_from_scratch.data_structures.memory import Episode, RecallMode
@@ -23,31 +23,53 @@ def episode() -> Episode:
 @pytest.fixture
 def mock_client():
     with patch(
-        "llm_agents_from_scratch.memory_stores.qdrant.store.QdrantClient",
+        "llm_agents_from_scratch.memory_stores.qdrant.store.AsyncQdrantClient",
     ) as mock_cls:
         instance = MagicMock()
         instance.embedding_model_name = "BAAI/bge-small-en-v1.5"
         instance.get_vector_field_name.return_value = "fast-bge-small-en-v1.5"
+        instance.collection_exists = AsyncMock(return_value=True)
+        instance.create_collection = AsyncMock()
+        instance.upsert = AsyncMock()
+        instance.count = AsyncMock(return_value=MagicMock(count=0))
+        instance.scroll = AsyncMock(return_value=([], None))
+        instance.retrieve = AsyncMock(return_value=[])
+        instance.delete = AsyncMock()
+        instance.query_points = AsyncMock(
+            return_value=MagicMock(points=[]),
+        )
         mock_cls.return_value = instance
         yield instance
 
 
-def test_init(mock_client: MagicMock) -> None:
-    mock_client.collection_exists.return_value = False
-    QdrantMemoryStore()
-    mock_client.set_model.assert_called_once_with("BAAI/bge-small-en-v1.5")
+async def test_ensure_collection_creates_when_missing(
+    mock_client: MagicMock,
+) -> None:
+    mock_client.collection_exists = AsyncMock(return_value=False)
+    store = QdrantMemoryStore()
+    await store._ensure_collection()
     mock_client.create_collection.assert_called_once()
 
 
-def test_init_skips_create_if_collection_exists(
+async def test_ensure_collection_skips_create_if_exists(
     mock_client: MagicMock,
 ) -> None:
-    mock_client.collection_exists.return_value = True
-    QdrantMemoryStore()
+    mock_client.collection_exists = AsyncMock(return_value=True)
+    store = QdrantMemoryStore()
+    await store._ensure_collection()
     mock_client.create_collection.assert_not_called()
 
 
-def test_init_custom_params(mock_client: MagicMock) -> None:
+async def test_ensure_collection_called_only_once(
+    mock_client: MagicMock,
+) -> None:
+    store = QdrantMemoryStore()
+    await store._ensure_collection()
+    await store._ensure_collection()
+    mock_client.collection_exists.assert_called_once()
+
+
+async def test_init_custom_params(mock_client: MagicMock) -> None:
     store = QdrantMemoryStore(
         collection_name="my_eps",
         embedding_model="BAAI/bge-large-en-v1.5",
@@ -57,7 +79,7 @@ def test_init_custom_params(mock_client: MagicMock) -> None:
 
 
 def test_init_custom_client() -> None:
-    custom_client = MagicMock(spec=QdrantClient)
+    custom_client = MagicMock(spec=AsyncQdrantClient)
     store = QdrantMemoryStore(client=custom_client)
     assert store._client is custom_client
     custom_client.set_model.assert_called_once()
@@ -95,19 +117,19 @@ async def test_write_uses_key_fn_when_provided(
 
 async def test_count(mock_client: MagicMock) -> None:
     expected = 7
-    mock_client.count.return_value.count = expected
+    mock_client.count.return_value = MagicMock(count=expected)
     store = QdrantMemoryStore()
     assert await store.count() == expected
 
 
 async def test_read_recent_empty(mock_client: MagicMock) -> None:
-    mock_client.count.return_value.count = 0
+    mock_client.count.return_value = MagicMock(count=0)
     store = QdrantMemoryStore()
     assert await store._read_recent(3) == []
 
 
 async def test_read_recent(mock_client: MagicMock, episode: Episode) -> None:
-    mock_client.count.return_value.count = 1
+    mock_client.count.return_value = MagicMock(count=1)
     record = MagicMock()
     record.payload = {
         "episode_json": episode.model_dump_json(),
@@ -140,7 +162,7 @@ async def test_read_recent_sorted_newest_first(
         completed_at=datetime(2025, 6, 1),
     )
 
-    mock_client.count.return_value.count = 2
+    mock_client.count.return_value = MagicMock(count=2)
     records = []
     for ep in [older, newer]:
         rec = MagicMock()
@@ -171,7 +193,7 @@ async def test_read_recent_respects_n_limit(mock_client: MagicMock) -> None:
             ),
         )
 
-    mock_client.count.return_value.count = 5
+    mock_client.count.return_value = MagicMock(count=5)
     records = []
     for ep in episodes:
         rec = MagicMock()
@@ -192,7 +214,7 @@ async def test_read_recent_respects_n_limit(mock_client: MagicMock) -> None:
 async def test_search(mock_client: MagicMock, episode: Episode) -> None:
     mock_point = MagicMock()
     mock_point.payload = {"episode_json": episode.model_dump_json()}
-    mock_client.query_points.return_value.points = [mock_point]
+    mock_client.query_points.return_value = MagicMock(points=[mock_point])
 
     max_results = 3
     store = QdrantMemoryStore(max_results=max_results)
@@ -209,7 +231,7 @@ async def test_search(mock_client: MagicMock, episode: Episode) -> None:
 
 
 async def test_search_empty(mock_client: MagicMock) -> None:
-    mock_client.query_points.return_value.points = []
+    mock_client.query_points.return_value = MagicMock(points=[])
     store = QdrantMemoryStore()
     results = await store.search("anything")
     assert results == []
@@ -219,7 +241,7 @@ async def test_search_uses_read_recent_when_recall_mode_recent(
     mock_client: MagicMock,
     episode: Episode,
 ) -> None:
-    mock_client.count.return_value.count = 1
+    mock_client.count.return_value = MagicMock(count=1)
     mock_point = MagicMock()
     mock_point.payload = {
         "episode_json": episode.model_dump_json(),
@@ -236,7 +258,7 @@ async def test_search_uses_read_recent_when_recall_mode_recent(
 
 
 async def test_summary_empty(mock_client: MagicMock) -> None:
-    mock_client.count.return_value.count = 0
+    mock_client.count.return_value = MagicMock(count=0)
     store = QdrantMemoryStore()
     summary = await store.summary()
     assert "QdrantMemoryStore" in summary
@@ -252,7 +274,7 @@ async def test_summary_with_episodes(
     record = MagicMock()
     record.payload = {"episode_json": ep_json, "completed_at": ts}
 
-    mock_client.count.return_value.count = 1
+    mock_client.count.return_value = MagicMock(count=1)
     mock_client.scroll.return_value = ([record], None)
 
     store = QdrantMemoryStore()
@@ -268,7 +290,7 @@ async def test_summary_with_episodes(
 
 @pytest.mark.asyncio
 async def test_delete_removes_existing_episode(
-    mock_client: QdrantClient,
+    mock_client: MagicMock,
 ) -> None:
     store = QdrantMemoryStore()
     hit = MagicMock()
@@ -285,7 +307,7 @@ async def test_delete_removes_existing_episode(
 
 @pytest.mark.asyncio
 async def test_delete_warns_when_id_not_found(
-    mock_client: QdrantClient,
+    mock_client: MagicMock,
 ) -> None:
     store = QdrantMemoryStore()
     mock_client.retrieve.return_value = []
@@ -301,7 +323,7 @@ async def test_delete_warns_when_id_not_found(
 
 @pytest.mark.asyncio
 async def test_update_upserts_existing_episode(
-    mock_client: QdrantClient,
+    mock_client: MagicMock,
     episode: Episode,
 ) -> None:
     store = QdrantMemoryStore()
@@ -316,7 +338,7 @@ async def test_update_upserts_existing_episode(
 
 @pytest.mark.asyncio
 async def test_update_warns_when_id_not_found(
-    mock_client: QdrantClient,
+    mock_client: MagicMock,
     episode: Episode,
 ) -> None:
     store = QdrantMemoryStore()

--- a/tests/memory/test_recipes.py
+++ b/tests/memory/test_recipes.py
@@ -19,7 +19,7 @@ from llm_agents_from_scratch.memory_stores.json import JSONMemoryStore
 from llm_agents_from_scratch.memory_stores.qdrant.store import QdrantMemoryStore
 
 _QDRANT_PATCH = (
-    "llm_agents_from_scratch.memory_stores.qdrant.store.QdrantClient"
+    "llm_agents_from_scratch.memory_stores.qdrant.store.AsyncQdrantClient"
 )
 
 
@@ -29,6 +29,12 @@ def mock_qdrant_client():
         instance = MagicMock()
         instance.embedding_model_name = "BAAI/bge-small-en-v1.5"
         instance.get_vector_field_name.return_value = "fast-bge-small-en-v1.5"
+        instance.collection_exists = AsyncMock(return_value=True)
+        instance.create_collection = AsyncMock()
+        instance.upsert = AsyncMock()
+        instance.query_points = AsyncMock(
+            return_value=MagicMock(points=[]),
+        )
         mock_cls.return_value = instance
         yield instance
 


### PR DESCRIPTION
## Summary

- Replaces `QdrantClient` with `AsyncQdrantClient` so all store operations are genuinely non-blocking
- Moves collection creation out of `__init__` (which can't `await`) into a lazy `_ensure_collection()` helper guarded by a `_collection_ready` flag — called at the start of every public method, no-op after the first call
- Awaits all client calls: `upsert`, `count`, `scroll`, `retrieve`, `delete`, `query_points`, `collection_exists`, `create_collection`
- Makes `_point_exists` async
- Updates tests: patches `AsyncQdrantClient`, uses `AsyncMock` for all awaitable methods, replaces the `test_init_*` collection tests with `test_ensure_collection_*`

Closes #638.

## Test plan

- [ ] All 21 `test_qdrant_store.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)