### PR TITLE
feat: add Example 5 to examples/ch07.ipynb — LLMAgent with reflective_memory()

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -143,14 +143,14 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <reflection>Always use the hailstone tool.</reflection>\n",
-      "    <completed_at>2026-06-14 18:28:42</completed_at>\n",
+      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
       "  </episode>\n",
       "\n",
       "=== CONCAT ===\n",
       "task: Compute the Hailstone sequence for 6.\n",
       "result: 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "reflection: Always use the hailstone tool.\n",
-      "completed_at: 2026-06-14 18:28:42\n"
+      "completed_at: 2026-06-17 19:15:04\n"
      ]
     }
    ],
@@ -262,7 +262,7 @@
       "    <task>Compute the Hailstone sequence for 8.</task>\n",
       "    <result>8 → 4 → 2 → 1</result>\n",
       "    <steps>3</steps>\n",
-      "    <completed_at>2026-06-14 18:28:43</completed_at>\n",
+      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -363,12 +363,12 @@
       "    <task>Compute the Hailstone sequence for 27.</task>\n",
       "    <result>27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1</result>\n",
       "    <steps>111</steps>\n",
-      "    <completed_at>2026-06-14 18:28:45</completed_at>\n",
+      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
       "  </episode>\n",
       "\n",
       "QdrantMemoryStore: 2 episodes | collection=episodes\n",
-      "  newest: 2026-06-14 18:28:45 | Compute the Hailstone sequence for 27.\n",
-      "  oldest: 2026-06-14 18:28:45 | Compute the Hailstone sequence for 6.\n"
+      "  newest: 2026-06-17 19:15:04 | Compute the Hailstone sequence for 27.\n",
+      "  oldest: 2026-06-17 19:15:04 | Compute the Hailstone sequence for 6.\n"
      ]
     }
    ],
@@ -407,7 +407,7 @@
       "  <episode>\n",
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
-      "    <completed_at>2026-06-14 18:28:47</completed_at>\n",
+      "    <completed_at>2026-06-17 19:15:05</completed_at>\n",
       "  </episode>\n",
       "\n",
       "Recalled episode (enriched by step_counter_fn at write time):\n",
@@ -415,7 +415,7 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <steps>9</steps>\n",
-      "    <completed_at>2026-06-14 18:28:47</completed_at>\n",
+      "    <completed_at>2026-06-17 19:15:05</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -457,6 +457,185 @@
     "recalled = await memory.recall(Task(instruction=\"Compute the Hailstone sequence for 3.\"))\n",
     "print(\"\\nRecalled episode (enriched by step_counter_fn at write time):\")\n",
     "print(recalled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6acdf857",
+   "metadata": {},
+   "source": [
+    "### Example 5: LLMAgent with reflective_memory()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6f216edf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import warnings\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.memory.recipes import reflective_memory\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "\n",
+    "def next_number(n: int) -> int:\n",
+    "    \"\"\"Returns the next number in the stop-at-one sequence.\"\"\"\n",
+    "    return n // 2 if n % 2 == 0 else 3 * n + 1\n",
+    "\n",
+    "\n",
+    "next_number_tool = SimpleFunctionTool(func=next_number)\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "memory = reflective_memory(llm=llm, max_results=1)\n",
+    "agent = LLMAgent(llm=llm, tools=[next_number_tool], memories=[memory])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0b6b3ff8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 8 is 4. \n",
+      "\n",
+      "If you'd like to continue computing the sequence, let me know!\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 4 is 2. \n",
+      "\n",
+      "If you'd like to continue computing the sequence, let me know!\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"a1b2c3d4-e5f6-7890-1234-567890abcdef\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 2 is 1. \n",
+      "\n",
+      "If you'd like to continue computing the sequence, let me know!\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The sequence for 8 has been computed as [8, 4, 2, 1]. If you'd like to continue computing the sequence, let me know!\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The sequence for 8 has been computed as [8, 4, 2, 1]. If you'd like to continue computing the sequence, let me know!\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd lik...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd ...[TRUNCATED]\n",
+      "The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Task 1: no memory yet — the agent computes the sequence via tools and\n",
+    "# reflective_memory records the episode with an LLM-generated reflection.\n",
+    "result_1 = await agent.run(\n",
+    "    Task(\n",
+    "        instruction=(\n",
+    "            \"Compute the stop-at-one sequence for 8 using the next_number tool, \"\n",
+    "            \"if it has not already been computed.\"\n",
+    "        )\n",
+    "    ),\n",
+    "    explicit_only_skills={\"stop-at-one\"},\n",
+    ")\n",
+    "print(result_1.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f472378a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Memory recalled for Task 2:\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.</task>\n",
+      "    <result>The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!</result>\n",
+      "    <reflection>The key lesson is to recognize that sequences following a clear mathematical rule (like halving until reaching 1) can be efficiently computed by identifying stopping conditions and leveraging pattern recognition to avoid redundant steps.</reflection>\n",
+      "    <completed_at>2026-06-17 19:17:13</completed_at>\n",
+      "  </episode>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect what will be injected into the system prompt as memory for Task 2.\n",
+    "# This is the same call the agent makes internally via memory.recall() before\n",
+    "# its first step — surfacing it here makes the memory context visible.\n",
+    "task_2 = Task(\n",
+    "    instruction=(\n",
+    "        \"Compute the stop-at-one sequence for 8 using the next_number tool, \"\n",
+    "        \"if it has not already been computed.\"\n",
+    "    )\n",
+    ")\n",
+    "print(\"Memory recalled for Task 2:\\n\")\n",
+    "print(await memory.recall(task_2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "31a8db6b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd lik...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd ...[TRUNCATED]\n",
+      "The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Task 2: memory.recall() already ran above — the reflection from Task 1 is\n",
+    "# now injected into the system prompt so the agent can apply it immediately.\n",
+    "result_2 = await agent.run(\n",
+    "    task_2,\n",
+    "    explicit_only_skills={\"stop-at-one\"},\n",
+    ")\n",
+    "print(result_2.content)"
    ]
   }
  ],

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -78,7 +78,9 @@ one, call the `from_scratch__use_skill` tool with the skill name.
 </available_skills>""".strip()
 
 DEFAULT_MEMORIES_BLOCK = """The following are memories from past episodes or
-task executions.
+task executions. Review these carefully: apply any lessons or insights to
+inform your approach, and if a past episode covers the same task, use its
+result directly unless instructed otherwise.
 
 <memories>
 {memories}


### PR DESCRIPTION
## Summary

- Adds Example 5 to `examples/ch07.ipynb`: an `LLMAgent` equipped with `reflective_memory()` and a `next_number` `SimpleFunctionTool` (obfuscated Hailstone/Collatz)
- Task 1 and Task 2 carry identical instructions ("compute stop-at-one sequence for 8, if not already computed"); Task 1 runs the tools, Task 2 returns the answer directly from recalled memory — zero tool calls
- An intermediate cell calls `memory.recall()` explicitly so the recalled episode (with `<reflection>` tag) is visible to the reader before Task 2 runs
- Tightens `DEFAULT_MEMORIES_BLOCK` to instruct the agent to reuse a past result when the same task has already been completed
- Uses `explicit_only_skills={"stop-at-one"}` to prevent the ch06 skill from auto-activating and taking over the demo

## Test plan

- [ ] Re-run Example 5 cells top-to-bottom in a fresh kernel: Task 1 should call `next_number` three times (8→4→2→1); the recall cell should show the episode with `<reflection>`; Task 2 should return the answer from memory without any tool calls
- [ ] Confirm existing Examples 1–4 still execute correctly

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)