### PR TITLE
feat(ch08): add Example 2 — end-of-loop approval gate

### DIFF
--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -227,6 +227,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "baf1bd33",
+   "source": "### Example 2: End-of-Loop Approval Gate",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7d13724c",
+   "source": "import logging\n\nfrom llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.logger import enable_console_logging\nfrom llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.tools import SimpleFunctionTool\n\nenable_console_logging(logging.INFO)\n\n\ndef next_number(x: int) -> int:\n    if x % 2 == 0:\n        return x // 2\n    return 3 * x + 1\n\n\nnext_number_tool = SimpleFunctionTool(func=next_number)\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[next_number_tool])",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "e7a074f4",
+   "source": "task = Task(\n    instruction=(\n        \"Compute the full Hailstone sequence starting from 6, \"\n        \"step by step using next_number, until you reach 1.\"\n    )\n)\nresult = await agent.run(task, with_approval=True)\nprint(result.content)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a1b2c3d4-0008-0000-0000-000000000010",

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -171,46 +171,66 @@
      "text": [
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask them ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask th...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence. Let me prompt them for it.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Prompt the human operator to provide the starting number for the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Prompt the human operator to provide the starting number for the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: human_input\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Please provide the starting number for the Hailstone sequence.: </pre>\n"
+      ],
+      "text/plain": [
+       "Please provide the starting number for the Hailstone sequence.: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "Please provide the starting number for the Hailstone sequence. 4\n"
+      " 8\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 8. I will now compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Use the next_number tool to compute the next number in the Hailstone sequence starting from 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Use the next_number tool to compute the next number in the Hailstone sequence starting from 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the argument x set to 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=8 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=8 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 4. Now I will compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 8 is 4. I will now use the next_number tool again to compute the subsequent number in t...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=4 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=4 to compute the next number in the Hailstone sequence.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 4 is 2. I will now compute the next number in the sequence using the next_number tool. ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 4 is 2. I will now use the next_number tool again to compute the subsequent number in t...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"f6a22a4c-7b6d-4f7d-91c5-4a8e0c419f5d\",\n",
+      "    \"id_\": \"4b8f9f3c-3f7e-4a8d-9b1a-5c0d2e6f7a1b\",\n",
       "    \"tool_name\": \"next_number\",\n",
-      "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the next_number tool starting from 2.\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequence....[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailstone s...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequen...[TRUNCATED]\n",
-      "The next number in the Hailstone sequence after 2 is 1. We have now reached the number 1, which is the stopping point for the sequence. The full Hailstone sequence starting from 4 is: 4, 2, 1.\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailston...[TRUNCATED]\n",
+      "The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailstone sequence starting from 8 is: 8, 4, 2, 1.\n"
      ]
     }
    ],
@@ -229,24 +249,192 @@
   {
    "cell_type": "markdown",
    "id": "baf1bd33",
-   "source": "### Example 2: End-of-Loop Approval Gate",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Example 2: End-of-Loop Approval Gate"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "7d13724c",
-   "source": "import logging\n\nfrom llm_agents_from_scratch import LLMAgent\nfrom llm_agents_from_scratch.data_structures import Task\nfrom llm_agents_from_scratch.logger import enable_console_logging\nfrom llm_agents_from_scratch.llms import OllamaLLM\nfrom llm_agents_from_scratch.tools import SimpleFunctionTool\n\nenable_console_logging(logging.INFO)\n\n\ndef next_number(x: int) -> int:\n    if x % 2 == 0:\n        return x // 2\n    return 3 * x + 1\n\n\nnext_number_tool = SimpleFunctionTool(func=next_number)\nllm = OllamaLLM(model=\"qwen3:14b\", think=False)\nagent = LLMAgent(llm=llm, tools=[next_number_tool])",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "\n",
+    "def next_number(x: int) -> int:\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "next_number_tool = SimpleFunctionTool(func=next_number)\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[next_number_tool])"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "e7a074f4",
-   "source": "task = Task(\n    instruction=(\n        \"Compute the full Hailstone sequence starting from 6, \"\n        \"step by step using next_number, until you reach 1.\"\n    )\n)\nresult = await agent.run(task, with_approval=True)\nprint(result.content)",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence starting from 6, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 6, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "# Stop At One\n",
+      "\n",
+      "Compute a full sequence from a starting number down to 1\n",
+      "using the `next_num...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 3\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 3. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The next step is to call the next_number tool with the current number 3.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The next step is to call the next_number tool with the current number 3.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 3.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the next_number tool with the current number 3.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the next_number tool with the current number 3.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 10\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 10. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"f52b84c4-d341-45e9-875b-e3bbcffa3e9e\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 5\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 5. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 16. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 8. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 4. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 2. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"d7b7419f-4e3a-453c-8f3d-53d75d10f86d\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"d7b7419f-4e3a-453c-8f3d-53d75d10f86d\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      " ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, startin...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> I received the result from the next_number tool: 1. This is the termination condition. I will now report the    <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> complete sequence, starting number, total steps taken, and the maximum value reached.                           <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
+       "\u001b[36m│\u001b[0m I received the result from the next_number tool: 1. This is the termination condition. I will now report the    \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m complete sequence, starting number, total steps taken, and the maximum value reached.                           \u001b[36m│\u001b[0m\n",
+       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Approve this result? <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[y/n]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "Approve this result? \u001b[1;35m[y/n]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, star...[TRUNCATED]\n",
+      "I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, starting number, total steps taken, and the maximum value reached.\n"
+     ]
+    }
+   ],
+   "source": [
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compute the full Hailstone sequence starting from 6, \"\n",
+    "        \"step by step using next_number, until you reach 1.\"\n",
+    "    )\n",
+    ")\n",
+    "result = await agent.run(task, with_approval=True)\n",
+    "print(result.content)"
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- Adds Example 2 to `examples/ch08.ipynb` demonstrating `with_approval=True` on `agent.run()`
- Uses the Hailstone sequence (starting from 6) consistent with Example 1
- Agent computes the sequence; approval gate fires before the result is accepted
- Human can reject with feedback, causing the agent to revise and resubmit; only the final approved result is returned

## Test plan

- [ ] Run notebook interactively: agent computes Hailstone sequence from 6, rich approval panel appears, approve/reject paths both work

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)