### PR TITLE
book diagrams: add UML diagrams for QdrantMemoryStore and JSONMemoryStore

### DIFF
--- a/uml/ch07/json_memory_store.puml
+++ b/uml/ch07/json_memory_store.puml
@@ -1,0 +1,30 @@
+@startuml json_memory_store
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
+  abstract class BaseMemoryStore {
+    --
+    +<<async>> write()
+    +<<async>> recall()
+    +<<async>> delete()
+    +<<async>> update()
+    +<<async>> count()
+    +<<async>> summary()
+    -<<async>> _read_recent()
+    -<<async>> _search()
+  }
+}
+
+package "llm_agents_from_scratch.memory_stores" <<Folder>> {
+
+  class JSONMemoryStore {
+    +path: Path
+    --
+    +<<constructor>> __init__(\n\tdir: Path,\n\tfilename: str,\n\tmax_results: int,\n\trecall_mode: RecallMode\n):
+  }
+}
+
+' Relations
+BaseMemoryStore <|-- JSONMemoryStore : " inherits"
+
+@enduml

--- a/uml/ch07/json_memory_store.puml
+++ b/uml/ch07/json_memory_store.puml
@@ -1,5 +1,6 @@
 @startuml json_memory_store
 !include ../common/book-clean.puml
+left to right direction
 
 package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
   abstract class BaseMemoryStore {
@@ -25,6 +26,6 @@ package "llm_agents_from_scratch.memory_stores" <<Folder>> {
 }
 
 ' Relations
-BaseMemoryStore <|-right- JSONMemoryStore : " inherits"
+BaseMemoryStore <|-- JSONMemoryStore : " inherits"
 
 @enduml

--- a/uml/ch07/json_memory_store.puml
+++ b/uml/ch07/json_memory_store.puml
@@ -25,6 +25,6 @@ package "llm_agents_from_scratch.memory_stores" <<Folder>> {
 }
 
 ' Relations
-BaseMemoryStore <|-- JSONMemoryStore : " inherits"
+BaseMemoryStore <|-right- JSONMemoryStore : " inherits"
 
 @enduml

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -27,6 +27,6 @@ package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
 }
 
 ' Relations
-BaseMemoryStore <|-- QdrantMemoryStore : " inherits"
+BaseMemoryStore <|-right- QdrantMemoryStore : " inherits"
 
 @enduml

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -1,5 +1,6 @@
 @startuml qdrant_memory_store
 !include ../common/book-clean.puml
+left to right direction
 
 package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
   abstract class BaseMemoryStore {
@@ -27,6 +28,6 @@ package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
 }
 
 ' Relations
-BaseMemoryStore <|-right- QdrantMemoryStore : " inherits"
+BaseMemoryStore <|-- QdrantMemoryStore : " inherits"
 
 @enduml

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -1,0 +1,32 @@
+@startuml qdrant_memory_store
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
+  abstract class BaseMemoryStore {
+    --
+    +<<async>> write()
+    +<<async>> recall()
+    +<<async>> delete()
+    +<<async>> update()
+    +<<async>> count()
+    +<<async>> summary()
+    -<<async>> _read_recent()
+    -<<async>> _search()
+  }
+}
+
+package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
+
+  class QdrantMemoryStore {
+    -_client: ~qdrant_client.AsyncQdrantClient
+    -_collection_name: str
+    -_key_fn: Callable[[Episode], str]
+    --
+    +<<constructor>> __init__(\n\tcollection_name: str,\n\tembedding_model: str,\n\tclient: AsyncQdrantClient | None,\n\tmax_results: int,\n\trecall_mode: RecallMode,\n\tkey_fn: Callable[[Episode], str] | None\n):
+  }
+}
+
+' Relations
+BaseMemoryStore <|-- QdrantMemoryStore : " inherits"
+
+@enduml

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -20,9 +20,9 @@ package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
   class QdrantMemoryStore {
     -_client: ~qdrant_client.AsyncQdrantClient
     -_collection_name: str
-    -_key_fn: Callable[[Episode], str]
+    -_key_fn: Callable
     --
-    +<<constructor>> __init__(\n\tcollection_name: str,\n\tembedding_model: str,\n\tclient: AsyncQdrantClient | None,\n\tmax_results: int,\n\trecall_mode: RecallMode,\n\tkey_fn: Callable[[Episode], str] | None\n):
+    +<<constructor>> __init__(\n\tcollection_name: str,\n\tembedding_model: str,\n\tclient: AsyncQdrantClient | None,\n\tmax_results: int,\n\trecall_mode: RecallMode,\n\tkey_fn: Callable | None\n):
   }
 }
 

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -24,6 +24,8 @@ package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
     -_key_fn: Callable
     --
     +<<constructor>> __init__(\n\tcollection_name: str,\n\tembedding_model: str,\n\tclient: AsyncQdrantClient | None,\n\tmax_results: int,\n\trecall_mode: RecallMode,\n\tkey_fn: Callable | None\n):
+    -<<async>> _ensure_collection(): None
+    -<<async>> _point_exists(id_: str): bool
   }
 }
 

--- a/uml/ch07/qdrant_memory_store.puml
+++ b/uml/ch07/qdrant_memory_store.puml
@@ -21,6 +21,7 @@ package "llm_agents_from_scratch.memory_stores.qdrant" <<Folder>> {
   class QdrantMemoryStore {
     -_client: ~qdrant_client.AsyncQdrantClient
     -_collection_name: str
+    -_collection_ready: bool
     -_key_fn: Callable
     --
     +<<constructor>> __init__(\n\tcollection_name: str,\n\tembedding_model: str,\n\tclient: AsyncQdrantClient | None,\n\tmax_results: int,\n\trecall_mode: RecallMode,\n\tkey_fn: Callable | None\n):


### PR DESCRIPTION
## Summary

- Adds `uml/ch07/qdrant_memory_store.puml` and `uml/ch07/json_memory_store.puml`
- Both follow the `OllamaLLM` pattern — abbreviated base class, constructor on the concrete class, inheritance arrow
- Renders to `uml/rendered/ch07/` via `make diagrams`

Closes #612

## Test plan

- [ ] Run `make diagrams` — both SVGs generated without errors
- [ ] Open each SVG and confirm correct fields, constructor params, and inheritance arrow from `BaseMemoryStore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)