### PR TITLE
docs: add UML class diagram for SupervisedTaskHandler

### DIFF
--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -1,9 +1,12 @@
 @startuml uml_ch08_supervised_taskhandler
 !include ../common/book-clean.puml
+left to right direction
 
 package "llm_agents_from_scratch.agent" <<Folder>> {
 
   class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>...</color>
+    --
     <color:#aaaaaa>...</color>
   }
 
@@ -33,5 +36,8 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
 
 ' Relations
 TaskHandler <|-- SupervisedTaskHandler : " inherits"
+
+' Layout only: keep all three on one row
+LLMAgent -[hidden]- TaskHandler
 
 @enduml

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -3,6 +3,18 @@
 
 package "llm_agents_from_scratch.agent" <<Folder>> {
 
+  class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>...</color>
+  }
+
+  class "LLMAgent.SupervisedTaskHandler" as SupervisedTaskHandler {
+    +<<override>> background_task\n\t{getter and setter raise TaskHandlerError}
+    --
+    +<<async>> complete(result: TaskResult): None
+    +reject(\n\tresult: TaskResult,\n\tfeedback: str\n): RejectedTaskResult
+    +<<async>> abort(\n\terror: Exception | None = None\n): None
+  }
+
   class LLMAgent {
     <color:#aaaaaa>+llm: LLM</color>
     <color:#aaaaaa>+tools_registry: dict[str, Tool]</color>
@@ -16,23 +28,6 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
     <color:#aaaaaa>+run_with_skill(skill_name: str, ...): TaskHandler</color>
     +<<async>> run_supervised(\n\ttask: Task, ...\n): SupervisedTaskHandler
     +<<async>> run_supervised_with_skill(\n\tskill_name: str, prompt: str | None, ...\n): SupervisedTaskHandler
-  }
-
-  class "LLMAgent.TaskHandler" as TaskHandler {
-    <color:#aaaaaa>+background_task: ~asyncio.Task</color>
-    <color:#aaaaaa>+<<async>> get_next_step(...): TaskStep | TaskResult</color>
-    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
-    <color:#aaaaaa>+<<async>> request_approval(...): ApprovalResult</color>
-    <color:#aaaaaa>+<<async>> load_memories(): None</color>
-    <color:#aaaaaa>+<<async>> record_memory(...): None</color>
-  }
-
-  class "LLMAgent.SupervisedTaskHandler" as SupervisedTaskHandler {
-    +<<override>> background_task\n\t{getter and setter raise TaskHandlerError}
-    --
-    +<<async>> complete(result: TaskResult): None
-    +reject(\n\tresult: TaskResult,\n\tfeedback: str\n): RejectedTaskResult
-    +<<async>> abort(\n\terror: Exception | None = None\n): None
   }
 }
 

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -1,0 +1,44 @@
+@startuml uml_ch08_supervised_taskhandler
+!include ../common/book-clean.puml
+left to right direction
+
+package "llm_agents_from_scratch.agent" <<Folder>> {
+
+  class LLMAgent {
+    <color:#aaaaaa>+llm: LLM</color>
+    <color:#aaaaaa>+tools_registry: dict[str, Tool]</color>
+    <color:#aaaaaa>+templates: LLMAgentTemplates</color>
+    <color:#aaaaaa>+logger: Logger</color>
+    <color:#aaaaaa>+memories: list[Memory]</color>
+    --
+    <color:#aaaaaa>+tools: list[Tool]</color>
+    <color:#aaaaaa>+add_tool(tool: Tool): Self</color>
+    <color:#aaaaaa>+run(task: Task, ...): TaskHandler</color>
+    <color:#aaaaaa>+run_with_skill(skill_name: str, ...): TaskHandler</color>
+    +<<async>> run_supervised(\n\ttask: Task, ...\n): SupervisedTaskHandler
+    +<<async>> run_supervised_with_skill(\n\tskill_name: str, prompt: str | None, ...\n): SupervisedTaskHandler
+  }
+
+  class "LLMAgent.TaskHandler" as TaskHandler {
+    <color:#aaaaaa>+background_task: ~asyncio.Task</color>
+    <color:#aaaaaa>+<<async>> get_next_step(...): TaskStep | TaskResult</color>
+    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
+    <color:#aaaaaa>+<<async>> request_approval(...): ApprovalResult</color>
+    <color:#aaaaaa>+<<async>> load_memories(): None</color>
+    <color:#aaaaaa>+<<async>> record_memory(...): None</color>
+  }
+
+  class "LLMAgent.SupervisedTaskHandler" as SupervisedTaskHandler {
+    +<<override>> background_task\n\t{getter and setter raise TaskHandlerError}
+    --
+    +<<async>> complete(result: TaskResult): None
+    +reject(\n\tresult: TaskResult,\n\tfeedback: str\n): RejectedTaskResult
+    +<<async>> abort(\n\terror: Exception | None = None\n): None
+  }
+}
+
+' Relations
+TaskHandler <|-- SupervisedTaskHandler : " inherits"
+LLMAgent *-- SupervisedTaskHandler : " has"
+
+@enduml

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -6,6 +6,8 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
   class "LLMAgent.TaskHandler" as TaskHandler {
     <color:#aaaaaa>...</color>
     --
+    <color:#aaaaaa>+<<async>> get_next_step(...): TaskStep | TaskResult</color>
+    <color:#aaaaaa>+<<async>> run_step(step: TaskStep): TaskStepResult</color>
     <color:#aaaaaa>...</color>
   }
 

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -1,6 +1,5 @@
 @startuml uml_ch08_supervised_taskhandler
 !include ../common/book-clean.puml
