### PR TITLE
docs: add UML diagram for BaseMemoryStore

### DIFF
--- a/uml/ch07/base_memory_store.puml
+++ b/uml/ch07/base_memory_store.puml
@@ -26,8 +26,6 @@ package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
   }
 }
 
-llm_agents_from_scratch.data_structures.memory -[hidden]right- llm_agents_from_scratch.base.memory_store
-
 ' Relations
 BaseMemoryStore *-left- RecallMode
 

--- a/uml/ch07/base_memory_store.puml
+++ b/uml/ch07/base_memory_store.puml
@@ -1,0 +1,34 @@
+@startuml base_memory_store
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.data_structures.memory" <<Folder>> {
+
+  enum RecallMode {
+    RECENT
+    SEARCH
+  }
+}
+
+package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
+
+  abstract class BaseMemoryStore {
+    +max_results: int
+    +recall_mode: RecallMode
+    --
+    +<<async>> write(episode: Episode): None
+    +<<async>> recall(\n\tquery: str,\n\t**kwargs\n): list[Episode]
+    +<<async>> delete(id_: str): None
+    +<<async>> update(episode: Episode): None
+    +<<async>> count(): int
+    +<<async>> summary(): str
+    -<<async>> _read_recent(n: int): list[Episode]
+    -<<async>> _search(\n\tquery: str,\n\t**kwargs\n): list[Episode]
+  }
+}
+
+llm_agents_from_scratch.data_structures.memory -[hidden]right- llm_agents_from_scratch.base.memory_store
+
+' Relations
+BaseMemoryStore *-left- RecallMode : " has"
+
+@enduml

--- a/uml/ch07/base_memory_store.puml
+++ b/uml/ch07/base_memory_store.puml
@@ -29,6 +29,6 @@ package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
 llm_agents_from_scratch.data_structures.memory -[hidden]right- llm_agents_from_scratch.base.memory_store
 
 ' Relations
-BaseMemoryStore *-left- RecallMode : " has"
+BaseMemoryStore *-left- RecallMode
 
 @enduml

--- a/uml/ch07/base_memory_store.puml
+++ b/uml/ch07/base_memory_store.puml
@@ -17,12 +17,12 @@ package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
     --
     +<<async>> write(episode: Episode): None
     +<<async>> recall(\n\tquery: str,\n\t**kwargs\n): list[Episode]
+    -<<async>> _read_recent(n: int): list[Episode]
+    -<<async>> _search(\n\tquery: str,\n\t**kwargs\n): list[Episode]
     +<<async>> delete(id_: str): None
     +<<async>> update(episode: Episode): None
     +<<async>> count(): int
     +<<async>> summary(): str
-    -<<async>> _read_recent(n: int): list[Episode]
-    -<<async>> _search(\n\tquery: str,\n\t**kwargs\n): list[Episode]
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `uml/ch07/base_memory_store.puml` with a PlantUML class diagram for `BaseMemoryStore` and `RecallMode`
- Follows the established style from other `uml/ch07/` diagrams
- Renders to `uml/rendered/ch07/base_memory_store.svg` via `make diagrams`

Closes #611

## Test plan

- [ ] Run `make diagrams` — `uml/rendered/ch07/base_memory_store.svg` is generated without errors
- [ ] Open the SVG and confirm `BaseMemoryStore` and `RecallMode` appear with correct fields, methods, and relationship arrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)