### PR TITLE
refactor: remove approval_prompt and approval_rationale_prompt from template system (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: remove `approval_prompt` and `approval_rationale_prompt` from `LLMAgentTemplates` — human-facing strings rendered by `rich`, not LLM prompts; hardcoded directly in `_prompt_for_approval()`; `TaskResult` now passed directly instead of its content string (#711)
 - refactor: move `_prompt_for_approval` inside `request_approval()` as a local function; it was only ever called from there via `asyncio.to_thread` (#709)
 - fix: guard `HumanInputTool.__call__()` against empty or absent `prompt` — returns an error `ToolCallResult` early; `"required"` in the JSON schema guarantees the key is present but not non-empty (#706)
 - fix: add `from_scratch__` prefix to `HumanInputTool.name` to match the naming convention of the other default tools (#704)

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -600,12 +600,12 @@ class LLMAgent:
             """
 
             def _prompt_for_approval(
-                proposed_content: str,
+                task_result: TaskResult,
             ) -> ApprovalResult:
                 console = Console()
                 console.print(
                     Panel(
-                        proposed_content,
+                        task_result.content,
                         title="Proposed Task Result",
                         border_style="cyan",
                     ),
@@ -622,7 +622,7 @@ class LLMAgent:
             try:
                 return await asyncio.to_thread(
                     _prompt_for_approval,
-                    result.content,
+                    result,
                 )
             except EOFError:
                 self.logger.info(

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -601,8 +601,6 @@ class LLMAgent:
 
             def _prompt_for_approval(
                 proposed_content: str,
-                prompt_text: str,
-                rationale_prompt_text: str,
             ) -> ApprovalResult:
                 console = Console()
                 console.print(
@@ -612,19 +610,19 @@ class LLMAgent:
                         border_style="cyan",
                     ),
                 )
-                approved = Confirm.ask(prompt_text, console=console)
+                approved = Confirm.ask("Approve this result?", console=console)
                 if approved:
                     return ApprovalResult(approved=True, feedback="")
-                feedback = Prompt.ask(rationale_prompt_text, console=console)
+                feedback = Prompt.ask(
+                    "Provide your correction rationale for the LLM agent to address",  # noqa: E501
+                    console=console,
+                )
                 return ApprovalResult(approved=False, feedback=feedback)
 
             try:
                 return await asyncio.to_thread(
                     _prompt_for_approval,
                     result.content,
-                    "Approve this result?",
-                    "Provide your correction rationale for the agent"
-                    " to address",
                 )
             except EOFError:
                 self.logger.info(

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -618,16 +618,13 @@ class LLMAgent:
                 feedback = Prompt.ask(rationale_prompt_text, console=console)
                 return ApprovalResult(approved=False, feedback=feedback)
 
-            prompt_text = self.llm_agent.templates["approval_prompt"]
-            rationale_prompt_text = self.llm_agent.templates[
-                "approval_rationale_prompt"
-            ]
             try:
                 return await asyncio.to_thread(
                     _prompt_for_approval,
                     result.content,
-                    prompt_text,
-                    rationale_prompt_text,
+                    "Approve this result?",
+                    "Provide your correction rationale for the agent"
+                    " to address",
                 )
             except EOFError:
                 self.logger.info(

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -99,12 +99,6 @@ result directly unless instructed otherwise.
 {memories}
 </memories>""".strip()
 
-DEFAULT_APPROVAL_PROMPT = "Approve this result?"
-
-DEFAULT_APPROVAL_RATIONALE_PROMPT = (
-    "Provide your correction rationale for the agent to address"
-)
-
 DEFAULT_APPROVAL_REJECTION_FEEDBACK = """The human operator REJECTED your \
 proposed task result. Revise your approach and try again.
 

--- a/src/llm_agents_from_scratch/agent/templates/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/templates/llm_agent.py
@@ -3,8 +3,6 @@
 from typing import TypedDict
 
 from .defaults import (
-    DEFAULT_APPROVAL_PROMPT,
-    DEFAULT_APPROVAL_RATIONALE_PROMPT,
     DEFAULT_APPROVAL_REJECTION_FEEDBACK,
     DEFAULT_GET_NEXT_INSTRUCTION_PROMPT,
     DEFAULT_MEMORIES_BLOCK,
@@ -36,8 +34,6 @@ class LLMAgentTemplates(TypedDict):
     # added in ch07
     memories: str
     # added in ch08
-    approval_prompt: str
-    approval_rationale_prompt: str
     approval_rejection_feedback: str
 
 
@@ -55,7 +51,5 @@ default_templates = LLMAgentTemplates(
     # added in ch07
     memories=DEFAULT_MEMORIES_BLOCK,
     # added in ch08
-    approval_prompt=DEFAULT_APPROVAL_PROMPT,
-    approval_rationale_prompt=DEFAULT_APPROVAL_RATIONALE_PROMPT,
     approval_rejection_feedback=DEFAULT_APPROVAL_REJECTION_FEEDBACK,
 )


### PR DESCRIPTION
## Summary

`approval_prompt` and `approval_rationale_prompt` were in `LLMAgentTemplates` but are human-facing strings rendered by `rich`, not LLM prompts. They don't belong in the template system.

- Removed both fields from `LLMAgentTemplates` and `default_templates`
- Dropped `DEFAULT_APPROVAL_PROMPT` and `DEFAULT_APPROVAL_RATIONALE_PROMPT` from `defaults.py`
- Hardcoded the strings directly in `_prompt_for_approval()` where they're used
- `DEFAULT_APPROVAL_REJECTION_FEEDBACK` is unchanged — it's a genuine LLM prompt

Closes #710

## Test plan

- [x] `pytest tests/` — 356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)