### PR TITLE
fix: Memory.record() works on a deep copy of Episode (#648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- fix: Memory.record() works on a deep copy of Episode (#650)
 - chore: use TypeAlias for MetadataFn in memory.py (#647)
 - refactor: `_read_recent()` uses `scroll(order_by=OrderBy(completed_at, DESC), limit=n)` — eliminates the `count()` round-trip and Python-side sort; float payload index on `completed_at` created unconditionally in `_ensure_collection()` (new and pre-existing collections) for server-mode compatibility (#643)
 - nit: rename JSONMemoryStore._rewrite() to_rewrite_jsonl() (#642)

--- a/src/llm_agents_from_scratch/memory/memory.py
+++ b/src/llm_agents_from_scratch/memory/memory.py
@@ -72,20 +72,27 @@ class Memory:
     async def record(self, episode: Episode) -> None:
         """Persist a completed episode.
 
+        Works on a shallow copy of ``episode`` so that ``metadata_fns``
+        enrichment never mutates the caller's object. This is important
+        when multiple ``Memory`` instances share the same episode: each
+        writes into its own copy, preventing cross-memory metadata
+        contamination.
+
         Runs all ``metadata_fns`` concurrently and writes their results
-        into ``episode.metadata``, then persists the episode via
+        into the copy's ``metadata``, then persists the copy via
         ``store.write()``.
 
         Args:
             episode (Episode): The completed episode to enrich and
-                store.
+                store. The original object is not modified.
         """
+        ep = episode.model_copy(deep=True)
         if self.metadata_fns:
 
             async def _call(fn: MetadataFn) -> str:
                 if inspect.iscoroutinefunction(fn):
-                    return await fn(episode)  # type: ignore[no-any-return]
-                return fn(episode)  # type: ignore[return-value]
+                    return await fn(ep)  # type: ignore[no-any-return]
+                return fn(ep)  # type: ignore[return-value]
 
             values = await asyncio.gather(
                 *[_call(fn) for fn in self.metadata_fns.values()],
@@ -95,9 +102,9 @@ class Memory:
                 values,
                 strict=True,
             ):
-                episode.metadata[key] = value
+                ep.metadata[key] = value
 
-        await self.store.write(episode)
+        await self.store.write(ep)
 
     async def summary(self) -> str:
         """Return a human-readable summary of this memory instance.

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -94,7 +94,7 @@ async def test_record_writes_episode() -> None:
 
     await memory.record(ep)
 
-    store.write.assert_awaited_once_with(ep)
+    store.write.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -102,10 +102,10 @@ async def test_record_runs_metadata_fns_concurrently() -> None:
     store = make_store()
     ep = make_episode()
 
-    async def reflect(ep: Episode) -> str:
+    async def reflect(episode: Episode) -> str:
         return "a lesson"
 
-    def tag(ep: Episode) -> str:
+    def tag(episode: Episode) -> str:
         return "important"
 
     memory = Memory(
@@ -115,9 +115,25 @@ async def test_record_runs_metadata_fns_concurrently() -> None:
 
     await memory.record(ep)
 
-    assert ep.metadata["reflection"] == "a lesson"
-    assert ep.metadata["tag"] == "important"
-    store.write.assert_awaited_once_with(ep)
+    written: Episode = store.write.call_args.args[0]
+    assert written.metadata["reflection"] == "a lesson"
+    assert written.metadata["tag"] == "important"
+    store.write.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_record_does_not_mutate_original_episode() -> None:
+    store = make_store()
+    ep = make_episode()
+
+    memory = Memory(
+        store=store,
+        metadata_fns={"note": lambda _: "enriched"},
+    )
+
+    await memory.record(ep)
+
+    assert ep.metadata == {}
 
 
 @pytest.mark.asyncio
@@ -134,8 +150,8 @@ async def test_record_all_metadata_fns_called() -> None:
 
     await memory.record(ep)
 
-    fn_a.assert_awaited_once_with(ep)
-    fn_b.assert_awaited_once_with(ep)
+    fn_a.assert_awaited_once()
+    fn_b.assert_awaited_once()
 
 
 # --- summary ---

--- a/tests/memory/test_recipes.py
+++ b/tests/memory/test_recipes.py
@@ -137,7 +137,8 @@ async def test_reflective_memory_reflect_calls_llm(
     await memory.record(ep)
 
     llm.complete.assert_awaited_once()
-    assert ep.metadata["reflection"] == "always call the tool first"
+    written: Episode = mock_qdrant_client.upsert.call_args.kwargs["points"][0]
+    assert "always call the tool first" in written.payload["episode_json"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #648.

## Summary

- `record()` now calls `episode.model_copy(deep=True)` at the start, so `metadata_fns` enrichment writes into an independent copy rather than mutating the caller's object
- Fixes the multi-`Memory` cross-contamination bug: when two `Memory` instances share the same episode, each now enriches its own copy independently
- Updated `test_record_runs_metadata_fns_concurrently` and `test_record_all_metadata_fns_called` to assert on the written copy rather than the original episode
- Added `test_record_does_not_mutate_original_episode` to assert the original is unchanged after `record()`
- Fixed `test_recipes.py` to inspect the written payload rather than the original episode's metadata

## Test plan

- [ ] `make test` passes (323 tests)
- [ ] `test_record_does_not_mutate_original_episode` confirms original `episode.metadata == {}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)