### PR TITLE
chore: fix request_approval() docstring — KeyboardInterrupt auto-approves

### DIFF
--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -588,9 +588,8 @@ class LLMAgent:
             Operator-gated human-in-the-loop pattern; unlike
             ``HumanInputTool``, the pause is not agent-initiated.
             Runs the blocking rich prompts in a thread via
-            ``asyncio.to_thread``. Auto-approves on ``EOFError``
-            (headless); rejects with an interruption note on
-            ``KeyboardInterrupt``.
+            ``asyncio.to_thread``. Auto-approves on ``EOFError`` or
+            ``KeyboardInterrupt`` (headless / interrupted terminal).
 
             Args:
                 result (TaskResult): The proposed task result to review.


### PR DESCRIPTION
Missed in #713 — docstring still said "rejects with an interruption note on `KeyboardInterrupt`" after the behaviour was changed to auto-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)