### PR TITLE
feat: swap JSONMemoryStore for QdrantMemoryStore in ch07.ipynb Example 2

### DIFF
--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -143,14 +143,14 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <reflection>Always use the hailstone tool.</reflection>\n",
-      "    <completed_at>2026-06-19 16:07:56</completed_at>\n",
+      "    <completed_at>2026-06-19 20:58:22</completed_at>\n",
       "  </episode>\n",
       "\n",
       "=== CONCAT ===\n",
       "task: Compute the Hailstone sequence for 6.\n",
       "result: 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "reflection: Always use the hailstone tool.\n",
-      "completed_at: 2026-06-19 16:07:56\n"
+      "completed_at: 2026-06-19 20:58:22\n"
      ]
     }
    ],
@@ -179,29 +179,102 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000009",
    "metadata": {},
-   "source": "### Example 2a: Writing Episodes to a QdrantMemoryStore"
+   "source": [
+    "### Example 2a: Writing Episodes to a QdrantMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a1b2c3d4-0007-0000-0000-000000000010",
    "metadata": {},
-   "outputs": [],
-   "source": "import warnings\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n\nwarnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n\nstore = QdrantMemoryStore(max_results=1)\n\ntask_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\ntask_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n\nepisodes = [\n    Episode(\n        task=task_1,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_1.id_,\n            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"8\"},\n    ),\n    Episode(\n        task=task_2,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_2.id_,\n            content=\"8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"3\"},\n    ),\n]\n\nfor ep in episodes:\n    await store.write(ep)\n    print(f\"count: {await store.count()}\")"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "count: 1\n",
+      "count: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
+    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
+    "from llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n",
+    "\n",
+    "store = QdrantMemoryStore(max_results=1)\n",
+    "\n",
+    "task_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\n",
+    "task_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n",
+    "\n",
+    "episodes = [\n",
+    "    Episode(\n",
+    "        task=task_1,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_1.id_,\n",
+    "            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"8\"},\n",
+    "    ),\n",
+    "    Episode(\n",
+    "        task=task_2,\n",
+    "        rollout=\"mock rollout\",\n",
+    "        result=TaskResult(\n",
+    "            task_id=task_2.id_,\n",
+    "            content=\"8 → 4 → 2 → 1\",\n",
+    "        ),\n",
+    "        metadata={\"steps\": \"3\"},\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for ep in episodes:\n",
+    "    await store.write(ep)\n",
+    "    print(f\"count: {await store.count()}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000011",
    "metadata": {},
-   "source": "### Example 2b: Recalling from a QdrantMemoryStore"
+   "source": [
+    "### Example 2b: Recalling from a QdrantMemoryStore"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "1eef4906-3d70-44d7-8c29-87fb4db89fef",
    "metadata": {},
-   "outputs": [],
-   "source": "results = await store.recall(\"Hailstone sequence starting from 6\")\nprint(\n    f\"recall() returned {len(results)} episode(s)\"\n    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n)\nprint(results[0].format())"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recall() returned 1 episode(s) -- query matched by similarity (RecallMode.SEARCH)\n",
+      "\n",
+      "  <episode>\n",
+      "    <task>Compute the Hailstone sequence for 6.</task>\n",
+      "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
+      "    <steps>8</steps>\n",
+      "    <completed_at>2026-06-19 20:58:22</completed_at>\n",
+      "  </episode>\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = await store.recall(\"Hailstone sequence starting from 6\")\n",
+    "print(\n",
+    "    f\"recall() returned {len(results)} episode(s)\"\n",
+    "    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n",
+    ")\n",
+    "print(results[0].format())"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -225,7 +298,7 @@
       "  <episode>\n",
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
-      "    <completed_at>2026-06-19 16:07:56</completed_at>\n",
+      "    <completed_at>2026-06-19 20:58:24</completed_at>\n",
       "  </episode>\n",
       "\n",
       "Recalled episode (enriched by step_counter_fn at write time):\n",
@@ -233,7 +306,7 @@
       "    <task>Compute the Hailstone sequence for 6.</task>\n",
       "    <result>6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1</result>\n",
       "    <steps>9</steps>\n",
-      "    <completed_at>2026-06-19 16:07:56</completed_at>\n",
+      "    <completed_at>2026-06-19 20:58:24</completed_at>\n",
       "  </episode>\n"
      ]
     }

--- a/examples/ch07.ipynb
+++ b/examples/ch07.ipynb
@@ -179,72 +179,21 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000009",
    "metadata": {},
