### PR TITLE
feat(ch08): add Example 3 — caller-driven stepwise execution with run_supervised()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: `SupervisedTaskHandler.complete()` raises `TaskHandlerError` at runtime when passed a non-`TaskResult` argument (#694)
 - feat: add `LLMAgent.run_supervised()` and `LLMAgent.SupervisedTaskHandler` — human-driven stepwise execution; caller controls cadence via `get_next_step()` / `run_step()` and finalises with `complete()`, `reject()`, or `abort()` (#693)
 - feat: introduce `RejectedTaskResult` data structure; `get_next_step` accepts `TaskStepResult | RejectedTaskResult | None` and dispatches by type — rejection routes deterministically to a new `TaskStep` without consulting the LLM; `_process_loop` captures raw `failed_result_content` + `feedback`; rejection template now includes `<proposed-result>` alongside `<human-correction>`; `HumanInputTool` styled with yellow `Panel` (#691)
 - refactor: adopt `rich.prompt.Prompt` in `HumanInputTool`; add optional `choices` parameter for constrained input (#689)

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ from core concepts to full multi-agent systems:
 | 5 | MCP Tools | [Ch 5](notebooks/ch05.ipynb) |
 | 6 | Skills | [Ch 6](notebooks/ch06.ipynb) |
 | 7 | Memory | [Ch 7](notebooks/ch07.ipynb) |
-| 8 | Human in the Loop | — |
+| 8 | Human in the Loop | [Ch 8](notebooks/ch08.ipynb) |
 
 ### Part 3 — Building Multi-Agent Systems
 

--- a/docs/notebooks/ch08.ipynb
+++ b/docs/notebooks/ch08.ipynb
@@ -1,0 +1,1 @@
+../../examples/ch08.ipynb

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -5,7 +5,7 @@
    "id": "a1b2c3d4-0008-0000-0000-000000000001",
    "metadata": {},
    "source": [
-    "# Chapter 8 — Human in the Loop"
+    "# Chapter 8 \u2014 Human in the Loop"
    ]
   },
   {
@@ -55,7 +55,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Ollama already running at http://localhost:11434\n"
+      "\u2713 Ollama already running at http://localhost:11434\n"
      ]
     }
    ],
@@ -74,7 +74,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -103,7 +103,7 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
@@ -169,26 +169,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask them ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask th...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: human_input\n"
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator \u2014 ask them ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator \u2014 ask th...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: human_input\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭────────────────────────────────────────────────── Human Input ──────────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide the starting number for the Hailstone sequence.                                                  <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> Please provide the starting number for the Hailstone sequence.                                                  <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m Please provide the starting number for the Hailstone sequence.                                                  \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
+       "\u001b[33m\u2502\u001b[0m Please provide the starting number for the Hailstone sequence.                                                  \u001b[33m\u2502\u001b[0m\n",
+       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -217,15 +217,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I have received the starting number, which is 2. I will now compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, 1].\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I have received the starting number, which is 2. I will now compute the Hailstone sequence step by step using the next_number tool unti...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the next number in the Hailstone sequence using the starting number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, 1].\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, ...[TRUNCATED]\n",
       "The next number in the Hailstone sequence after 2 is 1. Since we have reached 1, the sequence is complete. The full sequence is [2, 1].\n"
      ]
     }
@@ -234,7 +234,7 @@
     "task = Task(\n",
     "    instruction=(\n",
     "        \"Compute the full Hailstone sequence step by step using next_number. \"\n",
-    "        \"The starting number must come from the human operator — ask them \"\n",
+    "        \"The starting number must come from the human operator \u2014 ask them \"\n",
     "        \"before beginning.\"\n",
     "    )\n",
     ")\n",
