### PR TITLE
chore: add Ch 7 and Ch 8 notebook links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ core concepts to full multi-agent systems.
 | -- | ----- | -------- |
 | 5 | MCP Tools | [Ch 5](https://masfromscratch.com/notebooks/ch05/) |
 | 6 | Skills | [Ch 6](https://masfromscratch.com/notebooks/ch06/) |
-| 7 | Memory | — |
-| 8 | Human in the Loop | — |
+| 7 | Memory | [Ch 7](https://masfromscratch.com/notebooks/ch07/) |
+| 8 | Human in the Loop | [Ch 8](https://masfromscratch.com/notebooks/ch08/) |
 
 ### Part 3 — Building Multi-Agent Systems
 


### PR DESCRIPTION
## Summary

- `docs/notebooks/ch07.ipynb` and `docs/notebooks/ch08.ipynb` symlinks were already in place
- README table entries for Ch 7 (Memory) and Ch 8 (Human in the Loop) were still showing `—`
- Updated both to link to `https://masfromscratch.com/notebooks/ch07/` and `.../ch08/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)