### PR TITLE
nit: rename JSONMemoryStore._rewrite() to _rewrite_jsonl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- nit: rename JSONMemoryStore._rewrite() to_rewrite_jsonl() (#642)
 - refactor: migrate `QdrantMemoryStore` to `AsyncQdrantClient`; collection creation moved to lazy `_ensure_collection()` with `_collection_ready` flag (#638)
 - nit: rename `_collection` to `_collection_name` in `QdrantMemoryStore` (#637)
 - feat: add `MaxResultsExceededWarning`; `BaseMemoryStore.search()` emits it when `_search` or `_read_recent` returns more results than `max_results` (#632)

--- a/src/llm_agents_from_scratch/memory_stores/json.py
+++ b/src/llm_agents_from_scratch/memory_stores/json.py
@@ -123,7 +123,7 @@ class JSONMemoryStore(BaseMemoryStore):
             )
         return "\n".join(lines)
 
-    def _rewrite(self) -> None:
+    def _rewrite_jsonl(self) -> None:
         with open(self.path, "w") as f:
             for ep in self._episodes:
                 f.write(ep.model_dump_json() + "\n")
@@ -150,7 +150,7 @@ class JSONMemoryStore(BaseMemoryStore):
                 f"Episode '{id_}' not found in JSONMemoryStore.",
             )
         self._episodes.pop(idx)
-        self._rewrite()
+        self._rewrite_jsonl()
 
     async def update(self, episode: Episode) -> None:
         """Replace an existing episode with an updated version.
@@ -168,7 +168,7 @@ class JSONMemoryStore(BaseMemoryStore):
         for i, ep in enumerate(self._episodes):
             if ep.id_ == episode.id_:
                 self._episodes[i] = episode
-                self._rewrite()
+                self._rewrite_jsonl()
                 return
         raise EpisodeNotFoundError(
             f"Episode '{episode.id_}' not found in JSONMemoryStore.",


### PR DESCRIPTION
## Summary

Renames `_rewrite()` → `_rewrite_jsonl()` in `JSONMemoryStore` to avoid confusion with the public `write()` and `update()` methods.

Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)