### PR TITLE
feat: replace reflective_memory() with similarity_memory() in Example 5 of ch07.ipynb

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -143,14 +143,14 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <reflection>Always use the hailstone tool.</reflection>\n",
-      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
+      "    <completed_at>2026-06-19 10:50:02</completed_at>\n",
       "  </episode>\n",
       "\n",
       "=== CONCAT ===\n",
       "task: Compute the Hailstone sequence for 6.\n",
       "result: 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "reflection: Always use the hailstone tool.\n",
-      "completed_at: 2026-06-17 19:15:04\n"
+      "completed_at: 2026-06-19 10:50:02\n"
      ]
     }
    ],
@@ -262,7 +262,7 @@
       "    <task>Compute the Hailstone sequence for 8.</task>\n",
       "    <result>8 → 4 → 2 → 1</result>\n",
       "    <steps>3</steps>\n",
-      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
+      "    <completed_at>2026-06-19 10:50:03</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -363,12 +363,12 @@
       "    <task>Compute the Hailstone sequence for 27.</task>\n",
       "    <result>27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → ... → 1</result>\n",
       "    <steps>111</steps>\n",
-      "    <completed_at>2026-06-17 19:15:04</completed_at>\n",
+      "    <completed_at>2026-06-19 10:50:05</completed_at>\n",
       "  </episode>\n",
       "\n",
       "QdrantMemoryStore: 2 episodes | collection=episodes\n",
-      "  newest: 2026-06-17 19:15:04 | Compute the Hailstone sequence for 27.\n",
-      "  oldest: 2026-06-17 19:15:04 | Compute the Hailstone sequence for 6.\n"
+      "  newest: 2026-06-19 10:50:05 | Compute the Hailstone sequence for 27.\n",
+      "  oldest: 2026-06-19 10:50:05 | Compute the Hailstone sequence for 6.\n"
      ]
     }
    ],
@@ -407,7 +407,7 @@
       "  <episode>\n",
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
-      "    <completed_at>2026-06-17 19:15:05</completed_at>\n",
+      "    <completed_at>2026-06-19 10:50:07</completed_at>\n",
       "  </episode>\n",
       "\n",
       "Recalled episode (enriched by step_counter_fn at write time):\n",
