### PR TITLE
docs: add UML class diagram for approval gate data structures

### DIFF
--- a/uml/ch08/approval_gate_data_structures.puml
+++ b/uml/ch08/approval_gate_data_structures.puml
@@ -1,0 +1,28 @@
+@startuml approval_gate_data_structures
+!include ../common/book-clean.puml
+
+' External dependencies
+package "external_dependencies" <<Folder>> {
+  class "pydantic.BaseModel" as BaseModel
+}
+
+package "llm_agents_from_scratch.data_structures.agent" <<Folder>> {
+
+  class ApprovalResult {
+    +approved: bool
+    +feedback: str = ""
+    --
+    +__str__(): str
+  }
+
+  class RejectedTaskResult {
+    +failed_result_content: str
+    +feedback: str
+  }
+}
+
+' Relations
+BaseModel <|-- ApprovalResult : " inherits"
+BaseModel <|-- RejectedTaskResult : " inherits"
+
+@enduml


### PR DESCRIPTION
Adds `uml/ch08/approval_gate_data_structures.puml` — a single figure covering the Ch8 approval-gate data structures.

- `ApprovalResult` (`approved`, `feedback`, `__str__`) and `RejectedTaskResult` (`failed_result_content`, `feedback`), both inheriting `pydantic.BaseModel`
- Styled after `uml/ch07/episode.puml`

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)