### PR TITLE
chore: add .gitattributes to mark notebooks as documentation for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 examples/**/*.ipynb linguist-documentation=true
 more-examples/**/*.ipynb linguist-documentation=true
+capstones/**/*.ipynb linguist-documentation=true


### PR DESCRIPTION
## Summary

Adds `.gitattributes` marking all notebooks under `examples/`, `more-examples/`, and `capstones/` as `linguist-documentation=true`. This tells GitHub's Linguist to exclude them from language statistics, so the repo shows Python as the primary language instead of Jupyter Notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)