### PR TITLE
fix: add from_scratch__ prefix to HumanInputTool name (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - feat: implement end-of-loop human approval gate in `_process_loop` — adds `with_approval` param to `LLMAgent.run()`, `TaskHandler.request_approval()`, `TaskHandler._prompt_for_approval()`, `ApprovalResult` data structure, three approval template keys, and `rich>=13.9.0` dependency (#688)
 - feat: implement HumanInputTool (#685)
 
+### Changed
+
+- fix: add from_scratch__ prefix to HumanInputTool name (#704)
+
 ## [0.0.19] - 2026-06-23
 
 ### Added

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -174,7 +174,7 @@
       "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to ask the human operator for the starting number to compute the Hailstone sequence.\n",
       "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
       "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human operator for the starting number to compute the Hailstone sequence.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: human_input\n"
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -21,7 +21,7 @@ class HumanInputTool(BaseTool):
     @property
     def name(self) -> str:
         """Name of the human-input tool."""
-        return "human_input"
+        return "from_scratch__human_input"
 
     @property
     def description(self) -> str:

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -270,7 +270,7 @@ def test_default_tools_contains_python_interpreter_tool() -> None:
 def test_human_input_tool_name() -> None:
     """Tests HumanInputTool.name."""
     tool = HumanInputTool()
-    assert tool.name == "human_input"
+    assert tool.name == "from_scratch__human_input"
 
 
 def test_human_input_tool_description() -> None:
@@ -293,7 +293,7 @@ def test_human_input_tool_returns_response() -> None:
     """Tests HumanInputTool returns the human's response as content."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={"prompt": "What is your name?"},
     )
 
@@ -308,7 +308,7 @@ def test_human_input_tool_passes_prompt_to_input() -> None:
     """Tests HumanInputTool renders the prompt in a Panel and uses > inline."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={"prompt": "How old are you?"},
     )
 
@@ -328,7 +328,7 @@ def test_human_input_tool_missing_prompt_defaults_to_empty() -> None:
     """Tests HumanInputTool defaults to empty string when prompt is absent."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={},
     )
 
@@ -348,7 +348,7 @@ def test_human_input_tool_choices_passed_to_prompt() -> None:
     """Tests HumanInputTool passes choices to Prompt.ask when provided."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={"prompt": "Pick one:", "choices": ["yes", "no"]},
     )
 
@@ -371,7 +371,7 @@ def test_human_input_tool_eof_error() -> None:
     """Tests HumanInputTool returns error result on EOFError."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={"prompt": "Enter value:"},
     )
 
@@ -387,7 +387,7 @@ def test_human_input_tool_keyboard_interrupt() -> None:
     """Tests HumanInputTool returns error result on KeyboardInterrupt."""
     tool = HumanInputTool()
     tool_call = ToolCall(
-        tool_name="human_input",
+        tool_name="from_scratch__human_input",
         arguments={"prompt": "Enter value:"},
     )
 


### PR DESCRIPTION
## Summary

- `HumanInputTool.name` was returning `"human_input"`, missing the `from_scratch__` prefix that both other default tools use
- Updated to `"from_scratch__human_input"` to match `PythonInterpreterTool` (`from_scratch__python_interpreter`) and `ReadFileTool` (`from_scratch__read_file`)
- Updated all test assertions and `ToolCall(tool_name=...)` fixtures accordingly
- Updated the captured log output in `examples/ch08.ipynb`

Closes #703

## Test plan

- [x] `pytest tests/tools/test_default.py -k human_input` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)