### PR TITLE
feat: add Example 3 (QdrantMemoryStore) to examples/ch07.ipynb

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -233,6 +233,34 @@
     ")\n",
     "print(results[0].format())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6f0bcd",
+   "source": "### Example 3a: Writing Episodes to a QdrantMemoryStore",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b79433bc",
+   "source": "import warnings\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n\nwarnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n\nstore = QdrantMemoryStore(max_results=2)\n\ntask_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\ntask_2 = Task(instruction=\"Compute the Hailstone sequence for 27.\")\n\nepisodes = [\n    Episode(\n        task=task_1,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_1.id_,\n            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"8\"},\n    ),\n    Episode(\n        task=task_2,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_2.id_,\n            content=\"27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1\",\n        ),\n        metadata={\"steps\": \"111\"},\n    ),\n]\n\nfor ep in episodes:\n    await store.write(ep)\n    print(f\"count: {await store.count()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65da684d",
+   "source": "### Example 3b: Searching a QdrantMemoryStore",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7a09e1d2",
+   "source": "results = await store.search(\"Hailstone sequence starting from 27\")\nprint(\n    f\"search() returned {len(results)} episode(s)\"\n    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n)\nfor ep in results:\n    print(ep)\n    print()\n\nprint(await store.summary())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -143,14 +143,14 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <reflection>Always use the hailstone tool.</reflection>\n",
-      "    <completed_at>2026-06-08 00:34:07</completed_at>\n",
+      "    <completed_at>2026-06-13 02:22:59</completed_at>\n",
       "  </episode>\n",
       "\n",
       "=== CONCAT ===\n",
       "task: Compute the Hailstone sequence for 6.\n",
       "result: 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "reflection: Always use the hailstone tool.\n",
-      "completed_at: 2026-06-08 00:34:07\n"
+      "completed_at: 2026-06-13 02:22:59\n"
      ]
     }
    ],
@@ -179,7 +179,9 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000009",
    "metadata": {},
-   "source": "### Example 2a: Writing Episodes to a JSONMemoryStore"
+   "source": [
+    "### Example 2a: Writing Episodes to a JSONMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
@@ -196,13 +198,53 @@
      ]
     }
    ],
