### PR TITLE
book diagrams: add UML diagram for Memory class

### DIFF
--- a/uml/ch07/memory.puml
+++ b/uml/ch07/memory.puml
@@ -1,0 +1,35 @@
+@startuml memory
+!include ../common/book-clean.puml
+left to right direction
+
+package "llm_agents_from_scratch.base.memory_store" <<Folder>> {
+  abstract class BaseMemoryStore {
+    --
+    +<<async>> write()
+    +<<async>> recall()
+    +<<async>> delete()
+    +<<async>> update()
+    +<<async>> count()
+    +<<async>> summary()
+  }
+}
+
+package "llm_agents_from_scratch.memory" <<Folder>> {
+
+  class Memory {
+    +store: BaseMemoryStore
+    +metadata_fns: dict[str, MetadataFn]
+    --
+    +<<constructor>> __init__(\n\tstore: BaseMemoryStore,\n\tmetadata_fns: dict[str, MetadataFn] | None\n):
+    +<<async>> recall(task: Task): str
+    +<<async>> record(episode: Episode): None
+    +<<async>> delete(id_: str): None
+    +<<async>> update(episode: Episode): None
+    +<<async>> summary(): str
+  }
+}
+
+' Relations
+Memory *-- BaseMemoryStore : " has"
+
+@enduml


### PR DESCRIPTION
## Summary

- Adds `uml/ch07/memory.puml` with a PlantUML class diagram for `Memory`
- Shows `Memory` composed with `BaseMemoryStore` (abbreviated), with all public methods and the `metadata_fns` attribute
- Renders to `uml/rendered/ch07/memory.svg` via `make diagrams`

Closes #610

## Test plan

- [ ] Run `make diagrams` — `uml/rendered/ch07/memory.svg` is generated without errors
- [ ] Open the SVG and confirm `Memory` and `BaseMemoryStore` appear with correct fields, methods, and composition arrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)