### PR TITLE
feat(ch08): add ch08.ipynb Example 1 — HumanInputTool with Hailstone agent

### DIFF
--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "# Chapter 8 — Human in the Loop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000002",
+   "metadata": {},
+   "source": [
+    "## Setup Instructions\n",
+    "\n",
+    "To ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n",
+    "\n",
+    "```sh\n",
+    "uv run --with jupyter jupyter lab\n",
+    "```\n",
+    "\n",
+    "Alternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPi by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0008-0000-0000-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPi\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000004",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0008-0000-0000-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, shutil, subprocess, time, urllib.request, urllib.error\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\"\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000006",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000007",
+   "metadata": {},
+   "source": [
+    "### Example 1: Agent-Initiated Pause with HumanInputTool\n",
+    "\n",
+    "This example returns to the Hailstone running example used throughout the book. The agent is given the `next_number` tool to step through the sequence, but the task deliberately omits the starting number. The agent must call `human_input` to ask the operator which number to start from.\n",
+    "\n",
+    "When the cell below runs and the agent invokes `human_input`, execution pauses and a prompt appears in the cell output. Type any positive integer and press **Enter** — the agent receives the response as a tool result and continues computing the sequence autonomously."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0008-0000-0000-000000000008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "from llm_agents_from_scratch.tools.default import HumanInputTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "\n",
+    "def next_number(x: int) -> int:\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "next_number_tool = SimpleFunctionTool(func=next_number)\n",
+    "human_input_tool = HumanInputTool()\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[next_number_tool, human_input_tool])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0008-0000-0000-000000000009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compute the full Hailstone sequence step by step using next_number. \"\n",
+    "        \"The starting number must come from the human operator — ask them \"\n",
+    "        \"before beginning.\"\n",
+    "    )\n",
+    ")\n",
+    "result = await agent.run(task)\n",
+    "print(result.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0008-0000-0000-000000000010",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -116,13 +116,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0008-0000-0000-000000000007",
    "metadata": {},
-   "source": [
-    "### Example 1: Agent-Initiated Pause with HumanInputTool\n",
-    "\n",
-    "This example returns to the Hailstone running example used throughout the book. The agent is given the `next_number` tool to step through the sequence, but the task deliberately omits the starting number. The agent must call `human_input` to ask the operator which number to start from.\n",
-    "\n",
-    "When the cell below runs and the agent invokes `human_input`, execution pauses and a prompt appears in the cell output. Type any positive integer and press **Enter** — the agent receives the response as a tool result and continues computing the sequence autonomously."
-   ]
+   "source": "### Example 1: Agent-Initiated Pause with HumanInputTool"
   },
   {
    "cell_type": "code",

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -47,10 +47,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "a1b2c3d4-0008-0000-0000-000000000005",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os, shutil, subprocess, time, urllib.request, urllib.error\n",
     "\n",
@@ -116,11 +124,13 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0008-0000-0000-000000000007",
    "metadata": {},
-   "source": "### Example 1: Agent-Initiated Pause with HumanInputTool"
+   "source": [
+    "### Example 1: Agent-Initiated Pause with HumanInputTool"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "a1b2c3d4-0008-0000-0000-000000000008",
    "metadata": {},
    "outputs": [],
@@ -151,10 +161,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a1b2c3d4-0008-0000-0000-000000000009",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask them ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask th...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence. Let me prompt them for it.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Prompt the human operator to provide the starting number for the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Prompt the human operator to provide the starting number for the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: human_input\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Please provide the starting number for the Hailstone sequence. 4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 4. Now I will compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 4 is 2. I will now compute the next number in the sequence using the next_number tool. ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call:\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"f6a22a4c-7b6d-4f7d-91c5-4a8e0c419f5d\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequence....[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequen...[TRUNCATED]\n",
+      "The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequence. The full Hailstone sequence starting from 4 is: 4, 2, 1.\n"
+     ]
+    }
+   ],
    "source": [
     "task = Task(\n",
     "    instruction=(\n",


### PR DESCRIPTION
Closes #680

## Summary

- Adds `examples/ch08.ipynb` with Example 1 demonstrating `HumanInputTool`
- The agent is given the Hailstone `next_number` tool but no starting number — it calls `human_input` to ask the operator before computing the full sequence
- Follows the same notebook structure and boilerplate as prior chapters (setup instructions, ensure_ollama helper, Examples section)

## Test plan

- [ ] Run `uv run --with jupyter jupyter lab` from project root and open `examples/ch08.ipynb`
- [ ] Execute all cells in order; confirm Ollama starts / is detected
- [ ] When the agent invokes `human_input`, confirm a prompt appears in the cell output
- [ ] Type a positive integer (e.g. `6`) and press Enter; confirm the agent completes the Hailstone sequence autonomously
- [ ] Confirm `result.content` contains the full sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)