### PR TITLE
refactor: move _prompt_for_approval inside request_approval()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: move `_prompt_for_approval` inside `request_approval()` as a local function; it was only ever called from there via `asyncio.to_thread` (#709)
 - fix: guard `HumanInputTool.__call__()` against empty or absent `prompt` — returns an error `ToolCallResult` early; `"required"` in the JSON schema guarantees the key is present but not non-empty (#706)
 - fix: add `from_scratch__` prefix to `HumanInputTool.name` to match the naming convention of the other default tools (#704)
 

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -577,43 +577,6 @@ class LLMAgent:
             for memory in self.llm_agent.memories:
                 await memory.record(episode)
 
-        @staticmethod
-        def _prompt_for_approval(
-            proposed_content: str,
-            prompt_text: str,
-            rationale_prompt_text: str,
-        ) -> ApprovalResult:
-            """Render the proposed result and collect a yes/no approval.
-
-            Added in Chapter 8.
-
-            Synchronous helper intended to be called via ``asyncio.to_thread``.
-            Raises ``EOFError`` on closed stdin and ``KeyboardInterrupt`` on
-            operator interrupt — both are handled by the caller.
-
-            Args:
-                proposed_content: The result content to render in a ``Panel``.
-                prompt_text: The yes/no question text.
-                rationale_prompt_text: The rationale prompt shown on rejection.
-
-            Returns:
-                ApprovalResult: ``approved=True`` on yes; ``approved=False``
-                    with the rationale on no.
-            """
-            console = Console()
-            console.print(
-                Panel(
-                    proposed_content,
-                    title="Proposed Task Result",
-                    border_style="cyan",
-                ),
-            )
-            approved = Confirm.ask(prompt_text, console=console)
-            if approved:
-                return ApprovalResult(approved=True, feedback="")
-            feedback = Prompt.ask(rationale_prompt_text, console=console)
-            return ApprovalResult(approved=False, feedback=feedback)
-
         async def request_approval(
             self,
             result: TaskResult,
@@ -635,13 +598,33 @@ class LLMAgent:
             Returns:
                 ApprovalResult: The approval decision.
             """
+
+            def _prompt_for_approval(
+                proposed_content: str,
+                prompt_text: str,
+                rationale_prompt_text: str,
+            ) -> ApprovalResult:
+                console = Console()
+                console.print(
+                    Panel(
+                        proposed_content,
+                        title="Proposed Task Result",
+                        border_style="cyan",
+                    ),
+                )
+                approved = Confirm.ask(prompt_text, console=console)
+                if approved:
+                    return ApprovalResult(approved=True, feedback="")
+                feedback = Prompt.ask(rationale_prompt_text, console=console)
+                return ApprovalResult(approved=False, feedback=feedback)
+
             prompt_text = self.llm_agent.templates["approval_prompt"]
             rationale_prompt_text = self.llm_agent.templates[
                 "approval_rationale_prompt"
             ]
             try:
                 return await asyncio.to_thread(
-                    self._prompt_for_approval,
+                    _prompt_for_approval,
                     result.content,
                     prompt_text,
                     rationale_prompt_text,

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -8,7 +8,6 @@ from llm_agents_from_scratch.agent import LLMAgent
 from llm_agents_from_scratch.agent.templates import default_templates
 from llm_agents_from_scratch.base.llm import BaseLLM
 from llm_agents_from_scratch.data_structures import (
-    ApprovalResult,
     ChatMessage,
     ChatRole,
     NextStepDecision,
@@ -892,9 +891,9 @@ async def test_request_approval_approves(mock_llm: BaseLLM) -> None:
     )
     result = TaskResult(task_id=handler.task.id_, content="mock result")
 
-    with patch(
-        "llm_agents_from_scratch.agent.llm_agent.LLMAgent.TaskHandler._prompt_for_approval",
-        return_value=ApprovalResult(approved=True, feedback=""),
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Confirm.ask", return_value=True),
     ):
         approval = await handler.request_approval(result)
 
@@ -914,12 +913,10 @@ async def test_request_approval_rejects_with_feedback(
     )
     result = TaskResult(task_id=handler.task.id_, content="mock result")
 
-    with patch(
-        "llm_agents_from_scratch.agent.llm_agent.LLMAgent.TaskHandler._prompt_for_approval",
-        return_value=ApprovalResult(
-            approved=False,
-            feedback="needs more detail",
-        ),
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Confirm.ask", return_value=False),
+        patch("rich.prompt.Prompt.ask", return_value="needs more detail"),
     ):
         approval = await handler.request_approval(result)
 
@@ -939,9 +936,9 @@ async def test_request_approval_auto_approves_on_eof(
     )
     result = TaskResult(task_id=handler.task.id_, content="mock result")
 
-    with patch(
-        "llm_agents_from_scratch.agent.llm_agent.LLMAgent.TaskHandler._prompt_for_approval",
-        side_effect=EOFError(),
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Confirm.ask", side_effect=EOFError()),
     ):
         approval = await handler.request_approval(result)
 
@@ -961,64 +958,14 @@ async def test_request_approval_rejects_on_keyboard_interrupt(
     )
     result = TaskResult(task_id=handler.task.id_, content="mock result")
 
-    with patch(
-        "llm_agents_from_scratch.agent.llm_agent.LLMAgent.TaskHandler._prompt_for_approval",
-        side_effect=KeyboardInterrupt(),
+    with (
+        patch("rich.console.Console.print"),
+        patch("rich.prompt.Confirm.ask", side_effect=KeyboardInterrupt()),
     ):
         approval = await handler.request_approval(result)
 
     assert approval.approved is False
     assert approval.feedback == "Interrupted by operator."
-
-
-def test_prompt_for_approval_returns_approved_on_yes() -> None:
-    """Tests _prompt_for_approval returns approved=True when Confirm is yes."""
-    with (
-        patch("rich.prompt.Confirm.ask", return_value=True),
-        patch("rich.prompt.Prompt.ask") as mock_prompt,
-    ):
-        approval = LLMAgent.TaskHandler._prompt_for_approval(
-            "mock content",
-            "Approve?",
-            "Rationale?",
-        )
-
-    assert approval.approved is True
-    assert approval.feedback == ""
-    mock_prompt.assert_not_called()
-
-
-def test_prompt_for_approval_returns_rejected_with_rationale_on_no() -> None:
-    """Tests _prompt_for_approval returns rejected with rationale on no."""
-    with (
-        patch("rich.prompt.Confirm.ask", return_value=False),
-        patch("rich.prompt.Prompt.ask", return_value="fix the math") as mock_p,
-    ):
-        approval = LLMAgent.TaskHandler._prompt_for_approval(
-            "mock content",
-            "Approve?",
-            "Rationale?",
-        )
-
-    assert approval.approved is False
-    assert approval.feedback == "fix the math"
-    mock_p.assert_called_once()
-
-
-def test_prompt_for_approval_uses_approval_template_text() -> None:
-    """Tests _prompt_for_approval passes the template text to Confirm.ask."""
-    with (
-        patch("rich.prompt.Confirm.ask", return_value=True) as mock_confirm,
-        patch("rich.prompt.Prompt.ask"),
-    ):
-        LLMAgent.TaskHandler._prompt_for_approval(
-            "content",
-            "my question",
-            "my rationale",
-        )
-
-    mock_confirm.assert_called_once()
-    assert mock_confirm.call_args.args[0] == "my question"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_prompt_for_approval` was a `@staticmethod` on `TaskHandler` but was only ever called from `request_approval()` via `asyncio.to_thread`. Moving it inside as a local function better matches the actual usage and reduces unnecessary class API surface.

Tests that previously patched the static method now patch at the `rich` layer (`Confirm.ask`, `Prompt.ask`), which is the right level of abstraction anyway.

## Test plan

- [x] `pytest tests/agent/test_task_handler.py -k approval` — 4 passed
- [x] `pytest tests/` — 356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)