@@ -289,121 +289,121 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: \n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
       "using the `next_num...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 5.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 5 is 16. I will continue the process by calling the next_number tool with the current number 16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the next_number tool with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the starting number 5.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 5 is 16. I will continue the process by calling the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 16 is 8. I will continue the process by calling the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 16 is 8. I will continue the process by calling the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 8 is 4. I will continue the process by calling the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 8 is 4. I will continue the process by calling the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 4 is 2. I will continue the process by calling the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 4 is 2. I will continue the process by calling the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"12345678-90ab-cdef-1234-567890abcdef\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me summarize the full Hailstone...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me summarize the full Hailstone...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> summarize the full Hailstone sequence starting from 5:                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Proposed Task Result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> summarize the full Hailstone sequence starting from 5:                                                          <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m summarize the full Hailstone sequence starting from 5:                                                          \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Starting number:** 5                                                                                          \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[36m\u256d\u2500\u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m\u2500\u256e\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m The next number in the sequence after 2 is 1. Now that we have reached 1, the sequence is complete. Let me      \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m summarize the full Hailstone sequence starting from 5:                                                          \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Starting number:** 5                                                                                          \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -451,15 +451,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🔁 Task result rejected; re-entering loop with feedback.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step (rejection): Everything looks good, but just omit the first sentence in your response.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The human operator REJECTED your proposed task result. Revise your approach and try again.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\udd01 Task result rejected; re-entering loop with feedback.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step (rejection): Everything looks good, but just omit the first sentence in your response.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: The human operator REJECTED your proposed task result. Revise your approach and try again.\n",
       "\n",
       "<proposed-result>\n",
       "The next number in t...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Let me summarize the full Hailstone sequence starting from 5:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Let me summarize the full Hailstone sequence starting from 5:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  \n",
       "**Starting number:** 5  \n",
       "**Total ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
@@ -468,25 +468,25 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Let me summarize the full Hailstone sequence starting from 5:                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Proposed Task Result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> Let me summarize the full Hailstone sequence starting from 5:                                                   <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Starting number:** 5                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Total steps taken:** 5                                                                                        <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Maximum value reached:** 16                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Let me summarize the full Hailstone sequence starting from 5:                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Sequence:** 5 → 16 → 8 → 4 → 2 → 1                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Starting number:** 5                                                                                          \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[36m\u256d\u2500\u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m\u2500\u256e\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m Let me summarize the full Hailstone sequence starting from 5:                                                   \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Starting number:** 5                                                                                          \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Total steps taken:** 5                                                                                        \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Maximum value reached:** 16                                                                                   \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -515,14 +515,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Let me summarize the full Hailstone sequence starting from 5:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Let me summarize the full Hailstone sequence starting from 5:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  \n",
       "**Starting number:** 5  \n",
       "**Tot...[TRUNCATED]\n",
       "Let me summarize the full Hailstone sequence starting from 5:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  \n",
       "**Starting number:** 5  \n",
       "**Total steps taken:** 5  \n",
       "**Maximum value reached:** 16\n"
@@ -541,9 +541,285 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000010",
+   "metadata": {},
+   "source": [
+    "### Example 3: Caller-Driven Stepwise Execution with run_supervised()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d293e3ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "\n",
+    "def next_number(x: int) -> int:\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "next_number_tool = SimpleFunctionTool(func=next_number)\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[next_number_tool])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "933b6293",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compute the full Hailstone sequence starting from 4, \"\n",
+    "        \"step by step using next_number, until you reach 1.\"\n",
+    "    )\n",
+    ")\n",
+    "task_handler = await agent.run_supervised(task, explicit_only_skills=[\"stop-at-one\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d87789b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='2d14732d-e307-4706-aaac-944ebfdf0c69', task_id='fb5b7d5f-de29-4bec-b569-a88897230cf6', instruction='Compute the full Hailstone sequence starting from 4, step by step using next_number, until you reach 1.')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = await task_handler.get_next_step(None)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ae9ae241",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence starting from 4, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to call the next_number tool with x=4.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='2d14732d-e307-4706-aaac-944ebfdf0c69', content='I need to call the next_number tool with x=4.')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d1d3e3e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with x=4.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='690b7f82-7f4f-45fa-ade0-af13029d85d2', task_id='fb5b7d5f-de29-4bec-b569-a88897230cf6', instruction='Call the next_number tool with x=4.')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = await task_handler.get_next_step(step_result)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c035cb6f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with x=4.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: The next number in the Hailstone sequence starting from 4 is 2. I will now use the next_number tool again with x=2 to continue the sequ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='690b7f82-7f4f-45fa-ade0-af13029d85d2', content='The next number in the Hailstone sequence starting from 4 is 2. I will now use the next_number tool again with x=2 to continue the sequence.')"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "353c34ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with x=2.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='a145a42f-89b1-4be0-8213-94eb3e9dd7fb', task_id='fb5b7d5f-de29-4bec-b569-a88897230cf6', instruction='Call the next_number tool with x=2.')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = await task_handler.get_next_step(step_result)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "bc1ac257",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with x=2.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: The next number in the Hailstone sequence starting from 2 is 1. Since we have reached 1, the sequence is complete. The full Hailstone s...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='a145a42f-89b1-4be0-8213-94eb3e9dd7fb', content='The next number in the Hailstone sequence starting from 2 is 1. Since we have reached 1, the sequence is complete. The full Hailstone sequence starting from 4 is: 4, 2, 1.')"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "088f6eb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskResult(task_id='fb5b7d5f-de29-4bec-b569-a88897230cf6', content='The next number in the Hailstone sequence starting from 2 is 1. Since we have reached 1, the sequence is complete. The full Hailstone sequence starting from 4 is: 4, 2, 1.')"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = await task_handler.get_next_step(step_result)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "efccbb59-a063-49c3-9f8f-828c893f0ca9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The next number in the Hailstone sequence starting from 2 is 1. Since we have reached 1, the sequence is complete. The full Hailstone sequence starting from 4 is: 4, 2, 1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# since result is a TaskResult, we can call complete()\n",
+    "await task_handler.complete(result)\n",
+    "print(result.content)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1b2c3d4-0008-0000-0000-000000000010",
+   "id": "1881061d-fb9b-45c1-a948-0e409ffb4318",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -698,6 +698,11 @@ class LLMAgent:
             Args:
                 result: The ``TaskResult`` to accept.
             """
+            if not isinstance(result, TaskResult):
+                raise TaskHandlerError(
+                    f"complete() requires a TaskResult, "
+                    f"got {type(result).__name__}.",
+                )
             await self.record_memory(result=result)
             self.set_result(result)
 

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1154,3 +1154,17 @@ async def test_supervised_handler_reject_returns_rejected_task_result(
     assert isinstance(rejected, RejectedTaskResult)
     assert rejected.failed_result_content == "wrong answer"
     assert rejected.feedback == "fix the math"
+
+
+@pytest.mark.asyncio
+async def test_supervised_handler_complete_raises_on_non_task_result(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests complete() raises TaskHandlerError when not given a TaskResult."""
+    agent = LLMAgent(llm=mock_llm)
+    task = Task(instruction="mock instruction")
+    handler = await agent.run_supervised(task)
+    step = TaskStep(task_id=task.id_, instruction="do something")
+
+    with pytest.raises(TaskHandlerError, match="TaskResult"):
+        await handler.complete(step)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #681

## Summary
- Adds Example 3 to `examples/ch08.ipynb` demonstrating `run_supervised()` as the caller-driven HITL pattern
- Each `get_next_step()` / `run_step()` pair is its own notebook cell, showing that the human controls execution cadence step by step
- Uses Hailstone from 4 (short sequence) for a clean, readable trajectory
- Also adds a runtime guard in `SupervisedTaskHandler.complete()` that raises `TaskHandlerError` when a non-`TaskResult` is passed

## Test plan
- [ ] Run Example 3 cells in Jupyter top-to-bottom and verify the Hailstone sequence resolves correctly
- [ ] Verify `complete()` raises clearly when passed a `TaskStep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)