### PR TITLE
fix: guard HumanInputTool against empty prompt string (#705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - feat: implement end-of-loop human approval gate in `_process_loop` — adds `with_approval` param to `LLMAgent.run()`, `TaskHandler.request_approval()`, `TaskHandler._prompt_for_approval()`, `ApprovalResult` data structure, three approval template keys, and `rich>=13.9.0` dependency (#688)
 - feat: implement HumanInputTool (#685)
 
-### Fixed
+### Changed
 
 - fix: guard `HumanInputTool.__call__()` against empty or absent `prompt` — returns an error `ToolCallResult` early; `"required"` in the JSON schema guarantees the key is present but not non-empty (#706)
 - fix: add `from_scratch__` prefix to `HumanInputTool.name` to match the naming convention of the other default tools (#704)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - feat: implement end-of-loop human approval gate in `_process_loop` — adds `with_approval` param to `LLMAgent.run()`, `TaskHandler.request_approval()`, `TaskHandler._prompt_for_approval()`, `ApprovalResult` data structure, three approval template keys, and `rich>=13.9.0` dependency (#688)
 - feat: implement HumanInputTool (#685)
 
-### Changed
+### Fixed
 
-- fix: add from_scratch__ prefix to HumanInputTool name (#704)
+- fix: guard `HumanInputTool.__call__()` against empty or absent `prompt` — returns an error `ToolCallResult` early; `"required"` in the JSON schema guarantees the key is present but not non-empty (#706)
+- fix: add `from_scratch__` prefix to `HumanInputTool.name` to match the naming convention of the other default tools (#704)
 
 ## [0.0.19] - 2026-06-23
 

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -80,6 +80,12 @@ class HumanInputTool(BaseTool):
             ToolCallResult: The human's response as the content.
         """
         prompt = tool_call.arguments.get("prompt", "")
+        if not prompt:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="No prompt provided.",
+                error=True,
+            )
         choices = tool_call.arguments.get("choices")
         try:
             console = Console()

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -324,24 +324,26 @@ def test_human_input_tool_passes_prompt_to_input() -> None:
     )
 
 
-def test_human_input_tool_missing_prompt_defaults_to_empty() -> None:
-    """Tests HumanInputTool defaults to empty string when prompt is absent."""
+def test_human_input_tool_missing_prompt_returns_error() -> None:
+    """Tests HumanInputTool returns error when prompt is absent."""
     tool = HumanInputTool()
     tool_call = ToolCall(
         tool_name="from_scratch__human_input",
         arguments={},
     )
+    result = tool(tool_call=tool_call)
+    assert result.error is True
 
-    with (
-        patch("rich.console.Console.print"),
-        patch("rich.prompt.Prompt.ask", return_value="ok") as mock_ask,
-    ):
-        tool(tool_call=tool_call)
 
-    mock_ask.assert_called_once_with(
-        ">",
-        console=mock_ask.call_args.kwargs["console"],
+def test_human_input_tool_empty_prompt_returns_error() -> None:
+    """Tests HumanInputTool returns error when prompt is an empty string."""
+    tool = HumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": ""},
     )
+    result = tool(tool_call=tool_call)
+    assert result.error is True
 
 
 def test_human_input_tool_choices_passed_to_prompt() -> None:


### PR DESCRIPTION
## Summary

- Added an early-return error guard when `prompt` is absent or an empty string
- `"required": ["prompt"]` in the JSON schema only guarantees the key is present — an LLM could still pass `""` and satisfy it
- Also a useful educational example of validating at a system boundary (LLM outputs are external inputs)
- Updated the test that previously expected the tool to proceed on a missing prompt; added a second test for the explicit empty string case

Closes #705

## Test plan

- [x] `pytest tests/tools/test_default.py -k human_input` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)