### PR TITLE
docs: add UML class diagram for ch08 approval gate updates

### DIFF
--- a/uml/ch08/taskhandler.puml
+++ b/uml/ch08/taskhandler.puml
@@ -1,0 +1,54 @@
+@startuml uml_ch08_taskhandler_updates
+!include ../common/book-clean.puml
+left to right direction
+
+package "llm_agents_from_scratch.data_structures" <<Folder>> {
+  class ApprovalResult {
+    +approved: bool
+    +feedback: str = ""
+  }
+
+  class RejectedTaskResult {
+    +failed_result_content: str
+    +feedback: str
+  }
+}
+
+package "llm_agents_from_scratch.agent" <<Folder>> {
+
+  class LLMAgent {
+    <color:#aaaaaa>+llm: LLM</color>
+    <color:#aaaaaa>+tools_registry: dict[str, Tool]</color>
+    <color:#aaaaaa>+templates: LLMAgentTemplates</color>
+    <color:#aaaaaa>+logger: Logger</color>
+    <color:#aaaaaa>+memories: list[Memory]</color>
+    --
+    <color:#aaaaaa>+tools: list[Tool]</color>
+    <color:#aaaaaa>+add_tool(tool: Tool): Self</color>
+    +<b>run(task: Task, ...,</b>\n\t<b>with_approval: bool = False</b>\n<b>): TaskHandler</b>
+  }
+
+  class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>+llm_agent: LLMAgent</color>
+    <color:#aaaaaa>+task: Task</color>
+    <color:#aaaaaa>+rollout: str</color>
+    <color:#aaaaaa>+step_counter: int</color>
+    <color:#aaaaaa>-_background_task: ~asyncio.Task</color>
+    <color:#aaaaaa>+skills: dict[str, Skill]</color>
+    <color:#aaaaaa>-_recalled_memories: str</color>
+    --
+    +<b><<async>> get_next_step(</b>\n\t<b>previous_step_result: TaskStepResult</b>\n\t\t<b>| RejectedTaskResult | None</b>\n<b>): TaskStep | TaskResult</b>
+    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
+    <color:#aaaaaa>-_format_step_for_rollout()</color>
+    <color:#aaaaaa>+<<async>> load_memories(): None</color>
+    <color:#aaaaaa>+<<async>> record_memory(...): None</color>
+    +<b><<async>> request_approval(</b>\n\t<b>result: TaskResult</b>\n<b>): ApprovalResult</b>
+  }
+}
+
+' Relations
+LLMAgent *-- TaskHandler : " has"
+TaskHandler ..> ApprovalResult : " returns"
+TaskHandler ..> RejectedTaskResult : " consumes"
+
+@enduml

--- a/uml/ch08/taskhandler.puml
+++ b/uml/ch08/taskhandler.puml
@@ -30,7 +30,7 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     <color:#aaaaaa>-_format_step_for_rollout()</color>
     <color:#aaaaaa>+<<async>> load_memories(): None</color>
     <color:#aaaaaa>+<<async>> record_memory(...): None</color>
-    +<b><<async>> request_approval(</b>\n\t<b>result: TaskResult</b>\n<b>): ApprovalResult</b>
+    +<<async>> request_approval(\n\tresult: TaskResult\n): ApprovalResult
   }
 }
 

--- a/uml/ch08/taskhandler.puml
+++ b/uml/ch08/taskhandler.puml
@@ -2,18 +2,6 @@
 !include ../common/book-clean.puml
 left to right direction
 
-package "llm_agents_from_scratch.data_structures" <<Folder>> {
-  class ApprovalResult {
-    +approved: bool
-    +feedback: str = ""
-  }
-
-  class RejectedTaskResult {
-    +failed_result_content: str
-    +feedback: str
-  }
-}
-
 package "llm_agents_from_scratch.agent" <<Folder>> {
 
   class LLMAgent {
@@ -48,7 +36,5 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
 
 ' Relations
 LLMAgent *-- TaskHandler : " has"
-TaskHandler ..> ApprovalResult : " returns"
-TaskHandler ..> RejectedTaskResult : " consumes"
 
 @enduml

--- a/uml/ch08/taskhandler_llmagent_updates_for_approval_gate.puml
+++ b/uml/ch08/taskhandler_llmagent_updates_for_approval_gate.puml
@@ -23,11 +23,15 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     <color:#aaaaaa>+step_counter: int</color>
     <color:#aaaaaa>-_background_task: ~asyncio.Task</color>
     <color:#aaaaaa>+skills: dict[str, Skill]</color>
+    <color:#aaaaaa>-_skills_catalog: str</color>
+    <color:#aaaaaa>-_use_skill_tool: UseSkillTool | None</color>
+    <color:#aaaaaa>-_explicit_only_skills: set[str]</color>
     <color:#aaaaaa>-_recalled_memories: str</color>
     --
     +<b><<async>> get_next_step(</b>\n\t<b>previous_step_result: TaskStepResult</b>\n\t\t<b>| RejectedTaskResult | None</b>\n<b>): TaskStep | TaskResult</b>
     <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
     <color:#aaaaaa>-_format_step_for_rollout()</color>
+    <color:#aaaaaa>-_format_memories_for_system_prompt(...): str</color>
     <color:#aaaaaa>+<<async>> load_memories(): None</color>
     <color:#aaaaaa>+<<async>> record_memory(...): None</color>
     +<<async>> request_approval(\n\tresult: TaskResult\n): ApprovalResult

--- a/uml/ch08/taskhandler_llmagent_updates_for_approval_gate.puml
+++ b/uml/ch08/taskhandler_llmagent_updates_for_approval_gate.puml
@@ -1,4 +1,4 @@
-@startuml uml_ch08_taskhandler_updates
+@startuml uml_ch08_taskhandler_llmagent_updates_for_approval_gate
 !include ../common/book-clean.puml
 left to right direction
 


### PR DESCRIPTION
Adds `uml/ch08/taskhandler.puml` (`uml_ch08_taskhandler_updates`) — the Ch8 updates to `LLMAgent` and `LLMAgent.TaskHandler` that enable the end-of-loop result approval gate.

Follows the Ch6/Ch7 convention (`uml/ch07/taskhandler.puml`): pre-existing members greyed out, new/changed members bolded.

- **`LLMAgent.run(...)`** — CHANGED: new `with_approval: bool = False` flag
- **`TaskHandler.get_next_step(...)`** — CHANGED: now accepts `RejectedTaskResult`, bypassing LLM routing on rejection
- **`TaskHandler.request_approval(result: TaskResult) -> ApprovalResult`** — NEW
- Dashed dependency arrows to `RejectedTaskResult` (consumes) and `ApprovalResult` (returns)

`_prompt_for_approval` is intentionally omitted — it's a nested function inside `request_approval()`, not part of the class's public UML surface.

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)