### PR TITLE
feat(ch08): add run_supervised() and SupervisedTaskHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: add `LLMAgent.run_supervised()` and `LLMAgent.SupervisedTaskHandler` — human-driven stepwise execution; caller controls cadence via `get_next_step()` / `run_step()` and finalises with `complete()`, `reject()`, or `abort()` (#693)
 - feat: introduce `RejectedTaskResult` data structure; `get_next_step` accepts `TaskStepResult | RejectedTaskResult | None` and dispatches by type — rejection routes deterministically to a new `TaskStep` without consulting the LLM; `_process_loop` captures raw `failed_result_content` + `feedback`; rejection template now includes `<proposed-result>` alongside `<human-correction>`; `HumanInputTool` styled with yellow `Panel` (#691)
 - refactor: adopt `rich.prompt.Prompt` in `HumanInputTool`; add optional `choices` parameter for constrained input (#689)
 - feat: implement end-of-loop human approval gate in `_process_loop` — adds `with_approval` param to `LLMAgent.run()`, `TaskHandler.request_approval()`, `TaskHandler._prompt_for_approval()`, `ApprovalResult` data structure, three approval template keys, and `rich>=13.9.0` dependency (#688)

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -660,6 +660,60 @@ class LLMAgent:
                     feedback="Interrupted by operator.",
                 )
 
+    class SupervisedTaskHandler(TaskHandler):
+        """TaskHandler for human-driven stepwise execution.
+
+        Added in Chapter 8. Returned by ``run_supervised()``; the caller
+        drives the loop manually via ``get_next_step()`` and ``run_step()``
+        and finalises execution with ``complete()`` or ``abort()``.
+        """
+
+        async def complete(self, result: TaskResult) -> None:
+            """Accept the final result and resolve the handler.
+
+            Added in Chapter 8.
+
+            Args:
+                result: The ``TaskResult`` to accept.
+            """
+            await self.record_memory(result=result)
+            self.set_result(result)
+
+        def reject(
+            self,
+            result: TaskResult,
+            feedback: str,
+        ) -> RejectedTaskResult:
+            """Reject a proposed TaskResult and return feedback for re-routing.
+
+            Added in Chapter 8.
+
+            Args:
+                result: The ``TaskResult`` to reject.
+                feedback: Correction rationale passed back to the agent.
+
+            Returns:
+                RejectedTaskResult: Pass to ``get_next_step()`` to
+                    re-enter the loop without consulting the LLM.
+            """
+            return RejectedTaskResult(
+                failed_result_content=result.content,
+                feedback=feedback,
+            )
+
+        async def abort(self, error: Exception | None = None) -> None:
+            """Abort the supervised task and resolve the handler.
+
+            Added in Chapter 8.
+
+            Args:
+                error: Exception to set. Defaults to
+                    ``TaskHandlerError("Task aborted.")``.
+            """
+            err = error or TaskHandlerError("Task aborted.")
+            await self.record_memory(error=err)
+            self.set_exception(err)
+
     def run(
         self,
         task: Task,
@@ -805,3 +859,42 @@ class LLMAgent:
             # added in ch08
             with_approval=with_approval,
         )
+
+    async def run_supervised(
+        self,
+        task: Task,
+        # added in ch08
+        skills_scopes: list[SkillScope] | None = None,
+        explicit_only_skills: set[str] | None = None,
+    ) -> SupervisedTaskHandler:
+        """Human-driven stepwise task execution.
+
+        Added in Chapter 8. Creates and returns a
+        ``SupervisedTaskHandler`` with memories loaded, without starting
+        the autonomous ``_process_loop``. The caller drives execution
+        cell-by-cell via ``get_next_step()`` and ``run_step()``, then
+        finalises with ``complete()`` or ``abort()``.
+
+        Contrasts with ``run()``: supervised = human controls cadence;
+        autonomous = agent runs to completion.
+
+        Args:
+            task: The task to perform.
+            skills_scopes (list[SkillScope] | None): Scopes to scan for
+                skills. Defaults to ``[USER, PROJECT]``. Added in
+                Chapter 6.
+            explicit_only_skills (set[str] | None): Skill names to
+                exclude from the model catalog. Defaults to None.
+                Added in Chapter 6.
+
+        Returns:
+            SupervisedTaskHandler: Ready for stepwise execution.
+        """
+        task_handler = self.SupervisedTaskHandler(
+            llm_agent=self,
+            task=task,
+            skills_scopes=skills_scopes,
+            explicit_only_skills=explicit_only_skills,
+        )
+        await task_handler.load_memories()
+        return task_handler

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -663,9 +663,13 @@ class LLMAgent:
     class SupervisedTaskHandler(TaskHandler):
         """TaskHandler for human-driven stepwise execution.
 
-        Added in Chapter 8. Returned by ``run_supervised()``; the caller
-        drives the loop manually via ``get_next_step()`` and ``run_step()``
-        and finalises execution with ``complete()`` or ``abort()``.
+        Added in Chapter 8. Caller-driven human-in-the-loop pattern;
+        unlike ``HumanInputTool`` (agent-initiated) and
+        ``request_approval`` (operator-gated at result time), the human
+        controls the entire execution cadence. Returned by
+        ``run_supervised()``; the caller drives the loop manually via
+        ``get_next_step()`` and ``run_step()`` and finalises execution
+        with ``complete()`` or ``abort()``.
         """
 
         @property

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -668,6 +668,24 @@ class LLMAgent:
         and finalises execution with ``complete()`` or ``abort()``.
         """
 
+        @property
+        def background_task(self) -> asyncio.Task:
+            """Not available in supervised mode."""
+            raise TaskHandlerError(
+                "SupervisedTaskHandler has no background task — "
+                "execution is caller-driven via get_next_step() "
+                "and run_step().",
+            )
+
+        @background_task.setter
+        def background_task(self, asyncio_task: asyncio.Task) -> None:
+            """Not available in supervised mode."""
+            raise TaskHandlerError(
+                "SupervisedTaskHandler has no background task — "
+                "execution is caller-driven via get_next_step() "
+                "and run_step().",
+            )
+
         async def complete(self, result: TaskResult) -> None:
             """Accept the final result and resolve the handler.
 

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -863,7 +863,6 @@ class LLMAgent:
     async def run_supervised(
         self,
         task: Task,
-        # added in ch08
         skills_scopes: list[SkillScope] | None = None,
         explicit_only_skills: set[str] | None = None,
     ) -> SupervisedTaskHandler:
@@ -881,11 +880,9 @@ class LLMAgent:
         Args:
             task: The task to perform.
             skills_scopes (list[SkillScope] | None): Scopes to scan for
-                skills. Defaults to ``[USER, PROJECT]``. Added in
-                Chapter 6.
+                skills. Defaults to ``[USER, PROJECT]``.
             explicit_only_skills (set[str] | None): Skill names to
                 exclude from the model catalog. Defaults to None.
-                Added in Chapter 6.
 
         Returns:
             SupervisedTaskHandler: Ready for stepwise execution.

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1027,6 +1027,18 @@ def test_prompt_for_approval_uses_approval_template_text() -> None:
 
 
 @pytest.mark.asyncio
+async def test_supervised_handler_background_task_raises(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests background_task raises TaskHandlerError in supervised mode."""
+    agent = LLMAgent(llm=mock_llm)
+    handler = await agent.run_supervised(Task(instruction="mock instruction"))
+
+    with pytest.raises(TaskHandlerError, match="caller-driven"):
+        handler.background_task  # noqa: B018
+
+
+@pytest.mark.asyncio
 async def test_run_supervised_returns_supervised_task_handler(
     mock_llm: BaseLLM,
 ) -> None:

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1019,3 +1019,114 @@ def test_prompt_for_approval_uses_approval_template_text() -> None:
 
     mock_confirm.assert_called_once()
     assert mock_confirm.call_args.args[0] == "my question"
+
+
+# ---------------------------------------------------------------------------
+# SupervisedTaskHandler tests (Chapter 8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_supervised_returns_supervised_task_handler(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests run_supervised returns a SupervisedTaskHandler."""
+    agent = LLMAgent(llm=mock_llm)
+    task = Task(instruction="mock instruction")
+
+    handler = await agent.run_supervised(task)
+
+    assert isinstance(handler, LLMAgent.SupervisedTaskHandler)
+
+
+@pytest.mark.asyncio
+async def test_run_supervised_loads_memories(mock_llm: BaseLLM) -> None:
+    """Tests run_supervised calls load_memories before returning."""
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.return_value = "episode context"
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+    task = Task(instruction="mock instruction")
+
+    await agent.run_supervised(task)
+
+    mock_memory.recall.assert_awaited_once_with(task)
+
+
+@pytest.mark.asyncio
+async def test_run_supervised_does_not_start_background_task(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests run_supervised does not set a background asyncio task."""
+    agent = LLMAgent(llm=mock_llm)
+    task = Task(instruction="mock instruction")
+
+    handler = await agent.run_supervised(task)
+
+    assert handler._background_task is None
+
+
+@pytest.mark.asyncio
+async def test_supervised_handler_complete_sets_result_and_records_memory(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests complete() records memory then resolves the handler."""
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.return_value = ""
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+    task = Task(instruction="mock instruction")
+    handler = await agent.run_supervised(task)
+    result = TaskResult(task_id=task.id_, content="done")
+
+    await handler.complete(result)
+
+    assert handler.result() == result
+    mock_memory.record.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_supervised_handler_abort_sets_exception_and_records_memory(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests abort() records memory then sets exception on the handler."""
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.return_value = ""
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+    task = Task(instruction="mock instruction")
+    handler = await agent.run_supervised(task)
+
+    await handler.abort()
+
+    assert isinstance(handler.exception(), TaskHandlerError)
+    mock_memory.record.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_supervised_handler_abort_with_custom_error(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests abort() sets the provided exception on the handler."""
+    agent = LLMAgent(llm=mock_llm)
+    task = Task(instruction="mock instruction")
+    handler = await agent.run_supervised(task)
+    err = RuntimeError("operator stopped")
+
+    await handler.abort(error=err)
+
+    assert handler.exception() is err
+
+
+@pytest.mark.asyncio
+async def test_supervised_handler_reject_returns_rejected_task_result(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests reject() constructs a RejectedTaskResult from a TaskResult."""
+    agent = LLMAgent(llm=mock_llm)
+    task = Task(instruction="mock instruction")
+    handler = await agent.run_supervised(task)
+    result = TaskResult(task_id=task.id_, content="wrong answer")
+
+    rejected = handler.reject(result, feedback="fix the math")
+
+    assert isinstance(rejected, RejectedTaskResult)
+    assert rejected.failed_result_content == "wrong answer"
+    assert rejected.feedback == "fix the math"

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1039,6 +1039,18 @@ async def test_supervised_handler_background_task_raises(
 
 
 @pytest.mark.asyncio
+async def test_supervised_handler_background_task_setter_raises(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests background_task setter raises TaskHandlerError."""
+    agent = LLMAgent(llm=mock_llm)
+    handler = await agent.run_supervised(Task(instruction="mock instruction"))
+
+    with pytest.raises(TaskHandlerError, match="caller-driven"):
+        handler.background_task = MagicMock()  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
 async def test_run_supervised_returns_supervised_task_handler(
     mock_llm: BaseLLM,
 ) -> None:


### PR DESCRIPTION
Closes #678

## Summary

- `LLMAgent.SupervisedTaskHandler` — nested subclass of `TaskHandler`; adds `complete()`, `reject()`, and `abort()` for caller-controlled loop resolution
- `LLMAgent.run_supervised()` — async method that creates and returns a `SupervisedTaskHandler` with memories loaded, without starting `_process_loop`; caller drives execution cell-by-cell via `get_next_step()` and `run_step()`
- Introduces a third HITL pattern: supervised = human controls cadence, contrasting with `HumanInputTool` (agent-initiated) and `request_approval` (operator-gated end-of-loop)

## Typical trajectories

**Clean run:** `get_next_step` → `run_step` → ... → `TaskResult` → `handler.complete(result)`

**With rejection:** ... → `TaskResult` → `handler.reject(result, feedback)` → `get_next_step(rejected)` → `run_step` → ... → `handler.complete(result)`

**Abort:** `handler.abort()` or `handler.abort(error=some_exception)`

## Test plan

- [ ] `pytest tests/ -v` — 355 tests, 100% coverage
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)