### PR TITLE
feat(ch08): add more-example — supervised trajectories (reject/revise + abort)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,16 @@ points at the same JSONL file and picks up all prior episodes from disk.
 </div>
 
 <div class="landing-card landing-card--example" markdown>
+### :material-human-edit: Supervised Trajectories
+
+Step through two `SupervisedTaskHandler` trajectories: a reject-and-revise
+cycle where the human sends feedback and the agent corrects its output, and
+an abort that terminates mid-execution with a clean error.
+
+[Open Notebook](more-examples/ch08/supervised_trajectories.ipynb){ .md-button .md-button--primary }
+</div>
+
+<div class="landing-card landing-card--example" markdown>
 ### :material-magnify: Similarity Memory
 
 Look up seven countries across four regions, then run two targeted queries.

--- a/docs/more-examples/ch08/supervised_trajectories.ipynb
+++ b/docs/more-examples/ch08/supervised_trajectories.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch08/supervised_trajectories.ipynb

--- a/more-examples/ch08/supervised_trajectories.ipynb
+++ b/more-examples/ch08/supervised_trajectories.ipynb
@@ -197,7 +197,7 @@
     {
      "data": {
       "text/plain": [
-       "TaskStep(id_='6861d83d-ba0d-4ff4-bfff-e4362b184f19', task_id='830884ad-95a4-4fd7-9002-67deb56e4fba', instruction='Refactor the following Python function to replace the if-elif chain with a dictionary dispatch:\\n\\ndef calculate(x, y, operation):\\n    if operation == \"add\":\\n        return x + y\\n    elif operation == \"subtract\":\\n        return x - y\\n    elif operation == \"multiply\":\\n        return x * y\\n    elif operation == \"divide\":\\n        return x / y\\n')"
+       "TaskStep(id_='43578526-53c2-461e-8df4-cd214a0c43da', task_id='527becc1-a663-4567-aaf6-921dbf134483', instruction='Refactor the following Python function to replace the if-elif chain with a dictionary dispatch:\\n\\ndef calculate(x, y, operation):\\n    if operation == \"add\":\\n        return x + y\\n    elif operation == \"subtract\":\\n        return x - y\\n    elif operation == \"multiply\":\\n        return x * y\\n    elif operation == \"divide\":\\n        return x / y\\n')"
       ]
      },
      "execution_count": 5,
@@ -224,13 +224,13 @@
       "\n",
       "def calculate(x, y, operation):\n",
       " ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to refactor the given function by replacing the if-elif chain with a dictionary dispatch. This means I will create a dictionary ...[TRUNCATED]\n"
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to refactor the function by replacing the if-elif chain with a dictionary that maps operations to corresponding lambda functions...[TRUNCATED]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TaskStepResult(task_step_id='6861d83d-ba0d-4ff4-bfff-e4362b184f19', content=\"I need to refactor the given function by replacing the if-elif chain with a dictionary dispatch. This means I will create a dictionary that maps operation strings to corresponding lambda functions or function references. Then, I will use the dictionary to look up the appropriate function based on the operation parameter. Let's implement this approach.\")"
+       "TaskStepResult(task_step_id='43578526-53c2-461e-8df4-cd214a0c43da', content='I need to refactor the function by replacing the if-elif chain with a dictionary that maps operations to corresponding lambda functions or function references. This approach will make the code more concise and easier to extend. Let me proceed with this change.')"
       ]
      },
      "execution_count": 6,
@@ -248,38 +248,164 @@
    "execution_count": 7,
    "id": "c8-st-0011",
    "metadata": {},
-   "outputs": [],
-   "source": "step = await task_handler.get_next_step(step_result)\nstep"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step: Define a dictionary that maps each operation string to a corresponding lambda function or function reference, and then use the dictionary ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='05f23f72-89e8-4a00-829a-212f479f48c0', task_id='527becc1-a663-4567-aaf6-921dbf134483', instruction='Define a dictionary that maps each operation string to a corresponding lambda function or function reference, and then use the dictionary to perform the calculation.')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = await task_handler.get_next_step(step_result)\n",
+    "step"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "id": "f8cd23db-2651-440e-bb12-b63383b5b2e8",
    "metadata": {},
