### PR TITLE
chore: use TypeAlias for MetadataFn in memory.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- chore: use TypeAlias for MetadataFn in memory.py (#647)
 - refactor: `_read_recent()` uses `scroll(order_by=OrderBy(completed_at, DESC), limit=n)` — eliminates the `count()` round-trip and Python-side sort; float payload index on `completed_at` created unconditionally in `_ensure_collection()` (new and pre-existing collections) for server-mode compatibility (#643)
 - nit: rename JSONMemoryStore._rewrite() to_rewrite_jsonl() (#642)
 - refactor: migrate `QdrantMemoryStore` to `AsyncQdrantClient`; collection creation moved to lazy `_ensure_collection()` with `_collection_ready` flag (#638)

--- a/src/llm_agents_from_scratch/memory/memory.py
+++ b/src/llm_agents_from_scratch/memory/memory.py
@@ -2,13 +2,13 @@
 
 import asyncio
 import inspect
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, TypeAlias
 
 from llm_agents_from_scratch.base.memory_store import BaseMemoryStore
 from llm_agents_from_scratch.data_structures import Task
 from llm_agents_from_scratch.data_structures.memory import Episode
 
-MetadataFn = Callable[[Episode], str | Awaitable[str]]
+MetadataFn: TypeAlias = Callable[[Episode], str | Awaitable[str]]
 
 
 class Memory:
@@ -34,7 +34,7 @@ class Memory:
         store: BaseMemoryStore,
         metadata_fns: dict[str, MetadataFn] | None = None,
     ) -> None:
-        """Initialise a Memory instance.
+        """Initialize a Memory instance.
 
         Args:
             store (BaseMemoryStore): The memory store to read from and


### PR DESCRIPTION
## Summary

- Changes implicit type alias assignment `MetadataFn = Callable[...]` to an explicit `MetadataFn: TypeAlias = Callable[...]` in `memory/memory.py`
- Adds `TypeAlias` to the `typing` import; makes the alias intent clear to mypy and readers

## Test plan

- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)