-left to right direction
 
 package "llm_agents_from_scratch.agent" <<Folder>> {
 
@@ -39,6 +38,5 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
 
 ' Relations
 TaskHandler <|-- SupervisedTaskHandler : " inherits"
-LLMAgent *-- SupervisedTaskHandler : " has"
 
 @enduml

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -1,5 +1,6 @@
 @startuml uml_ch08_supervised_taskhandler
 !include ../common/book-clean.puml
+skinparam ranksep 25
 
 package "llm_agents_from_scratch.agent" <<Folder>> {
 

--- a/uml/ch08/supervised_taskhandler.puml
+++ b/uml/ch08/supervised_taskhandler.puml
@@ -1,6 +1,5 @@
 @startuml uml_ch08_supervised_taskhandler
 !include ../common/book-clean.puml
-left to right direction
 
 package "llm_agents_from_scratch.agent" <<Folder>> {
 
@@ -35,9 +34,10 @@ package "llm_agents_from_scratch.agent" <<Folder>> {
 }
 
 ' Relations
-TaskHandler <|-- SupervisedTaskHandler : " inherits"
+TaskHandler <|-right- SupervisedTaskHandler : " inherits"
 
-' Layout only: keep all three on one row
+' Layout only: LLMAgent centred on the row above the handlers
 LLMAgent -[hidden]- TaskHandler
+LLMAgent -[hidden]- SupervisedTaskHandler
 
 @enduml


### PR DESCRIPTION
Adds `uml/ch08/supervised_taskhandler.puml` (Figure 8.8) — the caller-driven supervised-execution mode.

**`LLMAgent.SupervisedTaskHandler(TaskHandler)`** — all new:
- `background_task` — marked `«override»`; getter and setter both raise `TaskHandlerError`
- `complete(result) -> None`, `reject(result, feedback) -> RejectedTaskResult`, `abort(error) -> None`

**`LLMAgent`** — new `run_supervised()` and `run_supervised_with_skill()` in regular font; everything else greyed, including `run()` and the `with_approval` gate from #727.

The parent `TaskHandler` box is fully greyed and shows only the members a supervised caller drives (`get_next_step`, `run_step`, `request_approval`, `load_memories`, `record_memory`, `background_task`).

Note: the placeholder omitted `run_supervised_with_skill()` — included here.

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)