-   "outputs": [],
-   "source": "step_result = await task_handler.run_step(step)\nstep_result"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Define a dictionary that maps each operation string to a corresponding lambda function or function reference, and then use the dic...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I will define a dictionary called `operations` where each key is an operation string, and the corresponding value is a lambda function ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='05f23f72-89e8-4a00-829a-212f479f48c0', content='I will define a dictionary called `operations` where each key is an operation string, and the corresponding value is a lambda function that performs the respective calculation. Then, I will use the dictionary to perform the calculation based on the `operation` parameter. Let me implement this change.')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "541c0585-db32-4f54-ad4c-ec64144dfb84",
+   "id": "93a2dd77-d506-41f5-8543-8341847c26e2",
    "metadata": {},
-   "outputs": [],
-   "source": "result = await task_handler.get_next_step(step_result)\nresult"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step: Define the dictionary `operations` with lambda functions for each operation and use it to perform the calculation.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='1469aa64-8378-44f4-a3c1-1200311a7db6', task_id='527becc1-a663-4567-aaf6-921dbf134483', instruction='Define the dictionary `operations` with lambda functions for each operation and use it to perform the calculation.')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step = await task_handler.get_next_step(step_result)\n",
+    "step"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "14f89600-f5b5-4b5f-b189-a29948494953",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Define the dictionary `operations` with lambda functions for each operation and use it to perform the calculation.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I will define the `operations` dictionary with lambda functions for each operation. Here's how the dictionary will look:\n",
+      "\n",
+      "```python\n",
+      "ope...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='1469aa64-8378-44f4-a3c1-1200311a7db6', content='I will define the `operations` dictionary with lambda functions for each operation. Here\\'s how the dictionary will look:\\n\\n```python\\noperations = {\\n    \"add\": lambda x, y: x + y,\\n    \"subtract\": lambda x, y: x - y,\\n    \"multiply\": lambda x, y: x * y,\\n    \"divide\": lambda x, y: x / y\\n}\\n```\\n\\nThen, I will use this dictionary to perform the calculation by accessing the appropriate lambda function based on the `operation` parameter. The updated function will look like this:\\n\\n```python\\ndef calculate(x, y, operation):\\n    return operations[operation](x, y)\\n```\\n\\nThis refactoring replaces the if-elif chain with a dictionary-based dispatch, making the code more concise and easier to maintain.')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "541c0585-db32-4f54-ad4c-ec64144dfb84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskResult(task_id='527becc1-a663-4567-aaf6-921dbf134483', content='I will define the `operations` dictionary with lambda functions for each operation. Here\\'s how the dictionary will look:\\n\\n```python\\noperations = {\\n    \"add\": lambda x, y: x + y,\\n    \"subtract\": lambda x, y: x - y,\\n    \"multiply\": lambda x, y: x * y,\\n    \"divide\": lambda x, y: x / y\\n}\\n```\\n\\nThen, I will use this dictionary to perform the calculation by accessing the appropriate lambda function based on the `operation` parameter. The updated function will look like this:\\n\\n```python\\ndef calculate(x, y, operation):\\n    return operations[operation](x, y)\\n```\\n\\nThis refactoring replaces the if-elif chain with a dictionary-based dispatch, making the code more concise and easier to maintain.')"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = await task_handler.get_next_step(step_result)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "c8-st-0012",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "RejectedTaskResult(failed_result_content='I will implement the dictionary dispatch by creating a dictionary that maps operation strings to corresponding lambda functions. Here\\'s the updated code:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b\\n    }\\n    return operations[operation](x, y)\\n```\\n\\nIn this implementation, I have created a dictionary called `operations` that maps each operation string to a lambda function that performs the corresponding operation. Then, I use the dictionary to look up the appropriate function based on the `operation` parameter and call it with the `x` and `y` parameters. This replaces the original if-elif chain with a more concise and scalable approach using dictionary dispatch.', feedback='Good start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.')"
+       "RejectedTaskResult(failed_result_content='I will define the `operations` dictionary with lambda functions for each operation. Here\\'s how the dictionary will look:\\n\\n```python\\noperations = {\\n    \"add\": lambda x, y: x + y,\\n    \"subtract\": lambda x, y: x - y,\\n    \"multiply\": lambda x, y: x * y,\\n    \"divide\": lambda x, y: x / y\\n}\\n```\\n\\nThen, I will use this dictionary to perform the calculation by accessing the appropriate lambda function based on the `operation` parameter. The updated function will look like this:\\n\\n```python\\ndef calculate(x, y, operation):\\n    return operations[operation](x, y)\\n```\\n\\nThis refactoring replaces the if-elif chain with a dictionary-based dispatch, making the code more concise and easier to maintain.', feedback='Good start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.')"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "c8-st-0013",
    "metadata": {},
    "outputs": [
@@ -311,10 +437,10 @@
     {
      "data": {
       "text/plain": [
-       "TaskStep(id_='7f8ccce0-4a9b-4df9-b04c-cbbc85405f10', task_id='830884ad-95a4-4fd7-9002-67deb56e4fba', instruction='The human operator REJECTED your proposed task result. Revise your approach and try again.\\n\\n<proposed-result>\\nI will implement the dictionary dispatch by creating a dictionary that maps operation strings to corresponding lambda functions. Here\\'s the updated code:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b\\n    }\\n    return operations[operation](x, y)\\n```\\n\\nIn this implementation, I have created a dictionary called `operations` that maps each operation string to a lambda function that performs the corresponding operation. Then, I use the dictionary to look up the appropriate function based on the `operation` parameter and call it with the `x` and `y` parameters. This replaces the original if-elif chain with a more concise and scalable approach using dictionary dispatch.\\n</proposed-result>\\n\\n<human-correction>\\nGood start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.\\n</human-correction>')"
+       "TaskStep(id_='0e361fcc-5680-4abc-94f7-aed80e88ddff', task_id='527becc1-a663-4567-aaf6-921dbf134483', instruction='The human operator REJECTED your proposed task result. Revise your approach and try again.\\n\\n<proposed-result>\\nI will define the `operations` dictionary with lambda functions for each operation. Here\\'s how the dictionary will look:\\n\\n```python\\noperations = {\\n    \"add\": lambda x, y: x + y,\\n    \"subtract\": lambda x, y: x - y,\\n    \"multiply\": lambda x, y: x * y,\\n    \"divide\": lambda x, y: x / y\\n}\\n```\\n\\nThen, I will use this dictionary to perform the calculation by accessing the appropriate lambda function based on the `operation` parameter. The updated function will look like this:\\n\\n```python\\ndef calculate(x, y, operation):\\n    return operations[operation](x, y)\\n```\\n\\nThis refactoring replaces the if-elif chain with a dictionary-based dispatch, making the code more concise and easier to maintain.\\n</proposed-result>\\n\\n<human-correction>\\nGood start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.\\n</human-correction>')"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -326,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "c8-st-0014",
    "metadata": {},
    "outputs": [
@@ -337,17 +463,19 @@
       "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: The human operator REJECTED your proposed task result. Revise your approach and try again.\n",
       "\n",
       "<proposed-result>\n",
-      "I will implement the...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to revise my approach by adding error handling to the dictionary dispatch implementation. Specifically, I should raise a `ValueE...[TRUNCATED]\n"
+      "I will define the `o...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to revise the function to include error handling as requested. Specifically, I should:\n",
+      "\n",
+      "1. Add a check to raise a `ValueError` i...[TRUNCATED]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TaskStepResult(task_step_id='7f8ccce0-4a9b-4df9-b04c-cbbc85405f10', content='I need to revise my approach by adding error handling to the dictionary dispatch implementation. Specifically, I should raise a `ValueError` if the provided operation is not recognized and a `ZeroDivisionError` if the division operation is used and the second operand (`y`) is zero. Let me update the code accordingly.\\n\\nHere\\'s the revised implementation:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b if b != 0 else (raise ZeroDivisionError(\"Division by zero\"))\\n    }\\n    \\n    if operation not in operations:\\n        raise ValueError(f\"Unknown operation: {operation}\")\\n    \\n    try:\\n        return operations[operation](x, y)\\n    except ZeroDivisionError as e:\\n        raise e\\n```\\n\\nIn this updated version, I have added a check to ensure that the `operation` is valid and exists in the `operations` dictionary. If not, a `ValueError` is raised. Additionally, for the `divide` operation, I have included a check to ensure that the second operand (`y`) is not zero, and if it is, a `ZeroDivisionError` is raised. This makes the function more robust and handles potential errors gracefully.')"
+       "TaskStepResult(task_step_id='0e361fcc-5680-4abc-94f7-aed80e88ddff', content='I need to revise the function to include error handling as requested. Specifically, I should:\\n\\n1. Add a check to raise a `ValueError` if the `operation` is not found in the `operations` dictionary.\\n2. Add a check to raise a `ZeroDivisionError` if the `operation` is \"divide\" and `y` is zero.\\n\\nHere\\'s the updated function with error handling:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda x, y: x + y,\\n        \"subtract\": lambda x, y: x - y,\\n        \"multiply\": lambda x, y: x * y,\\n        \"divide\": lambda x, y: x / y\\n    }\\n\\n    if operation not in operations:\\n        raise ValueError(f\"Unknown operation: {operation}\")\\n\\n    if operation == \"divide\" and y == 0:\\n        raise ZeroDivisionError(\"Division by zero is not allowed\")\\n\\n    return operations[operation](x, y)\\n```\\n\\nThis version includes the requested error handling while maintaining the dictionary-based dispatch approach.')"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -359,27 +487,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "c8-st-0015",
    "metadata": {},
-   "outputs": [],
-   "source": "step = await task_handler.get_next_step(step_result)\nstep"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "a43ccd74-5bc7-4715-b637-3c752c7da5ff",
-   "metadata": {},
-   "outputs": [],
-   "source": "step_result = await task_handler.run_step(step)\nstep_result"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "26721be0-9607-40d6-8116-a0310633fde2",
-   "metadata": {},
-   "outputs": [],
-   "source": "result = await task_handler.get_next_step(step_result)\nresult"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskResult(task_id='527becc1-a663-4567-aaf6-921dbf134483', content='I need to revise the function to include error handling as requested. Specifically, I should:\\n\\n1. Add a check to raise a `ValueError` if the `operation` is not found in the `operations` dictionary.\\n2. Add a check to raise a `ZeroDivisionError` if the `operation` is \"divide\" and `y` is zero.\\n\\nHere\\'s the updated function with error handling:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda x, y: x + y,\\n        \"subtract\": lambda x, y: x - y,\\n        \"multiply\": lambda x, y: x * y,\\n        \"divide\": lambda x, y: x / y\\n    }\\n\\n    if operation not in operations:\\n        raise ValueError(f\"Unknown operation: {operation}\")\\n\\n    if operation == \"divide\" and y == 0:\\n        raise ZeroDivisionError(\"Division by zero is not allowed\")\\n\\n    return operations[operation](x, y)\\n```\\n\\nThis version includes the requested error handling while maintaining the dictionary-based dispatch approach.')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = await task_handler.get_next_step(step_result)\n",
+    "result"
+   ]
   },
   {
    "cell_type": "code",
@@ -391,40 +524,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You're absolutely right. The `raise` statement cannot be used directly inside a lambda function in Python. To handle the division by zero case properly, I should use a separate function for the \"divide\" operation and add a check outside the lambda. Let me revise the code accordingly.\n",
+      "I need to revise the function to include error handling as requested. Specifically, I should:\n",
       "\n",
-      "Here's the updated implementation:\n",
+      "1. Add a check to raise a `ValueError` if the `operation` is not found in the `operations` dictionary.\n",
+      "2. Add a check to raise a `ZeroDivisionError` if the `operation` is \"divide\" and `y` is zero.\n",
+      "\n",
+      "Here's the updated function with error handling:\n",
       "\n",
       "```python\n",
       "def calculate(x, y, operation):\n",
-      "    def divide(a, b):\n",
-      "        if b == 0:\n",
-      "            raise ZeroDivisionError(\"Division by zero\")\n",
-      "        return a / b\n",
-      "\n",
       "    operations = {\n",
-      "        \"add\": lambda a, b: a + b,\n",
-      "        \"subtract\": lambda a, b: a - b,\n",
-      "        \"multiply\": lambda a, b: a * b,\n",
-      "        \"divide\": divide\n",
+      "        \"add\": lambda x, y: x + y,\n",
+      "        \"subtract\": lambda x, y: x - y,\n",
+      "        \"multiply\": lambda x, y: x * y,\n",
+      "        \"divide\": lambda x, y: x / y\n",
       "    }\n",
       "\n",
       "    if operation not in operations:\n",
       "        raise ValueError(f\"Unknown operation: {operation}\")\n",
       "\n",
-      "    try:\n",
-      "        return operations[operation](x, y)\n",
-      "    except ZeroDivisionError as e:\n",
-      "        raise e\n",
+      "    if operation == \"divide\" and y == 0:\n",
+      "        raise ZeroDivisionError(\"Division by zero is not allowed\")\n",
+      "\n",
+      "    return operations[operation](x, y)\n",
       "```\n",
       "\n",
-      "In this revised version:\n",
-      "1. I defined a separate function `divide` to handle the division operation and check for division by zero.\n",
-      "2. I updated the `operations` dictionary to use the `divide` function for the \"divide\" operation.\n",
-      "3. I added a check to ensure that the `operation` is valid and exists in the `operations` dictionary. If not, a `ValueError` is raised.\n",
-      "4. I used a `try-except` block to catch any `ZeroDivisionError` that might be raised during the execution of the divide function and re-raise it.\n",
-      "\n",
-      "This implementation now correctly handles both unknown operations and division by zero.\n"
+      "This version includes the requested error handling while maintaining the dictionary-based dispatch approach.\n"
      ]
     }
    ],
@@ -471,7 +596,7 @@
     {
      "data": {
       "text/plain": [
-       "TaskStep(id_='6faf3aa0-4290-4e79-b860-47d2a9c76bbd', task_id='18f81a99-5f1f-42d9-babd-dd19bfad4953', instruction='Refactor the authentication module to consolidate all login, logout, and session renewal functions into a single AuthService class.')"
+       "TaskStep(id_='c14e474b-986c-4b7f-b513-575df74eb097', task_id='8361095e-898f-4ce6-95e6-949c78a481f8', instruction='Refactor the authentication module to consolidate all login, logout, and session renewal functions into a single AuthService class.')"
       ]
      },
      "execution_count": 18,

--- a/more-examples/ch08/supervised_trajectories.ipynb
+++ b/more-examples/ch08/supervised_trajectories.ipynb
@@ -1,0 +1,365 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c8-st-0001",
+   "metadata": {},
+   "source": [
+    "# Supervised Trajectories — Reject and Revise, and Abort\n",
+    "\n",
+    "This notebook shows two trajectories available with `SupervisedTaskHandler`\n",
+    "that are not possible with `run()` or `run(with_approval=True)`:\n",
+    "\n",
+    "- **Reject and Revise.** After the agent delivers its result, the human calls\n",
+    "  `reject()` with structured feedback. The handler routes the rejection back\n",
+    "  through `get_next_step()` deterministically — the agent revises without\n",
+    "  replanning from scratch.\n",
+    "- **Abort.** The human calls `abort()` mid-execution to terminate cleanly,\n",
+    "  setting a `TaskHandlerError` (or a custom exception) on the handler that\n",
+    "  the caller can inspect.\n",
+    "\n",
+    "Both trajectories use a code refactoring scenario to keep the focus on the\n",
+    "HITL mechanics rather than tooling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-st-0003",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama\n",
+    "installed on your local machine and have its LLM hosting service running.\n",
+    "To download Ollama, follow the instructions found on this page:\n",
+    "https://ollama.com/download. After downloading and installing Ollama, you\n",
+    "can start a service by opening a terminal and running `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"\\u2713 Ollama already running at {host}\")\n",
+    "\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"\\u2713 Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-st-0006",
+   "metadata": {},
+   "source": [
+    "## Trajectory 1: Reject and Revise\n",
+    "\n",
+    "The agent is asked to refactor a function by replacing its `if-elif` chain\n",
+    "with a dictionary dispatch. After it delivers its result, the human inspects\n",
+    "it, finds it incomplete (no error handling), and calls `reject()` with\n",
+    "specific feedback. The handler feeds the rejection back through\n",
+    "`get_next_step()` and the agent revises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ORIGINAL = \"\"\"\\\n",
+    "def calculate(x, y, operation):\n",
+    "    if operation == \\\"add\\\":\n",
+    "        return x + y\n",
+    "    elif operation == \\\"subtract\\\":\n",
+    "        return x - y\n",
+    "    elif operation == \\\"multiply\\\":\n",
+    "        return x * y\n",
+    "    elif operation == \\\"divide\\\":\n",
+    "        return x / y\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task = Task(\n",
+    "    instruction=(\n",
+    "        \"Refactor the following Python function to replace the \"\n",
+    "        f\"if-elif chain with a dictionary dispatch:\\n\\n{ORIGINAL}\"\n",
+    "    ),\n",
+    ")\n",
+    "task_handler = await agent.run_supervised(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step = await task_handler.get_next_step(None)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0011",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await task_handler.get_next_step(step_result)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rejected = task_handler.reject(\n",
+    "    result,\n",
+    "    feedback=(\n",
+    "        \"Good start, but add error handling: raise ValueError for \"\n",
+    "        \"unknown operations and ZeroDivisionError for division by zero.\"\n",
+    "    ),\n",
+    ")\n",
+    "rejected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step = await task_handler.get_next_step(rejected)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_result = await task_handler.run_step(step)\n",
+    "step_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0015",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await task_handler.get_next_step(step_result)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0016",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await task_handler.complete(result)\n",
+    "print(result.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-st-0017",
+   "metadata": {},
+   "source": [
+    "## Trajectory 2: Abort\n",
+    "\n",
+    "The agent is asked to refactor the authentication module. After seeing the\n",
+    "first planned step, the human realises the task conflicts with an ongoing\n",
+    "security audit and calls `abort()`. The handler terminates cleanly and the\n",
+    "caller can inspect the exception that was set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task2 = Task(\n",
+    "    instruction=(\n",
+    "        \"Refactor the authentication module to consolidate all login, \"\n",
+    "        \"logout, and session renewal functions into a single AuthService class.\"\n",
+    "    ),\n",
+    ")\n",
+    "task_handler2 = await agent.run_supervised(task2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0019",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step = await task_handler2.get_next_step(None)\n",
+    "step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0020",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await task_handler2.abort(\n",
+    "    error=RuntimeError(\n",
+    "        \"Refactoring auth is blocked pending the security audit. \"\n",
+    "        \"Revisit after the audit completes.\",\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-st-0021",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task_handler2.exception()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat": 4,
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/more-examples/ch08/supervised_trajectories.ipynb
+++ b/more-examples/ch08/supervised_trajectories.ipynb
@@ -5,14 +5,14 @@
    "id": "c8-st-0001",
    "metadata": {},
    "source": [
-    "# Supervised Trajectories — Reject and Revise, and Abort\n",
+    "# Supervised Trajectories \u2014 Reject and Revise, and Abort\n",
     "\n",
     "This notebook shows two trajectories available with `SupervisedTaskHandler`\n",
     "that are not possible with `run()` or `run(with_approval=True)`:\n",
     "\n",
     "- **Reject and Revise.** After the agent delivers its result, the human calls\n",
     "  `reject()` with structured feedback. The handler routes the rejection back\n",
-    "  through `get_next_step()` deterministically — the agent revises without\n",
+    "  through `get_next_step()` deterministically \u2014 the agent revises without\n",
     "  replanning from scratch.\n",
     "- **Abort.** The human calls `abort()` mid-execution to terminate cleanly,\n",
     "  setting a `TaskHandlerError` (or a custom exception) on the handler that\n",
@@ -49,10 +49,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "c8-st-0004",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u2713 Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "c8-st-0005",
    "metadata": {},
    "outputs": [],
@@ -146,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "c8-st-0007",
    "metadata": {},
    "outputs": [],
@@ -166,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c8-st-0008",
    "metadata": {},
    "outputs": [],
@@ -182,10 +190,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "c8-st-0009",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='6861d83d-ba0d-4ff4-bfff-e4362b184f19', task_id='830884ad-95a4-4fd7-9002-67deb56e4fba', instruction='Refactor the following Python function to replace the if-elif chain with a dictionary dispatch:\\n\\ndef calculate(x, y, operation):\\n    if operation == \"add\":\\n        return x + y\\n    elif operation == \"subtract\":\\n        return x - y\\n    elif operation == \"multiply\":\\n        return x * y\\n    elif operation == \"divide\":\\n        return x / y\\n')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "step = await task_handler.get_next_step(None)\n",
     "step"
@@ -193,10 +212,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "c8-st-0010",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Refactor the following Python function to replace the if-elif chain with a dictionary dispatch:\n",
+      "\n",
+      "def calculate(x, y, operation):\n",
+      " ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to refactor the given function by replacing the if-elif chain with a dictionary dispatch. This means I will create a dictionary ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='6861d83d-ba0d-4ff4-bfff-e4362b184f19', content=\"I need to refactor the given function by replacing the if-elif chain with a dictionary dispatch. This means I will create a dictionary that maps operation strings to corresponding lambda functions or function references. Then, I will use the dictionary to look up the appropriate function based on the operation parameter. Let's implement this approach.\")"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "step_result = await task_handler.run_step(step)\n",
     "step_result"
@@ -204,21 +245,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "c8-st-0011",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "result = await task_handler.get_next_step(step_result)\n",
-    "result"
-   ]
+   "source": "step = await task_handler.get_next_step(step_result)\nstep"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c8-st-0012",
+   "execution_count": 8,
+   "id": "f8cd23db-2651-440e-bb12-b63383b5b2e8",
    "metadata": {},
    "outputs": [],
+   "source": "step_result = await task_handler.run_step(step)\nstep_result"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "541c0585-db32-4f54-ad4c-ec64144dfb84",
+   "metadata": {},
+   "outputs": [],
+   "source": "result = await task_handler.get_next_step(step_result)\nresult"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c8-st-0012",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RejectedTaskResult(failed_result_content='I will implement the dictionary dispatch by creating a dictionary that maps operation strings to corresponding lambda functions. Here\\'s the updated code:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b\\n    }\\n    return operations[operation](x, y)\\n```\\n\\nIn this implementation, I have created a dictionary called `operations` that maps each operation string to a lambda function that performs the corresponding operation. Then, I use the dictionary to look up the appropriate function based on the `operation` parameter and call it with the `x` and `y` parameters. This replaces the original if-elif chain with a more concise and scalable approach using dictionary dispatch.', feedback='Good start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rejected = task_handler.reject(\n",
     "    result,\n",
@@ -232,10 +297,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "c8-st-0013",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step (rejection): Good start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='7f8ccce0-4a9b-4df9-b04c-cbbc85405f10', task_id='830884ad-95a4-4fd7-9002-67deb56e4fba', instruction='The human operator REJECTED your proposed task result. Revise your approach and try again.\\n\\n<proposed-result>\\nI will implement the dictionary dispatch by creating a dictionary that maps operation strings to corresponding lambda functions. Here\\'s the updated code:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b\\n    }\\n    return operations[operation](x, y)\\n```\\n\\nIn this implementation, I have created a dictionary called `operations` that maps each operation string to a lambda function that performs the corresponding operation. Then, I use the dictionary to look up the appropriate function based on the `operation` parameter and call it with the `x` and `y` parameters. This replaces the original if-elif chain with a more concise and scalable approach using dictionary dispatch.\\n</proposed-result>\\n\\n<human-correction>\\nGood start, but add error handling: raise ValueError for unknown operations and ZeroDivisionError for division by zero.\\n</human-correction>')"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "step = await task_handler.get_next_step(rejected)\n",
     "step"
@@ -243,10 +326,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c8-st-0014",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: The human operator REJECTED your proposed task result. Revise your approach and try again.\n",
+      "\n",
+      "<proposed-result>\n",
+      "I will implement the...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to revise my approach by adding error handling to the dictionary dispatch implementation. Specifically, I should raise a `ValueE...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskStepResult(task_step_id='7f8ccce0-4a9b-4df9-b04c-cbbc85405f10', content='I need to revise my approach by adding error handling to the dictionary dispatch implementation. Specifically, I should raise a `ValueError` if the provided operation is not recognized and a `ZeroDivisionError` if the division operation is used and the second operand (`y`) is zero. Let me update the code accordingly.\\n\\nHere\\'s the revised implementation:\\n\\n```python\\ndef calculate(x, y, operation):\\n    operations = {\\n        \"add\": lambda a, b: a + b,\\n        \"subtract\": lambda a, b: a - b,\\n        \"multiply\": lambda a, b: a * b,\\n        \"divide\": lambda a, b: a / b if b != 0 else (raise ZeroDivisionError(\"Division by zero\"))\\n    }\\n    \\n    if operation not in operations:\\n        raise ValueError(f\"Unknown operation: {operation}\")\\n    \\n    try:\\n        return operations[operation](x, y)\\n    except ZeroDivisionError as e:\\n        raise e\\n```\\n\\nIn this updated version, I have added a check to ensure that the `operation` is valid and exists in the `operations` dictionary. If not, a `ValueError` is raised. Additionally, for the `divide` operation, I have included a check to ensure that the second operand (`y`) is not zero, and if it is, a `ZeroDivisionError` is raised. This makes the function more robust and handles potential errors gracefully.')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "step_result = await task_handler.run_step(step)\n",
     "step_result"
@@ -254,21 +359,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "c8-st-0015",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "result = await task_handler.get_next_step(step_result)\n",
-    "result"
-   ]
+   "source": "step = await task_handler.get_next_step(step_result)\nstep"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c8-st-0016",
+   "execution_count": 14,
+   "id": "a43ccd74-5bc7-4715-b637-3c752c7da5ff",
    "metadata": {},
    "outputs": [],
+   "source": "step_result = await task_handler.run_step(step)\nstep_result"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "26721be0-9607-40d6-8116-a0310633fde2",
+   "metadata": {},
+   "outputs": [],
+   "source": "result = await task_handler.get_next_step(step_result)\nresult"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "c8-st-0016",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You're absolutely right. The `raise` statement cannot be used directly inside a lambda function in Python. To handle the division by zero case properly, I should use a separate function for the \"divide\" operation and add a check outside the lambda. Let me revise the code accordingly.\n",
+      "\n",
+      "Here's the updated implementation:\n",
+      "\n",
+      "```python\n",
+      "def calculate(x, y, operation):\n",
+      "    def divide(a, b):\n",
+      "        if b == 0:\n",
+      "            raise ZeroDivisionError(\"Division by zero\")\n",
+      "        return a / b\n",
+      "\n",
+      "    operations = {\n",
+      "        \"add\": lambda a, b: a + b,\n",
+      "        \"subtract\": lambda a, b: a - b,\n",
+      "        \"multiply\": lambda a, b: a * b,\n",
+      "        \"divide\": divide\n",
+      "    }\n",
+      "\n",
+      "    if operation not in operations:\n",
+      "        raise ValueError(f\"Unknown operation: {operation}\")\n",
+      "\n",
+      "    try:\n",
+      "        return operations[operation](x, y)\n",
+      "    except ZeroDivisionError as e:\n",
+      "        raise e\n",
+      "```\n",
+      "\n",
+      "In this revised version:\n",
+      "1. I defined a separate function `divide` to handle the division operation and check for division by zero.\n",
+      "2. I updated the `operations` dictionary to use the `divide` function for the \"divide\" operation.\n",
+      "3. I added a check to ensure that the `operation` is valid and exists in the `operations` dictionary. If not, a `ValueError` is raised.\n",
+      "4. I used a `try-except` block to catch any `ZeroDivisionError` that might be raised during the execution of the divide function and re-raise it.\n",
+      "\n",
+      "This implementation now correctly handles both unknown operations and division by zero.\n"
+     ]
+    }
+   ],
    "source": [
     "await task_handler.complete(result)\n",
     "print(result.content)"
@@ -289,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "c8-st-0018",
    "metadata": {},
    "outputs": [],
@@ -305,10 +464,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "c8-st-0019",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TaskStep(id_='6faf3aa0-4290-4e79-b860-47d2a9c76bbd', task_id='18f81a99-5f1f-42d9-babd-dd19bfad4953', instruction='Refactor the authentication module to consolidate all login, logout, and session renewal functions into a single AuthService class.')"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "step = await task_handler2.get_next_step(None)\n",
     "step"
@@ -316,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "c8-st-0020",
    "metadata": {},
    "outputs": [],
@@ -331,10 +501,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "c8-st-0021",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RuntimeError('Refactoring auth is blocked pending the security audit. Revisit after the audit completes.')"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "task_handler2.exception()"
    ]
@@ -354,8 +535,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat": 4,
-   "nbformat_minor": 5,
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.5"
   }


### PR DESCRIPTION
Closes #696

## Summary
- Adds `more-examples/ch08/supervised_trajectories.ipynb` with two `SupervisedTaskHandler` trajectories using a code refactoring scenario
- **Trajectory 1 (Reject and Revise):** Agent refactors a `calculate()` function; human rejects the first result asking for error handling; agent revises; human calls `complete()`
- **Trajectory 2 (Abort):** Agent begins planning an auth module refactor; human spots a conflict with an ongoing security audit and calls `abort()`; exception is inspectable on the handler
- Adds a card for the notebook in `docs/index.md`
- Creates symlink at `docs/more-examples/ch08/supervised_trajectories.ipynb`

## Test plan
- [ ] Run the notebook in Jupyter top-to-bottom and verify both trajectories produce sensible output
- [ ] Verify `task_handler2.exception()` returns the `RuntimeError` passed to `abort()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)