### PR TITLE
feat(ch08): add more-example — HumanInputTool inside a skill (#697)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,16 @@ points at the same JSONL file and picks up all prior episodes from disk.
 </div>
 
 <div class="landing-card landing-card--example" markdown>
+### :material-comment-question-outline: HumanInputTool Inside a Skill
+
+A `meeting-notes-summarizer` skill that asks the operator two constrained
+questions — format and detail level — before producing its output. Shows
+that HITL can be embedded in a skill, not just wired at the agent level.
+
+[Open Notebook](more-examples/ch08/skill_with_human_input.ipynb){ .md-button .md-button--primary }
+</div>
+
+<div class="landing-card landing-card--example" markdown>
 ### :material-human-edit: Supervised Trajectories
 
 Step through two `SupervisedTaskHandler` trajectories: a reject-and-revise

--- a/docs/more-examples/ch08/skill_with_human_input.ipynb
+++ b/docs/more-examples/ch08/skill_with_human_input.ipynb
@@ -1,0 +1,1 @@
+../../../more-examples/ch08/skill_with_human_input.ipynb

--- a/more-examples/ch08/.agents/skills/meeting-notes-summarizer/SKILL.md
+++ b/more-examples/ch08/.agents/skills/meeting-notes-summarizer/SKILL.md
@@ -11,7 +11,7 @@ Produce a summary of a meeting transcript provided by the user.
 
 ### 1. Ask for format preference
 
-Call `human_input` with:
+Call `from_scratch__human_input` with:
 - `prompt`: "What format would you like the summary in?"
 - `choices`: `["bullet-points", "prose"]`
 
@@ -19,7 +19,7 @@ Record the response as `format_preference`.
 
 ### 2. Ask for detail level
 
-Call `human_input` with:
+Call `from_scratch__human_input` with:
 - `prompt`: "What level of detail?"
 - `choices`: `["brief", "detailed"]`
 

--- a/more-examples/ch08/.agents/skills/meeting-notes-summarizer/SKILL.md
+++ b/more-examples/ch08/.agents/skills/meeting-notes-summarizer/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: meeting-notes-summarizer
+description: Summarise a meeting transcript by first asking the human operator for their preferred format and level of detail, then producing the summary accordingly.
+---
+
+# Meeting Notes Summarizer
+
+Produce a summary of a meeting transcript provided by the user.
+
+## Steps
+
+### 1. Ask for format preference
+
+Call `human_input` with:
+- `prompt`: "What format would you like the summary in?"
+- `choices`: `["bullet-points", "prose"]`
+
+Record the response as `format_preference`.
+
+### 2. Ask for detail level
+
+Call `human_input` with:
+- `prompt`: "What level of detail?"
+- `choices`: `["brief", "detailed"]`
+
+Record the response as `detail_preference`.
+
+### 3. Summarise
+
+Produce a summary of the transcript according to the chosen format and detail level:
+
+- **bullet-points + brief**: 3–5 top-level bullet points covering key decisions and action items only.
+- **bullet-points + detailed**: Structured bullet points with sub-bullets covering all discussion topics, decisions, and action items.
+- **prose + brief**: Two to three sentences capturing the meeting's purpose, key outcomes, and next steps.
+- **prose + detailed**: Multiple paragraphs covering all discussion topics in narrative form, ending with action items and owners.

--- a/more-examples/ch08/skill_with_human_input.ipynb
+++ b/more-examples/ch08/skill_with_human_input.ipynb
@@ -138,6 +138,12 @@
    "source": "TRANSCRIPT = \"\"\"\\\nSprint 14 Planning — 2026-06-27\n\nAttendees: Priya (PM), Marcus (Lead Eng), Leila (Backend),\nTom (Frontend), Ana (QA)\n\nPriya opened by reviewing Sprint 13 velocity: 42 points delivered against a\ntarget of 45. Two stories were rolled over — the pagination refactor (8 pts)\nand the email digest feature (5 pts). Both are high priority for Sprint 14.\n\nMarcus flagged a dependency risk: the pagination refactor depends on a database\nmigration scheduled for next Tuesday. If the migration slips, the refactor\ncannot be merged. The team agreed to move the migration to Monday to de-risk.\n\nLeila volunteered to pick up the email digest feature and estimated three days\nof backend work. Tom said he'd need one day of frontend work once Leila's API\nis ready. Ana will write the test plan today so it's ready for review by\nWednesday.\n\nSprint 14 commitments (44 points total):\n- Pagination refactor: 8 pts — Marcus, Leila\n- Email digest: 5 pts — Leila, Tom\n- Auth token refresh: 3 pts — Leila\n- Dashboard chart improvements: 13 pts — Tom\n- Automated regression suite: 8 pts — Ana\n- Performance monitoring alerts: 7 pts — Marcus\n\nPriya reminded the team that the release is scheduled for July 11. All Sprint 14\nwork must be merged and QA-approved by July 9.\n\nMeeting closed at 10:24.\n\"\"\""
   },
   {
+   "cell_type": "markdown",
+   "id": "3c26a7c2",
+   "source": "## Running the Skill\n\nWhen the agent activates the `meeting-notes-summarizer` skill, it will pause\ntwice to collect your preferences via `HumanInputTool`:\n\n1. **Format** — `bullet-points` or `prose`\n2. **Detail level** — `brief` or `detailed`\n\nThe summary is then generated according to your choices.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "c8-swhi-0007",

--- a/more-examples/ch08/skill_with_human_input.ipynb
+++ b/more-examples/ch08/skill_with_human_input.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c8-swhi-0001",
+   "metadata": {},
+   "source": [
+    "# HumanInputTool Inside a Skill — Meeting Notes Summarizer\n",
+    "\n",
+    "This notebook shows that HITL is not only an agent-level concern — it can\n",
+    "be embedded directly inside a reusable skill.\n",
+    "\n",
+    "The `meeting-notes-summarizer` skill uses `HumanInputTool` with constrained\n",
+    "`choices` to ask the operator two questions before producing output:\n",
+    "\n",
+    "1. **Format** — `bullet-points` or `prose`\n",
+    "2. **Level of detail** — `brief` or `detailed`\n",
+    "\n",
+    "Any agent that loads this skill gets the human-input behaviour automatically,\n",
+    "without the caller knowing or configuring it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-swhi-0002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-swhi-0003",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama\n",
+    "installed on your local machine and have its LLM hosting service running.\n",
+    "To download Ollama, follow the instructions found on this page:\n",
+    "https://ollama.com/download. After downloading and installing Ollama, you\n",
+    "can start a service by opening a terminal and running `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-swhi-0004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"\\u2713 Ollama already running at {host}\")\n",
+    "\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"\\u2713 Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "ensure_ollama()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-swhi-0005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.tools.default import HumanInputTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "human_input_tool = HumanInputTool()\n",
+    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "agent = LLMAgent(llm=llm, tools=[human_input_tool])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-swhi-0006",
+   "metadata": {},
+   "outputs": [],
+   "source": "TRANSCRIPT = \"\"\"\\\nSprint 14 Planning — 2026-06-27\n\nAttendees: Priya (PM), Marcus (Lead Eng), Leila (Backend),\nTom (Frontend), Ana (QA)\n\nPriya opened by reviewing Sprint 13 velocity: 42 points delivered against a\ntarget of 45. Two stories were rolled over — the pagination refactor (8 pts)\nand the email digest feature (5 pts). Both are high priority for Sprint 14.\n\nMarcus flagged a dependency risk: the pagination refactor depends on a database\nmigration scheduled for next Tuesday. If the migration slips, the refactor\ncannot be merged. The team agreed to move the migration to Monday to de-risk.\n\nLeila volunteered to pick up the email digest feature and estimated three days\nof backend work. Tom said he'd need one day of frontend work once Leila's API\nis ready. Ana will write the test plan today so it's ready for review by\nWednesday.\n\nSprint 14 commitments (44 points total):\n- Pagination refactor: 8 pts — Marcus, Leila\n- Email digest: 5 pts — Leila, Tom\n- Auth token refresh: 3 pts — Leila\n- Dashboard chart improvements: 13 pts — Tom\n- Automated regression suite: 8 pts — Ana\n- Performance monitoring alerts: 7 pts — Marcus\n\nPriya reminded the team that the release is scheduled for July 11. All Sprint 14\nwork must be merged and QA-approved by July 9.\n\nMeeting closed at 10:24.\n\"\"\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-swhi-0007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await agent.run_with_skill(\n",
+    "    \"meeting-notes-summarizer\",\n",
+    "    prompt=f\"Summarise the following meeting transcript:\\n\\n{TRANSCRIPT}\",\n",
+    ")\n",
+    "print(result.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat": 4,
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Adds `more-examples/ch08/.agents/skills/meeting-notes-summarizer/SKILL.md` — a skill that calls `human_input` twice with constrained `choices` (format: `bullet-points`/`prose`, detail: `brief`/`detailed`) before producing its meeting summary
- Adds `more-examples/ch08/skill_with_human_input.ipynb` — notebook that wires one `HumanInputTool` instance into an `LLMAgent` and invokes the skill via `run_with_skill()`
- Adds `docs/more-examples/ch08/skill_with_human_input.ipynb` symlink and a landing card in `docs/index.md`
- Demonstrates that HITL is not only an agent-level concern — it can be embedded in a reusable skill, invisible to the caller

Closes #697
Part of #695

## Test plan

- [ ] Run `more-examples/ch08/skill_with_human_input.ipynb` end-to-end in Jupyter (interactive `HumanInputTool` prompts require a live terminal)
- [ ] Confirm the skill prompts for format then detail level with constrained choices
- [ ] Confirm the summary respects both preferences
- [ ] Check docs card renders correctly on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)