### PR TITLE
chore: fix correction rationale prompt text in ch08.ipynb Example 2

### DIFF
--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -431,10 +431,10 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provide your correction rationale for the agent to address: </pre>\n"
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Provide your correction rationale for the LLM agent to address: </pre>\n"
       ],
       "text/plain": [
-       "Provide your correction rationale for the agent to address: "
+       "Provide your correction rationale for the LLM agent to address: "
       ]
      },
      "metadata": {},


### PR DESCRIPTION
Captured output in Example 2 still showed the old string `"for the agent to address"` — updated to match the hardcoded text in `_prompt_for_approval()`: `"for the LLM agent to address"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)