### PR TITLE
feat(ch08): introduce RejectedTaskResult and fix approval-gate rejection loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: introduce `RejectedTaskResult` data structure; `get_next_step` accepts `TaskStepResult | RejectedTaskResult | None` and dispatches by type — rejection routes deterministically to a new `TaskStep` without consulting the LLM; `_process_loop` captures raw `failed_result_content` + `feedback`; rejection template now includes `<proposed-result>` alongside `<human-correction>`; `HumanInputTool` styled with yellow `Panel` (#691)
 - refactor: adopt `rich.prompt.Prompt` in `HumanInputTool`; add optional `choices` parameter for constrained input (#689)
 - feat: implement end-of-loop human approval gate in `_process_loop` — adds `with_approval` param to `LLMAgent.run()`, `TaskHandler.request_approval()`, `TaskHandler._prompt_for_approval()`, `ApprovalResult` data structure, three approval template keys, and `rich>=13.9.0` dependency (#688)
 - feat: implement HumanInputTool (#685)

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -180,10 +180,27 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Please provide the starting number for the Hailstone sequence.: </pre>\n"
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭────────────────────────────────────────────────── Human Input ──────────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide the starting number for the Hailstone sequence.                                                  <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
       ],
       "text/plain": [
-       "Please provide the starting number for the Hailstone sequence.: "
+       "\u001b[33m╭─\u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m Please provide the starting number for the Hailstone sequence.                                                  \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt;: </pre>\n"
+      ],
+      "text/plain": [
+       ">: "
       ]
      },
      "metadata": {},
@@ -193,44 +210,23 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      " 8\n"
+      " 2\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 8. I will now compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Use the next_number tool to compute the next number in the Hailstone sequence starting from 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Use the next_number tool to compute the next number in the Hailstone sequence starting from 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the argument x set to 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=8 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=8 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 8 is 4. I will now use the next_number tool again to compute the subsequent number in t...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=4 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=4 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 4 is 2. I will now use the next_number tool again to compute the subsequent number in t...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
-      "\n",
-      "{\n",
-      "    \"id_\": \"4b8f9f3c-3f7e-4a8d-9b1a-5c0d2e6f7a1b\",\n",
-      "    \"tool_name\": \"next_number\",\n",
-      "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=2 to compute the next number in the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 2. I will now compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailstone s...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, 1].\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailston...[TRUNCATED]\n",
-      "The next number in the Hailstone sequence after 2 is 1. The sequence has now reached the value 1, so we stop here. The full Hailstone sequence starting from 8 is: 8, 4, 2, 1.\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, ...[TRUNCATED]\n",
+      "The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, 1].\n"
      ]
     }
    ],
@@ -293,88 +289,94 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence starting from 6, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 6, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 6.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 6.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 6.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
       "using the `next_num...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 6.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 6.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 6.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 5.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 3\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 3. I will append this to the sequence and continue the process.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The next step is to call the next_number tool with the current number 3.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The next step is to call the next_number tool with the current number 3.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 3.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the next_number tool with the current number 3.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the next_number tool with the current number 3.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 10\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 10. I will append this to the sequence and continue the process.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 5 is 16. I will continue the process by calling the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 16.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"f52b84c4-d341-45e9-875b-e3bbcffa3e9e\",\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 10.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 5\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 5. I will append this to the sequence and continue the process.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 16. I will append this to the sequence and continue the process.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 16.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 16.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 8. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 16 is 8. I will continue the process by calling the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 4. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 8 is 4. I will continue the process by calling the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 2. I will append this to the sequence and continue the process.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 4 is 2. I will continue the process by calling the next_number tool with the current number 2.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"d7b7419f-4e3a-453c-8f3d-53d75d10f86d\",\n",
+      "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
-      "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to make the following tool call(s):\n",
-      "\n",
-      "{\n",
-      "    \"id_\": \"d7b7419f-4e3a-453c-8f3d-53d75d10f86d\",\n",
-      "    \"tool_name\": \"next_number\",\n",
-      " ...[TRUNCATED]\n",
+      "    \"a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n",
       "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
       "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, startin...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me summarize the full Hailstone...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
      ]
     },
