### PR TITLE
fix: KeyboardInterrupt in request_approval() should auto-approve (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- fix: `KeyboardInterrupt` in `request_approval()` now auto-approves (consistent with `EOFError`) instead of rejecting (#713)
 - refactor: remove `approval_prompt` and `approval_rationale_prompt` from `LLMAgentTemplates` — human-facing strings rendered by `rich`, not LLM prompts; hardcoded directly in `_prompt_for_approval()`; `TaskResult` now passed directly instead of its content string (#711)
 - refactor: move `_prompt_for_approval` inside `request_approval()` as a local function; it was only ever called from there via `asyncio.to_thread` (#709)
 - fix: guard `HumanInputTool.__call__()` against empty or absent `prompt` — returns an error `ToolCallResult` early; `"required"` in the JSON schema guarantees the key is present but not non-empty (#706)

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -631,11 +631,11 @@ class LLMAgent:
                 return ApprovalResult(approved=True, feedback="")
             except KeyboardInterrupt:
                 self.logger.info(
-                    "Approval prompt interrupted by operator; rejecting.",
+                    "Approval prompt interrupted by operator; auto-approving.",
                 )
                 return ApprovalResult(
-                    approved=False,
-                    feedback="Interrupted by operator.",
+                    approved=True,
+                    feedback="",
                 )
 
     class SupervisedTaskHandler(TaskHandler):

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -950,7 +950,7 @@ async def test_request_approval_auto_approves_on_eof(
 async def test_request_approval_rejects_on_keyboard_interrupt(
     mock_llm: BaseLLM,
 ) -> None:
-    """Tests request_approval rejects with interruption note on Ctrl-C."""
+    """Tests request_approval auto-approves on Ctrl-C (consistent with EOF)."""
     agent = LLMAgent(llm=mock_llm)
     handler = LLMAgent.TaskHandler(
         llm_agent=agent,
@@ -964,8 +964,8 @@ async def test_request_approval_rejects_on_keyboard_interrupt(
     ):
         approval = await handler.request_approval(result)
 
-    assert approval.approved is False
-    assert approval.feedback == "Interrupted by operator."
+    assert approval.approved is True
+    assert approval.feedback == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

On `KeyboardInterrupt`, `request_approval()` was returning `approved=False` with feedback `"Interrupted by operator."`. This is inconsistent with the `EOFError` path, which auto-approves.

Both cases represent an operator who cannot interact with the terminal — auto-approving is the safer default in both.

Closes #712

## Test plan

- [x] `pytest tests/` — 356 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)