-   "source": [
-    "### Example 2a: Writing Episodes to a JSONMemoryStore"
-   ]
+   "source": "### Example 2a: Writing Episodes to a QdrantMemoryStore"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a1b2c3d4-0007-0000-0000-000000000010",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "count: 1\n",
-      "count: 2\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pathlib import Path\n",
-    "from llm_agents_from_scratch.data_structures import Task, TaskResult\n",
-    "from llm_agents_from_scratch.data_structures.memory import Episode\n",
-    "from llm_agents_from_scratch.memory_stores import JSONMemoryStore\n",
-    "\n",
-    "STORE_DIR = Path(\".\")\n",
-    "(STORE_DIR / \"episodes.jsonl\").unlink(missing_ok=True)  # start clean on each full run\n",
-    "\n",
-    "store = JSONMemoryStore(dir=STORE_DIR, max_results=1)\n",
-    "\n",
-    "task_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\n",
-    "task_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n",
-    "\n",
-    "episodes = [\n",
-    "    Episode(\n",
-    "        task=task_1,\n",
-    "        rollout=\"mock rollout\",\n",
-    "        result=TaskResult(\n",
-    "            task_id=task_1.id_,\n",
-    "            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n",
-    "        ),\n",
-    "        metadata={\"steps\": \"8\"},\n",
-    "    ),\n",
-    "    Episode(\n",
-    "        task=task_2,\n",
-    "        rollout=\"mock rollout\",\n",
-    "        result=TaskResult(\n",
-    "            task_id=task_2.id_,\n",
-    "            content=\"8 → 4 → 2 → 1\",\n",
-    "        ),\n",
-    "        metadata={\"steps\": \"3\"},\n",
-    "    ),\n",
-    "]\n",
-    "\n",
-    "for ep in episodes:\n",
-    "    await store.write(ep)\n",
-    "    print(f\"count: {await store.count()}\")"
-   ]
+   "outputs": [],
+   "source": "import warnings\n\nfrom llm_agents_from_scratch.data_structures import Task, TaskResult\nfrom llm_agents_from_scratch.data_structures.memory import Episode\nfrom llm_agents_from_scratch.memory_stores.qdrant import QdrantMemoryStore\n\nwarnings.filterwarnings(\"ignore\", message=\"Payload indexes have no effect\")\n\nstore = QdrantMemoryStore(max_results=1)\n\ntask_1 = Task(instruction=\"Compute the Hailstone sequence for 6.\")\ntask_2 = Task(instruction=\"Compute the Hailstone sequence for 8.\")\n\nepisodes = [\n    Episode(\n        task=task_1,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_1.id_,\n            content=\"6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"8\"},\n    ),\n    Episode(\n        task=task_2,\n        rollout=\"mock rollout\",\n        result=TaskResult(\n            task_id=task_2.id_,\n            content=\"8 → 4 → 2 → 1\",\n        ),\n        metadata={\"steps\": \"3\"},\n    ),\n]\n\nfor ep in episodes:\n    await store.write(ep)\n    print(f\"count: {await store.count()}\")"
   },
   {
    "cell_type": "markdown",
    "id": "a1b2c3d4-0007-0000-0000-000000000011",
    "metadata": {},
-   "source": [
-    "### Example 2b: Searching a JSONMemoryStore"
-   ]
+   "source": "### Example 2b: Recalling from a QdrantMemoryStore"
   },
   {
    "cell_type": "code",
@@ -252,7 +201,7 @@
    "id": "1eef4906-3d70-44d7-8c29-87fb4db89fef",
    "metadata": {},
    "outputs": [],
-   "source": "results = await store.recall(\"What Hailstone sequences have been computed?\")\nprint(\n    f\"recall() returned {len(results)} episode(s)\"\n    \" -- query is ignored (RecallMode.RECENT)\\n\"\n)\nprint(results[0].format())"
+   "source": "results = await store.recall(\"Hailstone sequence starting from 6\")\nprint(\n    f\"recall() returned {len(results)} episode(s)\"\n    \" -- query matched by similarity (RecallMode.SEARCH)\\n\"\n)\nprint(results[0].format())"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- **Example 2a**: Replace `JSONMemoryStore` with `QdrantMemoryStore` — drops the file-path boilerplate and `episodes.jsonl` cleanup line; store is now in-process Qdrant (consistent with Examples 3 and 4)
- **Example 2b**: Rename heading to "Recalling from a QdrantMemoryStore"; update the recall query and print message to reflect similarity-based lookup (`RecallMode.SEARCH`) rather than recency (`RecallMode.RECENT`)

Closes #662

## Test plan

- [ ] Run Examples 2a and 2b top-to-bottom: write succeeds, recall returns the most similar episode
- [ ] No `episodes.jsonl` file created in the working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)