@@ -382,15 +384,108 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> I received the result from the next_number tool: 1. This is the termination condition. I will now report the    <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> complete sequence, starting number, total steps taken, and the maximum value reached.                           <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> summarize the full Hailstone sequence starting from 5:                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
        "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m I received the result from the next_number tool: 1. This is the termination condition. I will now report the    \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m complete sequence, starting number, total steps taken, and the maximum value reached.                           \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m summarize the full Hailstone sequence starting from 5:                                                          \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Starting number:** 5                                                                                          \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m│\u001b[0m\n",
+       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Approve this result? <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[y/n]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "Approve this result? \u001b[1;35m[y/n]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " n\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provide your correction rationale for the agent to address: </pre>\n"
+      ],
+      "text/plain": [
+       "Provide your correction rationale for the agent to address: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " Everything looks good, but just omit the first sentence in your response.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🔁 Task result rejected; re-entering loop with feedback.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step (rejection): Everything looks good, but just omit the first sentence in your response.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The human operator REJECTED your proposed task result. Revise your approach and try again.\n",
+      "\n",
+      "<proposed-result>\n",
+      "The next number in t...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Let me summarize the full Hailstone sequence starting from 5:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Starting number:** 5  \n",
+      "**Total ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Let me summarize the full Hailstone sequence starting from 5:                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Let me summarize the full Hailstone sequence starting from 5:                                                   \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Starting number:** 5                                                                                          \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m│\u001b[0m\n",
        "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
       ]
      },