@@ -415,7 +415,7 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <steps>9</steps>\n",
-      "    <completed_at>2026-06-17 19:15:05</completed_at>\n",
+      "    <completed_at>2026-06-19 10:50:07</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -464,7 +464,7 @@
    "id": "6acdf857",
    "metadata": {},
    "source": [
-    "### Example 5: LLMAgent with reflective_memory()"
+    "### Example 5: LLMAgent with similarity_memory()"
    ]
   },
   {
@@ -481,7 +481,7 @@
     "from llm_agents_from_scratch.data_structures import Task\n",
     "from llm_agents_from_scratch.logger import enable_console_logging\n",
     "from llm_agents_from_scratch.llms import OllamaLLM\n",
-    "from llm_agents_from_scratch.memory.recipes import reflective_memory\n",
+    "from llm_agents_from_scratch.memory.recipes import similarity_memory\n",
     "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
     "\n",
     "warnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n",
@@ -495,13 +495,13 @@
     "\n",
     "next_number_tool = SimpleFunctionTool(func=next_number)\n",
     "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
-    "memory = reflective_memory(llm=llm, max_results=1)\n",
+    "memory = similarity_memory(max_results=1)\n",
     "agent = LLMAgent(llm=llm, tools=[next_number_tool], memories=[memory])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "0b6b3ff8",
    "metadata": {},
    "outputs": [
@@ -509,74 +509,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=8 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 8 is 4. \n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the stop-at-one sequence for 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the stop-at-one sequence for 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "# Stop At One\n",
       "\n",
-      "If you'd like to continue computing the sequence, let me know!\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=4 to compute the next number in the stop-at-one sequence.\n",
+      "Compute a full sequence from a starting number down to 1\n",
+      "using the `next_num...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current value of x (4)\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current value of x (4)\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 4 is 2. \n",
-      "\n",
-      "If you'd like to continue computing the sequence, let me know!\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue computing the stop-at-one sequence for 8 by calling the next_number tool with n=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
-      "\n",
-      "{\n",
-      "    \"id_\": \"a1b2c3d4-e5f6-7890-1234-567890abcdef\",\n",
-      "    \"tool_name\": \"next_number\",\n",
-      "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with n=2 to compute the next number in the stop-at-one sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 2. I will now update the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The next number in the sequence is 2. I will now update the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The next number in the sequence is 2. I will now update the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The sequence is now [4, 2]. I need to call the next_number tool with the current value of x (2).\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current value of x (2).\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current value of x (2).\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the stop-at-one sequence for 2 is 1. \n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 1. The sequence is now [4, 2, 1]. Since we have reached 1, the process is complete.\n",
       "\n",
-      "If you'd like to continue computing the sequence, let me know!\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The sequence for 8 has been computed as [8, 4, 2, 1]. If you'd like to continue computing the sequence, let me know!\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The sequence for 8 has been computed as [8, 4, 2, 1]. If you'd like to continue computing the sequence, let me know!\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd lik...[TRUNCATED]\n",
+      "Here is the res...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd ...[TRUNCATED]\n",
-      "The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence is 1. The sequence is now [4, 2, 1]. Since we have reached 1, the process is complete.\n",
+      "\n",
+      "Here is the ...[TRUNCATED]\n",
+      "The next number in the sequence is 1. The sequence is now [4, 2, 1]. Since we have reached 1, the process is complete.\n",
+      "\n",
+      "Here is the result:\n",
+      "- **Starting number**: 4\n",
+      "- **Total steps taken**: 2 (tool calls made)\n",
+      "- **Maximum value reached**: 4\n",
+      "\n",
+      "The complete sequence is: 4 → 2 → 1.\n"
      ]
     }
    ],
    "source": [
     "# Task 1: no memory yet — the agent computes the sequence via tools and\n",
-    "# reflective_memory records the episode with an LLM-generated reflection.\n",
+    "# similarity_memory records the episode in the Qdrant vector store.\n",
     "result_1 = await agent.run(\n",
     "    Task(\n",
     "        instruction=(\n",
-    "            \"Compute the stop-at-one sequence for 8 using the next_number tool, \"\n",
-    "            \"if it has not already been computed.\"\n",
+    "            \"Compute the stop-at-one sequence for 4\"\n",
     "        )\n",
     "    ),\n",
-    "    explicit_only_skills={\"stop-at-one\"},\n",
+    "    # explicit_only_skills={\"stop-at-one\"},\n",
     ")\n",
     "print(result_1.content)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "f472378a",
    "metadata": {},
    "outputs": [
@@ -587,10 +581,16 @@
       "Memory recalled for Task 2:\n",
       "\n",
       "  <episode>\n",
-      "    <task>Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.</task>\n",
-      "    <result>The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!</result>\n",
-      "    <reflection>The key lesson is to recognize that sequences following a clear mathematical rule (like halving until reaching 1) can be efficiently computed by identifying stopping conditions and leveraging pattern recognition to avoid redundant steps.</reflection>\n",
-      "    <completed_at>2026-06-17 19:17:13</completed_at>\n",
+      "    <task>Compute the stop-at-one sequence for 4</task>\n",
+      "    <result>The next number in the sequence is 1. The sequence is now [4, 2, 1]. Since we have reached 1, the process is complete.\n",
+      "\n",
+      "Here is the result:\n",
+      "- **Starting number**: 4\n",
+      "- **Total steps taken**: 2 (tool calls made)\n",
+      "- **Maximum value reached**: 4\n",
+      "\n",
+      "The complete sequence is: 4 → 2 → 1.</result>\n",
+      "    <completed_at>2026-06-19 10:53:22</completed_at>\n",
       "  </episode>\n"
      ]
     }
