### PR TITLE
docs: add UML diagram for ch07 updates to LLMAgent and TaskHandler

### DIFF
--- a/uml/ch07/taskhandler.puml
+++ b/uml/ch07/taskhandler.puml
@@ -1,0 +1,43 @@
+@startuml uml_ch07_taskhandler_updates
+!include ../common/book-clean.puml
+left to right direction
+
+package "llm_agents_from_scratch.agent" <<Folder>> {
+
+  class LLMAgent {
+    <color:#aaaaaa>+llm: LLM</color>
+    <color:#aaaaaa>+tools_registry: dict[str, Tool]</color>
+    <color:#aaaaaa>+templates: LLMAgentTemplates</color>
+    <color:#aaaaaa>+logger: Logger</color>
+    +memories: list[Memory]
+    --
+    <color:#aaaaaa>+tools: list[Tool]</color>
+    <color:#aaaaaa>+add_tool(tool: Tool): Self</color>
+    +<b>run(task: Task, ...): TaskHandler</b>
+  }
+
+  class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>+llm_agent: LLMAgent</color>
+    <color:#aaaaaa>+task: Task</color>
+    <color:#aaaaaa>+rollout: str</color>
+    <color:#aaaaaa>+step_counter: int</color>
+    <color:#aaaaaa>-_background_task: ~asyncio.Task</color>
+    <color:#aaaaaa>+skills: dict[str, Skill]</color>
+    <color:#aaaaaa>-_skills_catalog: str</color>
+    <color:#aaaaaa>-_use_skill_tool: UseSkillTool | None</color>
+    <color:#aaaaaa>-_explicit_only_skills: set[str]</color>
+    -_recalled_memories: str
+    --
+    <color:#aaaaaa>+<<async>> get_next_step(): TaskStep | TaskResult</color>
+    +<b><<async>> run_step(step: TaskStep): TaskStepResult</b>
+    <color:#aaaaaa>-_format_step_for_rollout()</color>
+    -_format_memories_for_system_prompt(\n\tmemories: list[str]\n): str
+    +<<async>> load_memories(): None
+    +<<async>> record_memory(\n\tresult: TaskResult | None,\n\terror: Exception | None\n): None
+  }
+}
+
+' Relations
+LLMAgent *-- TaskHandler : " has"
+
+@enduml


### PR DESCRIPTION
## Summary

- Adds `uml/ch07/taskhandler.puml` showing ch07 additions to `LLMAgent` and `LLMAgent.TaskHandler`
- Follows the ch06 style — pre-existing members greyed out, new/updated members highlighted in bold
- New in `LLMAgent`: `memories: list[Memory]`; `run()` bolded (calls `load_memories()` and `record_memory()` in the processing loop)
- New in `TaskHandler`: `_recalled_memories`, `_format_memories_for_system_prompt()`, `load_memories()`, `record_memory()`; `run_step()` bolded (memory injection)
- Classes laid out side by side (`left to right direction`)
- Renders to `uml/rendered/ch07/uml_ch07_taskhandler_updates.svg` via `make diagrams`

Closes #668

## Test plan

- [ ] Run `make diagrams` — SVG generated without errors
- [ ] Open the SVG and confirm `LLMAgent` on the left, `TaskHandler` on the right, new members unhighlighted and updated methods bolded

🤖 Generated with [Claude Code](https://claude.com/claude-code)