### PR TITLE
feat: implement HumanInputTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-- ...
+### Added
+
+- feat: implement HumanInputTool (#685)
 
 ## [0.0.19] - 2026-06-23
 

--- a/src/llm_agents_from_scratch/tools/default/__init__.py
+++ b/src/llm_agents_from_scratch/tools/default/__init__.py
@@ -1,9 +1,15 @@
 """Default tools included with every LLMAgent."""
 
 from ...base.tool import BaseTool
+from .human_input import HumanInputTool
 from .interpreter import PythonInterpreterTool
 from .read_file import ReadFileTool
 
 DEFAULT_TOOLS: list[BaseTool] = [ReadFileTool(), PythonInterpreterTool()]
 
-__all__ = ["DEFAULT_TOOLS", "PythonInterpreterTool", "ReadFileTool"]
+__all__ = [
+    "DEFAULT_TOOLS",
+    "HumanInputTool",
+    "PythonInterpreterTool",
+    "ReadFileTool",
+]

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -7,19 +7,26 @@ from ...data_structures import ToolCall, ToolCallResult
 
 
 class HumanInputTool(BaseTool):
-    """_summary_
+    """A tool that pauses execution to collect input from a human operator.
 
-    Args:
-        BaseTool (_type_): _description_
+    The LLM calls this tool when it needs clarification, a decision, or
+    additional information that cannot be inferred from the task alone.
+    Execution blocks until the human responds.
     """
 
     @property
     def name(self) -> str:
-        return "HumanInputTool"
+        """Name of the human-input tool."""
+        return "human_input"
 
     @property
     def description(self) -> str:
-        return ""
+        """Description of the human-input tool."""
+        return (
+            "Ask the human operator a question and wait for their response. "
+            "Use this tool when you need clarification or additional "
+            "information that is not available from the task context."
+        )
 
     @property
     def parameters_json_schema(self) -> dict[str, Any]:
@@ -29,9 +36,12 @@ class HumanInputTool(BaseTool):
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "Prompt to provide human.",
+                    "description": (
+                        "The question or prompt to present to the human."
+                    ),
                 },
             },
+            "required": ["prompt"],
         }
 
     def __call__(
@@ -40,7 +50,20 @@ class HumanInputTool(BaseTool):
         *args: Any,
         **kwargs: Any,
     ) -> ToolCallResult:
-        prompt = tool_call.arguments.get("prompt")
+        """Display a prompt to the human operator and return their response.
+
+        Blocks until the operator submits a response via stdin.
+
+        Args:
+            tool_call (ToolCall): The tool call containing the ``prompt``
+                argument.
+            *args (Any): Additional positional arguments (unused).
+            **kwargs (Any): Additional keyword arguments (unused).
+
+        Returns:
+            ToolCallResult: The human's response as the content.
+        """
+        prompt = tool_call.arguments.get("prompt", "")
         response = input(prompt)
 
         return ToolCallResult(

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -64,7 +64,20 @@ class HumanInputTool(BaseTool):
             ToolCallResult: The human's response as the content.
         """
         prompt = tool_call.arguments.get("prompt", "")
-        response = input(prompt)
+        try:
+            response = input(prompt)
+        except EOFError:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="No input received (stdin closed).",
+                error=True,
+            )
+        except KeyboardInterrupt:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="Human declined to provide input (KeyboardInterrupt).",
+                error=True,
+            )
 
         return ToolCallResult(
             tool_call_id=tool_call.id_,

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -1,0 +1,49 @@
+"""Human in the loop via HumanInputTool."""
+
+from typing import Any
+
+from ...base.tool import BaseTool
+from ...data_structures import ToolCall, ToolCallResult
+
+
+class HumanInputTool(BaseTool):
+    """_summary_
+
+    Args:
+        BaseTool (_type_): _description_
+    """
+
+    @property
+    def name(self) -> str:
+        return "HumanInputTool"
+
+    @property
+    def description(self) -> str:
+        return ""
+
+    @property
+    def parameters_json_schema(self) -> dict[str, Any]:
+        """JSON schema for human input parameters."""
+        return {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Prompt to provide human.",
+                },
+            },
+        }
+
+    def __call__(
+        self,
+        tool_call: ToolCall,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ToolCallResult:
+        prompt = tool_call.arguments.get("prompt")
+        response = input(prompt)
+
+        return ToolCallResult(
+            tool_call_id=tool_call.id_,
+            content=response,
+        )

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from llm_agents_from_scratch.data_structures import ToolCall
 from llm_agents_from_scratch.tools.default import (
     DEFAULT_TOOLS,
+    HumanInputTool,
     PythonInterpreterTool,
     ReadFileTool,
 )
@@ -261,3 +262,102 @@ def test_python_interpreter_tool_passes_stdin(tmp_path: Path) -> None:
 def test_default_tools_contains_python_interpreter_tool() -> None:
     """Tests DEFAULT_TOOLS includes a PythonInterpreterTool instance."""
     assert any(isinstance(t, PythonInterpreterTool) for t in DEFAULT_TOOLS)
+
+
+# --- HumanInputTool ---
+
+
+def test_human_input_tool_name() -> None:
+    """Tests HumanInputTool.name."""
+    tool = HumanInputTool()
+    assert tool.name == "human_input"
+
+
+def test_human_input_tool_description() -> None:
+    """Tests HumanInputTool.description mentions human and input."""
+    tool = HumanInputTool()
+    assert "human" in tool.description.lower()
+
+
+def test_human_input_tool_parameters_json_schema() -> None:
+    """Tests HumanInputTool schema has required prompt field."""
+    tool = HumanInputTool()
+    schema = tool.parameters_json_schema
+    assert schema["type"] == "object"
+    assert "prompt" in schema["properties"]
+    assert schema["required"] == ["prompt"]
+
+
+def test_human_input_tool_returns_response() -> None:
+    """Tests HumanInputTool returns the human's response as content."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="human_input",
+        arguments={"prompt": "What is your name?"},
+    )
+
+    with patch("builtins.input", return_value="Alice"):
+        result = tool(tool_call=tool_call)
+
+    assert result.error is False
+    assert result.content == "Alice"
+
+
+def test_human_input_tool_passes_prompt_to_input() -> None:
+    """Tests HumanInputTool passes the prompt argument to input()."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="human_input",
+        arguments={"prompt": "How old are you?"},
+    )
+
+    with patch("builtins.input", return_value="30") as mock_input:
+        tool(tool_call=tool_call)
+
+    mock_input.assert_called_once_with("How old are you?")
+
+
+def test_human_input_tool_missing_prompt_defaults_to_empty() -> None:
+    """Tests HumanInputTool defaults to empty string when prompt is absent."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="human_input",
+        arguments={},
+    )
+
+    with patch("builtins.input", return_value="ok") as mock_input:
+        tool(tool_call=tool_call)
+
+    mock_input.assert_called_once_with("")
+
+
+def test_human_input_tool_eof_error() -> None:
+    """Tests HumanInputTool returns error result on EOFError."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="human_input",
+        arguments={"prompt": "Enter value:"},
+    )
+
+    with patch("builtins.input", side_effect=EOFError):
+        result = tool(tool_call=tool_call)
+
+    assert result.error is True
+    assert result.content is not None
+    assert "stdin" in result.content.lower()
+
+
+def test_human_input_tool_keyboard_interrupt() -> None:
+    """Tests HumanInputTool returns error result on KeyboardInterrupt."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="human_input",
+        arguments={"prompt": "Enter value:"},
+    )
+
+    with patch("builtins.input", side_effect=KeyboardInterrupt):
+        result = tool(tool_call=tool_call)
+
+    assert result.error is True
+    assert result.content is not None
+    assert "declined" in result.content.lower()


### PR DESCRIPTION
## Summary

- Implements `HumanInputTool` in `tools/default/human_input.py` as a `BaseTool` (sync, plain `input()`)
- Single `prompt: str` parameter — the question the agent wants to ask the human
- Handles `EOFError` (stdin closed) and `KeyboardInterrupt` (user declined) as error `ToolCallResult`s rather than crashing the agent loop
- Exports `HumanInputTool` from `tools/default/__init__` (not added to `DEFAULT_TOOLS` — opt-in)
- 8 new tests covering happy path, prompt passthrough, missing prompt, EOFError, and KeyboardInterrupt

Closes #677

## Test plan

- [x] `pytest tests/tools/test_default.py` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)