### PR TITLE
feat: add Example 4 to examples/ch07.ipynb — Memory demo with metadata_fn

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -143,14 +143,14 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <reflection>Always use the hailstone tool.</reflection>\n",
-      "    <completed_at>2026-06-13 02:22:59</completed_at>\n",
+      "    <completed_at>2026-06-14 18:28:42</completed_at>\n",
       "  </episode>\n",
       "\n",
       "=== CONCAT ===\n",
       "task: Compute the Hailstone sequence for 6.\n",
       "result: 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "reflection: Always use the hailstone tool.\n",
-      "completed_at: 2026-06-13 02:22:59\n"
+      "completed_at: 2026-06-14 18:28:42\n"
      ]
     }
    ],
@@ -262,7 +262,7 @@
       "    <task>Compute the Hailstone sequence for 8.</task>\n",
       "    <result>8 → 4 → 2 → 1</result>\n",
       "    <steps>3</steps>\n",
-      "    <completed_at>2026-06-13 02:23:01</completed_at>\n",
+      "    <completed_at>2026-06-14 18:28:43</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "b79433bc",
    "metadata": {},
    "outputs": [
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "7a09e1d2",
    "metadata": {},
    "outputs": [
@@ -363,12 +363,12 @@
       "    <task>Compute the Hailstone sequence for 27.</task>\n",
       "    <result>27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1</result>\n",
       "    <steps>111</steps>\n",
-      "    <completed_at>2026-06-13 02:28:49</completed_at>\n",
+      "    <completed_at>2026-06-14 18:28:45</completed_at>\n",
       "  </episode>\n",
       "\n",
       "QdrantMemoryStore: 2 episodes | collection=episodes\n",
-      "  newest: 2026-06-13 02:28:49 | Compute the Hailstone sequence for 27.\n",
-      "  oldest: 2026-06-13 02:28:49 | Compute the Hailstone sequence for 6.\n"
+      "  newest: 2026-06-14 18:28:45 | Compute the Hailstone sequence for 27.\n",
+      "  oldest: 2026-06-14 18:28:45 | Compute the Hailstone sequence for 6.\n"
      ]
     }
    ],
@@ -388,16 +388,76 @@
   {
    "cell_type": "markdown",
    "id": "e5b253d6",
-   "source": "### Example 4: Memory with a metadata_fn",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Example 4: Memory with a metadata_fn"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "bce04b23",
-   "source": "from pathlib import Path\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory import Memory\nfrom llm_agents_from_scratch.memory_stores import JSONMemoryStore\n\n(Path(\".\") / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n\ntask = Task(instruction=\"Compute the Hailstone sequence for 6.\")\nepisode = Episode(\n    task=task,\n    rollout=\"mock rollout\",\n    result=TaskResult(\n        task_id=task.id_,\n        content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n    ),\n)\n\n\ndef step_counter_fn(ep: Episode) -> str:\n    return str(len(ep.result.content.split(\"→\")))\n\n\nstore = JSONMemoryStore(dir=Path(\".\"), max_results=1)\nmemory = Memory(store=store, metadata_fns={\"steps\": step_counter_fn})\n\nawait memory.record(episode)\n\n# The original episode is not mutated — record() works on a deep copy\nprint(\"Original episode.metadata:\", episode.metadata)\n\nrecalled = await memory.recall(Task(instruction=\"Compute the Hailstone sequence for 3.\"))\nprint(\"\\nRecalled episode:\")\nprint(recalled)",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original episode:\n",
+      "  <episode>\n",
+      "    <task>Compute the Hailstone sequence for 6.</task>\n",
+      "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
+      "    <completed_at>2026-06-14 18:28:47</completed_at>\n",
+      "  </episode>\n",
+      "\n",
+      "Recalled episode (enriched by step_counter_fn at write time):\n",
+      "  <episode>\n",
+      "    <task>Compute the Hailstone sequence for 6.</task>\n",
+      "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
+      "    <steps>9</steps>\n",
+      "    <completed_at>2026-06-14 18:28:47</completed_at>\n",
+      "  </episode>\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.memory import Memory\n",
+    "from llm_agents_from_scratch.memory_stores import JSONMemoryStore\n",
+    "\n",
+    "(Path(\".\") / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n",
+    "\n",
+    "task = Task(instruction=\"Compute the Hailstone sequence for 6.\")\n",
+    "episode = Episode(\n",
+    "    task=task,\n",
+    "    rollout=\"mock rollout\",\n",
+    "    result=TaskResult(\n",
+    "        task_id=task.id_,\n",
+    "        content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def step_counter_fn(ep: Episode) -> str:\n",
+    "    return str(len(ep.result.content.split(\"→\")))\n",
+    "\n",
+    "\n",
+    "store = JSONMemoryStore(dir=Path(\".\"), max_results=1)\n",
+    "memory = Memory(store=store, metadata_fns={\"steps\": step_counter_fn})\n",
+    "\n",
+    "await memory.record(episode)\n",
+    "\n",
+    "# record() works on a deep copy — the original episode is not mutated\n",
+    "print(\"Original episode:\")\n",
+    "print(episode)\n",
+    "\n",
+    "recalled = await memory.recall(Task(instruction=\"Compute the Hailstone sequence for 3.\"))\n",
+    "print(\"\\nRecalled episode (enriched by step_counter_fn at write time):\")\n",
+    "print(recalled)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -384,6 +384,20 @@
     "\n",
     "print(await store.summary())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5b253d6",
+   "source": "### Example 4: Memory with a metadata_fn",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "bce04b23",
+   "source": "from pathlib import Path\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory import Memory\nfrom llm_agents_from_scratch.memory_stores import JSONMemoryStore\n\n(Path(\".\") / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n\ntask = Task(instruction=\"Compute the Hailstone sequence for 6.\")\nepisode = Episode(\n    task=task,\n    rollout=\"mock rollout\",\n    result=TaskResult(\n        task_id=task.id_,\n        content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n    ),\n)\n\n\ndef step_counter_fn(ep: Episode) -> str:\n    return str(len(ep.result.content.split(\"→\")))\n\n\nstore = JSONMemoryStore(dir=Path(\".\"), max_results=1)\nmemory = Memory(store=store, metadata_fns={\"steps\": step_counter_fn})\n\nawait memory.record(episode)\n\n# The original episode is not mutated — record() works on a deep copy\nprint(\"Original episode.metadata:\", episode.metadata)\n\nrecalled = await memory.recall(Task(instruction=\"Compute the Hailstone sequence for 3.\"))\nprint(\"\\nRecalled episode:\")\nprint(recalled)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #649. Sub-issue of #532.

## Summary

- Adds **Example 4** to `examples/ch07.ipynb` demonstrating `Memory` constructed directly (no recipe) with a `JSONMemoryStore` and a `step_counter_fn` metadata_fn
- Shows `metadata_fns` enriching the stored episode at write time (`steps: 9`)
- Proves `record()` does not mutate the original episode (`episode.metadata` stays `{}`) — the observable proof of the #648 fix

## Test plan

- [ ] Run `examples/ch07.ipynb` top to bottom; Example 4 executes without error
- [ ] `Original episode.metadata: {}` confirms no mutation
- [ ] Recalled episode XML contains `<steps>9</steps>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)