-   "source": "from pathlib import Path\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory_stores import JSONMemoryStore\n\nSTORE_DIR = Path(\".\")\n(STORE_DIR / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n\nstore = JSONMemoryStore(dir=STORE_DIR, max_results=1)\n\ntask_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\ntask_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n\nepisodes = [\n    Episode(\n        task=task_1,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_1.id_,\n            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"8\"},\n    ),\n    Episode(\n        task=task_2,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_2.id_,\n            content=\"8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"3\"},\n    ),\n]\n\nfor ep in episodes:\n    await store.write(ep)\n    print(f\"count: {await store.count()}\")"
+   "source": [
+    "from pathlib import Path\n",
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.memory_stores import JSONMemoryStore\n",
+    "\n",
+    "STORE_DIR = Path(\".\")\n",
+    "(STORE_DIR / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n",
+    "\n",
+    "store = JSONMemoryStore(dir=STORE_DIR, max_results=1)\n",
+    "\n",
+    "task_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\n",
+    "task_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n",
+    "\n",
+    "episodes = [\n",
+    "    Episode(\n",
+    "        task=task_1,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_1.id_,\n",
+    "            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"8\"},\n",
+    "    ),\n",
+    "    Episode(\n",
+    "        task=task_2,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_2.id_,\n",
+    "            content=\"8 → 4 → 2 → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"3\"},\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for ep in episodes:\n",
+    "    await store.write(ep)\n",
+    "    print(f\"count: {await store.count()}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000011",
    "metadata": {},
-   "source": "### Example 2b: Searching a JSONMemoryStore"
+   "source": [
+    "### Example 2b: Searching a JSONMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
@@ -220,7 +262,7 @@
       "    <task>Compute the Hailstone sequence for 8.</task>\n",
       "    <result>8 → 4 → 2 → 1</result>\n",
       "    <steps>3</steps>\n",
-      "    <completed_at>2026-06-08 00:34:07</completed_at>\n",
+      "    <completed_at>2026-06-13 02:23:01</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -237,30 +279,111 @@
   {
    "cell_type": "markdown",
    "id": "ac6f0bcd",
-   "source": "### Example 3a: Writing Episodes to a QdrantMemoryStore",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Example 3a: Writing Episodes to a QdrantMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "b79433bc",
-   "source": "import warnings\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n\nwarnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n\nstore = QdrantMemoryStore(max_results=2)\n\ntask_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\ntask_2 = Task(instruction=\"Compute the Hailstone sequence for 27.\")\n\nepisodes = [\n    Episode(\n        task=task_1,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_1.id_,\n            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"8\"},\n    ),\n    Episode(\n        task=task_2,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_2.id_,\n            content=\"27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1\",\n        ),\n        metadata={\"steps\": \"111\"},\n    ),\n]\n\nfor ep in episodes:\n    await store.write(ep)\n    print(f\"count: {await store.count()}\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "count: 1\n",
+      "count: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n",
+    "\n",
+    "store = QdrantMemoryStore(max_results=1)\n",
+    "\n",
+    "task_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\n",
+    "task_2 = Task(instruction=\"Compute the Hailstone sequence for 27.\")\n",
+    "\n",
+    "episodes = [\n",
+    "    Episode(\n",
+    "        task=task_1,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_1.id_,\n",
+    "            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"8\"},\n",
+    "    ),\n",
+    "    Episode(\n",
+    "        task=task_2,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_2.id_,\n",
+    "            content=\"27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"111\"},\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for ep in episodes:\n",
+    "    await store.write(ep)\n",
+    "    print(f\"count: {await store.count()}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "65da684d",
-   "source": "### Example 3b: Searching a QdrantMemoryStore",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Example 3b: Searching a QdrantMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "7a09e1d2",
-   "source": "results = await store.search(\"Hailstone sequence starting from 27\")\nprint(\n    f\"search() returned {len(results)} episode(s)\"\n    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n)\nfor ep in results:\n    print(ep)\n    print()\n\nprint(await store.summary())",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "search() returned 1 episode(s) -- query matched by similarity (RecallMode.SEARCH)\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>Compute the Hailstone sequence for 27.</task>\n",
+      "    <result>27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1</result>\n",
+      "    <steps>111</steps>\n",
+      "    <completed_at>2026-06-13 02:28:49</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "QdrantMemoryStore: 2 episodes | collection=episodes\n",
+      "  newest: 2026-06-13 02:28:49 | Compute the Hailstone sequence for 27.\n",
+      "  oldest: 2026-06-13 02:28:49 | Compute the Hailstone sequence for 6.\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = await store.search(\"Hailstone sequence starting from 27\")\n",
+    "print(\n",
+    "    f\"search() returned {len(results)} episode(s)\"\n",
+    "    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n",
+    ")\n",
+    "for ep in results:\n",
+    "    print(ep)\n",
+    "    print()\n",
+    "\n",
+    "print(await store.summary())"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #645. Sub-issue of #532.

## Summary

- Adds **Example 3a**: constructs an in-memory `QdrantMemoryStore`, writes two handcrafted Hailstone episodes (n=6, n=27), prints `count()` after each write
- Adds **Example 3b**: searches with `"Hailstone sequence starting from 27"` to demonstrate similarity-based recall (`RecallMode.SEARCH`), then prints `summary()`
- Suppresses the in-memory payload index `UserWarning` to keep notebook output clean

## Test plan

- [ ] Run `examples/ch07.ipynb` top to bottom; Examples 3a and 3b execute without error
- [ ] Example 3b search returns the n=27 episode ranked first

🤖 Generated with [Claude Code](https://claude.com/claude-code)