### PR TITLE
feat: add run_supervised_with_skill() to LLMAgent (#717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat: add `LLMAgent.run_supervised_with_skill()` — combines skill-activation framing with caller-controlled stepwise execution; returns a `SupervisedTaskHandler` ready for `get_next_step()` / `run_step()` (#719)
 - feat: `SupervisedTaskHandler.complete()` raises `TaskHandlerError` at runtime when passed a non-`TaskResult` argument (#694)
 - feat: add `LLMAgent.run_supervised()` and `LLMAgent.SupervisedTaskHandler` — human-driven stepwise execution; caller controls cadence via `get_next_step()` / `run_step()` and finalises with `complete()`, `reject()`, or `abort()` (#693)
 - feat: introduce `RejectedTaskResult` data structure; `get_next_step` accepts `TaskStepResult | RejectedTaskResult | None` and dispatches by type — rejection routes deterministically to a new `TaskStep` without consulting the LLM; `_process_loop` captures raw `failed_result_content` + `feedback`; rejection template now includes `<proposed-result>` alongside `<human-correction>`; `HumanInputTool` styled with yellow `Panel` (#691)

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -899,3 +899,47 @@ class LLMAgent:
         )
         await task_handler.load_memories()
         return task_handler
+
+    async def run_supervised_with_skill(
+        self,
+        skill_name: str,
+        prompt: str | None = None,
+        skills_scopes: list[SkillScope] | None = None,
+        explicit_only_skills: set[str] | None = None,
+    ) -> SupervisedTaskHandler:
+        """Human-driven stepwise execution with a pre-loaded skill.
+
+        Added in Chapter 8. Combines ``run_with_skill()`` (skill
+        activation framing) with ``run_supervised()`` (caller-controlled
+        cadence). The named skill is embedded in the task instruction so
+        the model activates it as its first action; the caller then
+        drives execution cell-by-cell via ``get_next_step()`` and
+        ``run_step()``.
+
+        Args:
+            skill_name (str): Name of the skill to activate.
+            prompt (str | None): Optional instruction to pass alongside
+                the skill activation. Defaults to None.
+            skills_scopes (list[SkillScope] | None): Scopes to scan for
+                skills. Defaults to ``[USER, PROJECT]``.
+            explicit_only_skills (set[str] | None): Skill names to
+                exclude from the model catalog. Defaults to None.
+
+        Returns:
+            SupervisedTaskHandler: Ready for stepwise execution.
+        """
+        if prompt:
+            instruction = EXPLICIT_SKILL_ACTIVATION_WITH_PROMPT_TEMPLATE.format(
+                name=skill_name,
+                prompt=prompt,
+            )
+        else:
+            instruction = EXPLICIT_SKILL_ACTIVATION_TEMPLATE.format(
+                name=skill_name,
+            )
+        task = Task(instruction=instruction)
+        return await self.run_supervised(
+            task=task,
+            skills_scopes=skills_scopes,
+            explicit_only_skills=explicit_only_skills,
+        )

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -192,6 +192,58 @@ def test_run_with_skill_with_prompt(mock_llm: BaseLLM) -> None:
     assert task.instruction == expected
 
 
+@pytest.mark.asyncio
+async def test_run_supervised_with_skill_no_prompt(mock_llm: BaseLLM) -> None:
+    """Tests run_supervised_with_skill builds instruction without prompt."""
+    agent = LLMAgent(llm=mock_llm)
+
+    with patch.object(
+        agent,
+        "run_supervised",
+        new_callable=AsyncMock,
+    ) as mock_sup:
+        await agent.run_supervised_with_skill("summarize")
+
+    task = mock_sup.call_args.kwargs["task"]
+    expected = EXPLICIT_SKILL_ACTIVATION_TEMPLATE.format(name="summarize")
+    assert task.instruction == expected
+
+
+@pytest.mark.asyncio
+async def test_run_supervised_with_skill_with_prompt(mock_llm: BaseLLM) -> None:
+    """Tests run_supervised_with_skill builds instruction with prompt."""
+    agent = LLMAgent(llm=mock_llm)
+
+    with patch.object(
+        agent,
+        "run_supervised",
+        new_callable=AsyncMock,
+    ) as mock_sup:
+        await agent.run_supervised_with_skill(
+            "summarize",
+            prompt="Summarize this doc",
+        )
+
+    task = mock_sup.call_args.kwargs["task"]
+    expected = EXPLICIT_SKILL_ACTIVATION_WITH_PROMPT_TEMPLATE.format(
+        name="summarize",
+        prompt="Summarize this doc",
+    )
+    assert task.instruction == expected
+
+
+@pytest.mark.asyncio
+async def test_run_supervised_with_skill_returns_supervised_task_handler(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests run_supervised_with_skill returns a SupervisedTaskHandler."""
+    agent = LLMAgent(llm=mock_llm)
+
+    handler = await agent.run_supervised_with_skill("summarize")
+
+    assert isinstance(handler, LLMAgent.SupervisedTaskHandler)
+
+
 # Memory record tests (Chapter 7)
 
 


### PR DESCRIPTION
## Summary

Adds `run_supervised_with_skill()` — the missing combination of skill-activation framing and caller-controlled stepwise execution.

Previously you had to choose one or the other:
- `run_with_skill()` → skill loaded, agent runs autonomously
- `run_supervised()` → caller drives step-by-step, no skill

Now you can do both:

```python
task_handler = await agent.run_supervised_with_skill(
    "meeting-notes-summarizer",
    prompt="Summarise the following transcript: ...",
)
step = await task_handler.get_next_step(None)
# drive execution cell-by-cell...
```

The implementation simply builds the skill-activation instruction (same as `run_with_skill()`) and delegates to `run_supervised()`.

Closes #717

## Test plan

- [x] `pytest tests/agent/test_agent.py -k supervised_with_skill` — 3 passed
- [x] `pytest tests/` — 359 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)