@@ -420,15 +515,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, star...[TRUNCATED]\n",
-      "I received the result from the next_number tool: 1. This is the termination condition. I will now report the complete sequence, starting number, total steps taken, and the maximum value reached.\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Let me summarize the full Hailstone sequence starting from 5:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Starting number:** 5  \n",
+      "**Tot...[TRUNCATED]\n",
+      "Let me summarize the full Hailstone sequence starting from 5:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Starting number:** 5  \n",
+      "**Total steps taken:** 5  \n",
+      "**Maximum value reached:** 16\n"
      ]
     }
    ],
    "source": [
     "task = Task(\n",
     "    instruction=(\n",
-    "        \"Compute the full Hailstone sequence starting from 6, \"\n",
+    "        \"Compute the full Hailstone sequence starting from 5, \"\n",
     "        \"step by step using next_number, until you reach 1.\"\n",
     "    )\n",
     ")\n",

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -1,7 +1,6 @@
 """Agent Module."""
 
 import asyncio
-import uuid
 from typing import Any
 
 from rich.console import Console
@@ -16,6 +15,7 @@ from llm_agents_from_scratch.data_structures import (
     ChatMessage,
     ChatRole,
     NextStepDecision,
+    RejectedTaskResult,
     Task,
     TaskResult,
     TaskStep,
@@ -282,18 +282,36 @@ class LLMAgent:
 
         async def get_next_step(
             self,
-            previous_step_result: TaskStepResult | None,
+            previous_step_result: (
+                TaskStepResult
+                | RejectedTaskResult  # added in ch08
+                | None
+            ),
         ) -> TaskStep | TaskResult:
             """Based on previous step result, get next step or conclude task.
 
             Returns:
-                TaskStep | TaskResult: Either the next step or the result of the
-                    task.
+                TaskStep | TaskResult: Either the next step or the result of
+                    the task.
             """
             if not previous_step_result:
                 return TaskStep(
                     task_id=self.task.id_,
                     instruction=self.task.instruction,
+                )
+            # added in ch08: rejection bypasses LLM routing
+            if isinstance(previous_step_result, RejectedTaskResult):
+                self.logger.info(
+                    f"🧠 New Step (rejection): {previous_step_result.feedback}",
+                )
+                return TaskStep(
+                    task_id=self.task.id_,
+                    instruction=self.llm_agent.templates[
+                        "approval_rejection_feedback"
+                    ].format(
+                        content=previous_step_result.failed_result_content,
+                        feedback=previous_step_result.feedback,
+                    ),
                 )
             self.logger.debug(f"🧵 Rollout: {self.rollout}")
 
@@ -715,15 +733,9 @@ class LLMAgent:
                                     next_step,
                                 )
                                 if not approval.approved:
-                                    step_result = TaskStepResult(
-                                        task_step_id=str(
-                                            uuid.uuid4(),
-                                        ),
-                                        content=self.templates[
-                                            "approval_rejection_feedback"
-                                        ].format(
-                                            feedback=approval.feedback,
-                                        ),
+                                    step_result = RejectedTaskResult(
+                                        failed_result_content=next_step.content,
+                                        feedback=approval.feedback,
                                     )
                                     self.logger.info(
                                         "🔁 Task result rejected; "
@@ -751,6 +763,8 @@ class LLMAgent:
         skill_name: str,
         prompt: str | None = None,
         max_steps: int | None = None,
+        # added in ch08
+        with_approval: bool = False,
     ) -> TaskHandler:
         """User-explicit skill activation: the programmatic slash command.
 
@@ -768,6 +782,8 @@ class LLMAgent:
                 skill activation. Defaults to None.
             max_steps (int | None): Maximum number of steps to run.
                 Defaults to None.
+            with_approval (bool): Passed through to ``run()``. Added in
+                Chapter 8.
 
         Returns:
             TaskHandler: The handler responsible for task execution.
@@ -783,4 +799,9 @@ class LLMAgent:
             )
         task = Task(instruction=instruction)
 
-        return self.run(task=task, max_steps=max_steps)
+        return self.run(
+            task=task,
+            max_steps=max_steps,
+            # added in ch08
+            with_approval=with_approval,
+        )

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -102,11 +102,15 @@ result directly unless instructed otherwise.
 DEFAULT_APPROVAL_PROMPT = "Approve this result?"
 
 DEFAULT_APPROVAL_RATIONALE_PROMPT = (
-    "Provide your correction rationale for the agent to address:"
+    "Provide your correction rationale for the agent to address"
 )
 
 DEFAULT_APPROVAL_REJECTION_FEEDBACK = """The human operator REJECTED your \
 proposed task result. Revise your approach and try again.
+
+<proposed-result>
+{content}
+</proposed-result>
 
 <human-correction>
 {feedback}

--- a/src/llm_agents_from_scratch/data_structures/__init__.py
+++ b/src/llm_agents_from_scratch/data_structures/__init__.py
@@ -1,6 +1,7 @@
 from .agent import (
     ApprovalResult,
     NextStepDecision,
+    RejectedTaskResult,
     Task,
     TaskResult,
     TaskStep,
@@ -15,6 +16,7 @@ __all__ = [
     # agent
     "ApprovalResult",
     "NextStepDecision",
+    "RejectedTaskResult",
     "Task",
     "TaskResult",
     "TaskStep",

--- a/src/llm_agents_from_scratch/data_structures/agent.py
+++ b/src/llm_agents_from_scratch/data_structures/agent.py
@@ -103,10 +103,6 @@ class RejectedTaskResult(BaseModel):
     failed_result_content: str
     feedback: str
 
-    def __str__(self) -> str:
-        """String representation of RejectedTaskResult."""
-        return self.feedback
-
 
 class ApprovalResult(BaseModel):
     """The outcome of the end-of-loop human approval gate.

--- a/src/llm_agents_from_scratch/data_structures/agent.py
+++ b/src/llm_agents_from_scratch/data_structures/agent.py
@@ -87,6 +87,27 @@ class NextStepDecision(BaseModel):
     )
 
 
+class RejectedTaskResult(BaseModel):
+    """Human rejection feedback from the approval gate.
+
+    Added in Chapter 8. Returned by ``_process_loop`` when the operator
+    rejects a proposed ``TaskResult``; passed to ``get_next_step`` so it
+    can route deterministically to a new ``TaskStep`` without consulting
+    the LLM.
+
+    Attributes:
+        failed_result_content: Content of the rejected ``TaskResult``.
+        feedback: The operator's raw correction rationale.
+    """
+
+    failed_result_content: str
+    feedback: str
+
+    def __str__(self) -> str:
+        """String representation of RejectedTaskResult."""
+        return self.feedback
+
+
 class ApprovalResult(BaseModel):
     """The outcome of the end-of-loop human approval gate.
 

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from rich.console import Console
+from rich.panel import Panel
 from rich.prompt import Prompt
 
 from ...base.tool import BaseTool
@@ -80,10 +82,14 @@ class HumanInputTool(BaseTool):
         prompt = tool_call.arguments.get("prompt", "")
         choices = tool_call.arguments.get("choices")
         try:
+            console = Console()
+            console.print(
+                Panel(prompt, title="Human Input", border_style="yellow"),
+            )
             if choices:
-                response = Prompt.ask(prompt, choices=choices)
+                response = Prompt.ask(">", choices=choices, console=console)
             else:
-                response = Prompt.ask(prompt)
+                response = Prompt.ask(">", console=console)
         except EOFError:
             return ToolCallResult(
                 tool_call_id=tool_call.id_,

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -5,12 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from llm_agents_from_scratch.agent import LLMAgent
-from llm_agents_from_scratch.agent.templates import default_templates
 from llm_agents_from_scratch.base.llm import BaseLLM
 from llm_agents_from_scratch.base.tool import BaseTool
 from llm_agents_from_scratch.data_structures import (
     ApprovalResult,
     Episode,
+    RejectedTaskResult,
 )
 from llm_agents_from_scratch.data_structures.agent import (
     Task,
@@ -374,13 +374,12 @@ async def test_run_approval_gate_rejection_feedback_is_template_wrapped(
     handler = agent.run(task, with_approval=True)
     await handler
 
-    # second get_next_step call receives the template-wrapped feedback
+    # second get_next_step call receives a RejectedTaskResult
     second_call_args = mock_get_next_step.await_args_list[1]
     step_result = second_call_args.args[0]
-    expected_feedback = default_templates["approval_rejection_feedback"].format(
-        feedback="fix the math",
-    )
-    assert step_result.content == expected_feedback
+    assert isinstance(step_result, RejectedTaskResult)
+    assert step_result.failed_result_content == "wrong answer"
+    assert step_result.feedback == "fix the math"
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -12,6 +12,7 @@ from llm_agents_from_scratch.data_structures import (
     ChatMessage,
     ChatRole,
     NextStepDecision,
+    RejectedTaskResult,
     Task,
     TaskResult,
     TaskStep,
@@ -146,6 +147,31 @@ async def test_get_next_step(mock_llm: BaseLLM) -> None:
     assert initial_step.instruction == "mock instruction"
     assert isinstance(next_step, TaskStep)
     assert next_step.instruction == expected_next_step.content
+
+
+@pytest.mark.asyncio
+async def test_get_next_step_routes_rejected_task_result_without_llm(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests get_next_step returns TaskStep directly for RejectedTaskResult."""
+    task = Task(instruction="mock instruction")
+    handler = LLMAgent.TaskHandler(
+        llm_agent=LLMAgent(llm=mock_llm),
+        task=task,
+    )
+
+    rejected = RejectedTaskResult(
+        failed_result_content="wrong answer",
+        feedback="fix the math",
+    )
+    next_step = await handler.get_next_step(previous_step_result=rejected)
+
+    assert isinstance(next_step, TaskStep)
+    expected = default_templates["approval_rejection_feedback"].format(
+        content="wrong answer",
+        feedback="fix the math",
+    )
+    assert next_step.instruction == expected
 
 
 @pytest.mark.asyncio

--- a/tests/data_structures/test_agent.py
+++ b/tests/data_structures/test_agent.py
@@ -1,10 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from llm_agents_from_scratch.data_structures import Task, TaskStep
-from llm_agents_from_scratch.data_structures.agent import (
-    ApprovalResult,
-    RejectedTaskResult,
-)
+from llm_agents_from_scratch.data_structures.agent import ApprovalResult
 
 
 @patch("llm_agents_from_scratch.data_structures.agent.uuid")
@@ -31,15 +28,6 @@ def test_string_representation_task_step(mock_uuid: MagicMock) -> None:
     assert str(task_step) == "a fake instruction"
     assert task_step.task_id == "000"
     assert task_step.id_ == "111"
-
-
-def test_rejected_task_result_str() -> None:
-    """Tests RejectedTaskResult.__str__ returns feedback."""
-    result = RejectedTaskResult(
-        failed_result_content="wrong answer",
-        feedback="fix the math",
-    )
-    assert str(result) == "fix the math"
 
 
 def test_approval_result_str_approved() -> None:

--- a/tests/data_structures/test_agent.py
+++ b/tests/data_structures/test_agent.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from llm_agents_from_scratch.data_structures import Task, TaskStep
-from llm_agents_from_scratch.data_structures.agent import ApprovalResult
+from llm_agents_from_scratch.data_structures.agent import (
+    ApprovalResult,
+    RejectedTaskResult,
+)
 
 
 @patch("llm_agents_from_scratch.data_structures.agent.uuid")
@@ -28,6 +31,15 @@ def test_string_representation_task_step(mock_uuid: MagicMock) -> None:
     assert str(task_step) == "a fake instruction"
     assert task_step.task_id == "000"
     assert task_step.id_ == "111"
+
+
+def test_rejected_task_result_str() -> None:
+    """Tests RejectedTaskResult.__str__ returns feedback."""
+    result = RejectedTaskResult(
+        failed_result_content="wrong answer",
+        feedback="fix the math",
+    )
+    assert str(result) == "fix the math"
 
 
 def test_approval_result_str_approved() -> None:

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -305,17 +305,23 @@ def test_human_input_tool_returns_response() -> None:
 
 
 def test_human_input_tool_passes_prompt_to_input() -> None:
-    """Tests HumanInputTool passes the prompt argument to Prompt.ask."""
+    """Tests HumanInputTool renders the prompt in a Panel and uses > inline."""
     tool = HumanInputTool()
     tool_call = ToolCall(
         tool_name="human_input",
         arguments={"prompt": "How old are you?"},
     )
 
-    with patch("rich.prompt.Prompt.ask", return_value="30") as mock_ask:
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Prompt.ask", return_value="30") as mock_ask,
+    ):
         tool(tool_call=tool_call)
 
-    mock_ask.assert_called_once_with("How old are you?")
+    mock_ask.assert_called_once_with(
+        ">",
+        console=mock_ask.call_args.kwargs["console"],
+    )
 
 
 def test_human_input_tool_missing_prompt_defaults_to_empty() -> None:
@@ -326,10 +332,16 @@ def test_human_input_tool_missing_prompt_defaults_to_empty() -> None:
         arguments={},
     )
 
-    with patch("rich.prompt.Prompt.ask", return_value="ok") as mock_ask:
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Prompt.ask", return_value="ok") as mock_ask,
+    ):
         tool(tool_call=tool_call)
 
-    mock_ask.assert_called_once_with("")
+    mock_ask.assert_called_once_with(
+        ">",
+        console=mock_ask.call_args.kwargs["console"],
+    )
 
 
 def test_human_input_tool_choices_passed_to_prompt() -> None:
@@ -340,10 +352,17 @@ def test_human_input_tool_choices_passed_to_prompt() -> None:
         arguments={"prompt": "Pick one:", "choices": ["yes", "no"]},
     )
 
-    with patch("rich.prompt.Prompt.ask", return_value="yes") as mock_ask:
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Prompt.ask", return_value="yes") as mock_ask,
+    ):
         result = tool(tool_call=tool_call)
 
-    mock_ask.assert_called_once_with("Pick one:", choices=["yes", "no"])
+    mock_ask.assert_called_once_with(
+        ">",
+        choices=["yes", "no"],
+        console=mock_ask.call_args.kwargs["console"],
+    )
     assert result.error is False
     assert result.content == "yes"
 


### PR DESCRIPTION
## Summary

- Introduces `RejectedTaskResult` data structure (union member alongside `TaskStepResult`) so `get_next_step` can dispatch by type rather than inspecting sentinel fields
- `_process_loop` captures raw rejection data (`failed_result_content` + `feedback`); `get_next_step` owns the template rendering when building the re-entry `TaskStep`
- Rejection template now includes the failed result content (`<proposed-result>`) alongside the human correction (`<human-correction>`), giving the LLM full context to revise
- `HumanInputTool` styled with yellow Panel to visually distinguish it from the cyan approval-gate Panel
- Example 2 notebook re-executed capturing the full rejection→revision→approval flow

## Test plan

- [ ] `pytest tests/ -v` — 349 tests, 100% coverage
- [ ] `make lint` passes
- [ ] Example 2 notebook output shows: agent computes Hailstone 5→16→8→4→2→1, operator rejects with feedback, `🧠 New Step (rejection):` log confirms raw feedback routing, agent revises, operator approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)