### PR TITLE
docs: add UML class diagram for HumanInputTool

### DIFF
--- a/uml/ch08/human_input_tool.puml
+++ b/uml/ch08/human_input_tool.puml
@@ -1,0 +1,27 @@
+@startuml uml_human_input_tool
+!include ../common/book-clean.puml
+
+package "llm_agents_from_scratch.base.tool" <<Folder>> {
+  abstract class BaseTool {
+    +name: str
+    +description: str
+    +parameters_json_schema: dict[str, Any]
+    --
+    +__call__(tool_call: ToolCall): ToolCallResult
+  }
+}
+
+package "llm_agents_from_scratch.tools.default" <<Folder>> {
+  class HumanInputTool {
+    +name: str = 'from_scratch__human_input'
+    +description: str
+    +parameters_json_schema: dict[str, Any]\n\t{prompt: str, choices: list[str] | None}
+    --
+    +__call__(tool_call: ToolCall, ...): ToolCallResult
+  }
+}
+
+' Relations
+BaseTool <|-- HumanInputTool : " inherits"
+
+@enduml


### PR DESCRIPTION
Adds `uml/ch08/human_input_tool.puml` — the Ch8 UML class diagram for `HumanInputTool`.

- Shows inheritance from `BaseTool`, the overridden `name` / `description` / `parameters_json_schema` properties, and `__call__`
- Parameters schema (`prompt` required, `choices` optional) is inlined in the class box
- Styled after `uml/ch06/use_skill_tool.puml` (includes `common/book-clean.puml`)
- First diagram under `uml/ch08/`

Not registered in `book_figures.yml` — that file currently only tracks `ch01` (ch02+ are commented out), so ch08 numbering can be added when the chapter's figures are exported.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)