@@ -601,8 +601,7 @@
     "# its first step — surfacing it here makes the memory context visible.\n",
     "task_2 = Task(\n",
     "    instruction=(\n",
-    "        \"Compute the stop-at-one sequence for 8 using the next_number tool, \"\n",
-    "        \"if it has not already been computed.\"\n",
+    "        \"What is the stop-at-one sequence for 4?\"\n",
     "    )\n",
     ")\n",
     "print(\"Memory recalled for Task 2:\\n\")\n",
@@ -611,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "31a8db6b",
    "metadata": {},
    "outputs": [
@@ -619,21 +618,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the stop-at-one sequence for 8 using the next_number tool, if it has not already been computed.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd lik...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: What is the stop-at-one sequence for 4?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: What is the stop-at-one sequence for 4?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The stop-at-one sequence for 4 is as follows:\n",
+      "\n",
+      "- Start with 4.\n",
+      "- The next number is 2 (since 4 divided by 2 is 2).\n",
+      "- The next number is...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd ...[TRUNCATED]\n",
-      "The stop-at-one sequence for 8 is now complete: [8, 4, 2, 1]. Since the sequence has reached 1, it stops here. Let me know if you'd like to compute the sequence for another number!\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The stop-at-one sequence for 4 is as follows:\n",
+      "\n",
+      "- Start with 4.\n",
+      "- The next number is 2 (since 4 divided by 2 is 2).\n",
+      "- The next number...[TRUNCATED]\n",
+      "The stop-at-one sequence for 4 is as follows:\n",
+      "\n",
+      "- Start with 4.\n",
+      "- The next number is 2 (since 4 divided by 2 is 2).\n",
+      "- The next number is 1 (since 2 divided by 2 is 1).\n",
+      "\n",
+      "The sequence is complete once we reach 1.\n",
+      "\n",
+      "Here is the result:\n",
+      "- **Starting number**: 4\n",
+      "- **Total steps taken**: 2\n",
+      "- **Maximum value reached**: 4\n",
+      "\n",
+      "The complete sequence is: 4 → 2 → 1.\n"
      ]
     }
    ],
    "source": [
-    "# Task 2: memory.recall() already ran above — the reflection from Task 1 is\n",
-    "# now injected into the system prompt so the agent can apply it immediately.\n",
+    "# Task 2: the episode from Task 1 is recalled by similarity search and\n",
+    "# injected into the system prompt — the agent answers directly from memory.\n",
     "result_2 = await agent.run(\n",
     "    task_2,\n",
-    "    explicit_only_skills={\"stop-at-one\"},\n",
     ")\n",
     "print(result_2.content)"
    ]

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -78,9 +78,13 @@ one, call the `from_scratch__use_skill` tool with the skill name.
 </available_skills>""".strip()
 
 DEFAULT_MEMORIES_BLOCK = """The following are memories from past episodes or
-task executions. Review these carefully: apply any lessons or insights to
+task executions.
+
+<warning>
+Review these carefully: apply any lessons or insights to
 inform your approach, and if a past episode covers the same task, use its
 result directly unless instructed otherwise.
+</warning>
 
 <memories>
 {memories}


### PR DESCRIPTION
## Summary

- Replaces `reflective_memory()` with `similarity_memory()` in Example 5 — no LLM call at write time, simpler and more focused on the core memory mechanism
- Task 1 computes the stop-at-one sequence for 4 via the `next_number` tool (the stop-at-one skill guides execution when `explicit_only_skills` is not set)
- Task 2 asks the same question with a different phrasing — similarity search recalls the Task 1 episode and the agent answers directly from memory with **zero tool calls**
- Strengthens `DEFAULT_MEMORIES_BLOCK` to explicitly instruct the agent to reuse a past result when the same task has already been completed

## Test plan

- [ ] Re-run Example 5 top-to-bottom in a fresh kernel: Task 1 should call `next_number` tool steps; recall cell should show the stored episode; Task 2 should return from memory with no tool calls
- [ ] Confirm Examples 1–4 still execute correctly

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)