### PR TITLE
feat: add json_prompt_mode to OllamaLLM for cloud model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-- ...
+- feat: add `json_prompt_mode` flag to `OllamaLLM` — prompt-level JSON coercion for structured output, working around cloud models that ignore the Ollama `format` parameter; not covered in the book (#735)
 
 ## [0.0.20] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added
+
 - feat: add `json_prompt_mode` flag to `OllamaLLM` — prompt-level JSON coercion for structured output, working around cloud models that ignore the Ollama `format` parameter; not covered in the book (#735)
 
 ## [0.0.20] - 2026-07-13

--- a/more-examples/ch08/skill_with_human_input.ipynb
+++ b/more-examples/ch08/skill_with_human_input.ipynb
@@ -47,10 +47,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "c8-swhi-0004",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -110,7 +118,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "22244ba6-7995-49c3-9323-bb82b3960167",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"glm-5.2:cloud\" if \"OLLAMA_API_KEY\" in os.environ else \"qwen3:14b\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "c8-swhi-0005",
    "metadata": {},
    "outputs": [],
@@ -125,30 +143,255 @@
     "enable_console_logging(logging.INFO)\n",
     "\n",
     "human_input_tool = HumanInputTool()\n",
-    "llm = OllamaLLM(model=\"qwen3:14b\", think=False)\n",
+    "llm = OllamaLLM(model=model, think=False, json_prompt_mode=True)\n",
     "agent = LLMAgent(llm=llm, tools=[human_input_tool])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "c8-swhi-0006",
    "metadata": {},
    "outputs": [],
-   "source": "TRANSCRIPT = \"\"\"\\\nSprint 14 Planning — 2026-06-27\n\nAttendees: Priya (PM), Marcus (Lead Eng), Leila (Backend),\nTom (Frontend), Ana (QA)\n\nPriya opened by reviewing Sprint 13 velocity: 42 points delivered against a\ntarget of 45. Two stories were rolled over — the pagination refactor (8 pts)\nand the email digest feature (5 pts). Both are high priority for Sprint 14.\n\nMarcus flagged a dependency risk: the pagination refactor depends on a database\nmigration scheduled for next Tuesday. If the migration slips, the refactor\ncannot be merged. The team agreed to move the migration to Monday to de-risk.\n\nLeila volunteered to pick up the email digest feature and estimated three days\nof backend work. Tom said he'd need one day of frontend work once Leila's API\nis ready. Ana will write the test plan today so it's ready for review by\nWednesday.\n\nSprint 14 commitments (44 points total):\n- Pagination refactor: 8 pts — Marcus, Leila\n- Email digest: 5 pts — Leila, Tom\n- Auth token refresh: 3 pts — Leila\n- Dashboard chart improvements: 13 pts — Tom\n- Automated regression suite: 8 pts — Ana\n- Performance monitoring alerts: 7 pts — Marcus\n\nPriya reminded the team that the release is scheduled for July 11. All Sprint 14\nwork must be merged and QA-approved by July 9.\n\nMeeting closed at 10:24.\n\"\"\""
+   "source": [
+    "TRANSCRIPT = \"\"\"\\\n",
+    "Sprint 14 Planning — 2026-06-27\n",
+    "\n",
+    "Attendees: Priya (PM), Marcus (Lead Eng), Leila (Backend),\n",
+    "Tom (Frontend), Ana (QA)\n",
+    "\n",
+    "Priya opened by reviewing Sprint 13 velocity: 42 points delivered against a\n",
+    "target of 45. Two stories were rolled over — the pagination refactor (8 pts)\n",
+    "and the email digest feature (5 pts). Both are high priority for Sprint 14.\n",
+    "\n",
+    "Marcus flagged a dependency risk: the pagination refactor depends on a database\n",
+    "migration scheduled for next Tuesday. If the migration slips, the refactor\n",
+    "cannot be merged. The team agreed to move the migration to Monday to de-risk.\n",
+    "\n",
+    "Leila volunteered to pick up the email digest feature and estimated three days\n",
+    "of backend work. Tom said he'd need one day of frontend work once Leila's API\n",
+    "is ready. Ana will write the test plan today so it's ready for review by\n",
+    "Wednesday.\n",
+    "\n",
+    "Sprint 14 commitments (44 points total):\n",
+    "- Pagination refactor: 8 pts — Marcus, Leila\n",
+    "- Email digest: 5 pts — Leila, Tom\n",
+    "- Auth token refresh: 3 pts — Leila\n",
+    "- Dashboard chart improvements: 13 pts — Tom\n",
+    "- Automated regression suite: 8 pts — Ana\n",
+    "- Performance monitoring alerts: 7 pts — Marcus\n",
+    "\n",
+    "Priya reminded the team that the release is scheduled for July 11. All Sprint 14\n",
+    "work must be merged and QA-approved by July 9.\n",
+    "\n",
+    "Meeting closed at 10:24.\n",
+    "\"\"\""
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3c26a7c2",
-   "source": "## Running the Skill\n\nWhen the agent activates the `meeting-notes-summarizer` skill, it will pause\ntwice to collect your preferences via `HumanInputTool`:\n\n1. **Format** — `bullet-points` or `prose`\n2. **Detail level** — `brief` or `detailed`\n\nThe summary is then generated according to your choices.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Running the Skill\n",
+    "\n",
+    "When the agent activates the `meeting-notes-summarizer` skill, it will pause\n",
+    "twice to collect your preferences via `HumanInputTool`:\n",
+    "\n",
+    "1. **Format** — `bullet-points` or `prose`\n",
+    "2. **Detail level** — `brief` or `detailed`\n",
+    "\n",
+    "The summary is then generated according to your choices."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "c8-swhi-0007",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: This is a user-explicit skill activation. Call the from_scratch__use_skill tool with name='meeting-notes-summarizer'. Use exactly thi...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: This is a user-explicit skill activation. Call the from_scratch__use_skill tool with name='meeting-notes-summarizer'. Use exactly ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"meeting-notes-summarizer\">\n",
+      "# Meeting Notes Summarizer\n",
+      "\n",
+      "Produce a summary of a meeting transcript provided...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"0f43bb20-0d7d-467c-8ab4-4a3bf84718f9\",\n",
+      "    \"tool_name\": \"from_scratch__human_inp...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: The previous tool call was malformed. Please correct the tool call to `from_scratch__human_input` with `prompt` set to \"What format would ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: The previous tool call was malformed. Please correct the tool call to `from_scratch__human_input` with `prompt` set to \"What forma...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭────────────────────────────────────────────────── Human Input ──────────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What format would you like the summary in?                                                                      <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[33m╭─\u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m What format would you like the summary in?                                                                      \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt; <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[bullet-points/prose]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "> \u001b[1;35m[bullet-points/prose]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " bullet-points\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: bullet-points\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"ed207fb4-bb36-4344-ad69-1895adbf35e0\",\n",
+      "    \"tool_name\": \"from_scratch__human_inp...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"ed207fb4-bb36-4344-ad69-1895adbf35e0\",\n",
+      "    \"tool_name\": \"from_scratch__human_inp...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"ed207fb4-bb36-4344-ad69-1895adbf35e0\",\n",
+      "    \"tool_name\": \"from_scratch__h...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭────────────────────────────────────────────────── Human Input ──────────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What level of detail?                                                                                           <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[33m╭─\u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m What level of detail?                                                                                           \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt; <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[brief/detailed]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "> \u001b[1;35m[brief/detailed]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " detailed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: detailed\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The user chose \"detailed\". Now I have both preferences:\n",
+      "- Format: bullet-points\n",
+      "- Detail: detailed\n",
+      "\n",
+      "According to the skill, bullet-poin...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The user chose \"detailed\". Now I have both preferences:\n",
+      "- Format: bullet-points\n",
+      "- Detail: detailed\n",
+      "\n",
+      "According to the skill, bullet-p...[TRUNCATED]\n",
+      "The user chose \"detailed\". Now I have both preferences:\n",
+      "- Format: bullet-points\n",
+      "- Detail: detailed\n",
+      "\n",
+      "According to the skill, bullet-points + detailed should produce: \"Structured bullet points with sub-bullets covering all discussion topics, decisions, and action items.\"\n",
+      "\n",
+      "Let me create the summary based on the transcript provided.The user has chosen **bullet-points** format with **detailed** detail level. Now I'll produce a structured summary with sub-bullets covering all discussion topics, decisions, and action items.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "# Sprint 14 Planning Meeting Summary — 2026-06-27\n",
+      "\n",
+      "**Attendees:** Priya (PM), Marcus (Lead Eng), Leila (Backend), Tom (Frontend), Ana (QA)\n",
+      "\n",
+      "## Sprint 13 Review\n",
+      "- **Velocity:** 42 points delivered against a 45-point target\n",
+      "- **Rollover stories:**\n",
+      "  - Pagination refactor (8 pts) — high priority for Sprint 14\n",
+      "  - Email digest feature (5 pts) — high priority for Sprint 14\n",
+      "\n",
+      "## Dependency Risk & Mitigation\n",
+      "- **Risk identified:** Pagination refactor depends on a database migration scheduled for Tuesday; a slip would block the merge\n",
+      "- **Decision:** Move the migration to Monday to de-risk the refactor\n",
+      "\n",
+      "## Email Digest Feature Plan\n",
+      "- **Backend:** Leila volunteered, estimated 3 days of work\n",
+      "- **Frontend:** Tom needs 1 day once Leila's API is ready\n",
+      "- **QA:** Ana will write the test plan today, ready for review by Wednesday\n",
+      "\n",
+      "## Sprint 14 Commitments (44 points total)\n",
+      "- **Pagination refactor** (8 pts) — Marcus, Leila\n",
+      "- **Email digest** (5 pts) — Leila, Tom\n",
+      "- **Auth token refresh** (3 pts) — Leila\n",
+      "- **Dashboard chart improvements** (13 pts) — Tom\n",
+      "- **Automated regression suite** (8 pts) — Ana\n",
+      "- **Performance monitoring alerts** (7 pts) — Marcus\n",
+      "\n",
+      "## Release Timeline\n",
+      "- **Release date:** July 11\n",
+      "- **Deadline:** All Sprint 14 work must be merged and QA-approved by July 9\n",
+      "\n",
+      "## Action Items\n",
+      "- **Marcus:** Move database migration to Monday; own performance monitoring alerts (7 pts)\n",
+      "- **Marcus & Leila:** Complete pagination refactor (8 pts)\n",
+      "- **Leila:** Begin email digest backend work (3 days); own auth token refresh (3 pts)\n",
+      "- **Tom:** Complete frontend for email digest (1 day after API ready); own dashboard chart improvements (13 pts)\n",
+      "- **Ana:** Write email digest test plan today (ready for review Wednesday); own automated regression suite (8 pts)\n",
+      "\n",
+      "**Meeting closed:** 10:24\n"
+     ]
+    }
+   ],
    "source": [
     "result = await agent.run_with_skill(\n",
     "    \"meeting-notes-summarizer\",\n",
@@ -172,8 +415,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbformat": 4,
-   "nbformat_minor": 5,
+   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.5"
   }

--- a/src/llm_agents_from_scratch/llms/ollama/llm.py
+++ b/src/llm_agents_from_scratch/llms/ollama/llm.py
@@ -1,5 +1,7 @@
 """Ollama LLM integration."""
 
+import json
+import re
 from typing import Any, Sequence
 
 from ollama import AsyncClient
@@ -31,6 +33,7 @@ class OllamaLLM(LLM):
         host: str | None = None,
         *,
         think: bool = False,
+        json_prompt_mode: bool = False,  # not included in the book
         **kwargs: Any,
     ) -> None:
         """Create an OllamaLLM instance.
@@ -39,12 +42,17 @@ class OllamaLLM(LLM):
             model (str): The name of the LLM model.
             host (str | None): Host of running Ollama service. Defaults to None.
             think (bool): Enable/disable thinking mode. Defaults to False.
+            json_prompt_mode (bool): Use prompt-level JSON coercion for
+                structured output instead of the Ollama format parameter.
+                Useful for cloud models that ignore the format parameter.
+                Defaults to False. NOTE not included in the book.
             **kwargs (Any): Additional keyword arguments.
         """
         super().__init__(**kwargs)
         self.model = model
         self._client = AsyncClient(host=host)
         self.think = think
+        self.json_prompt_mode = json_prompt_mode
 
     async def complete(self, prompt: str, **kwargs: Any) -> CompleteResult:
         """Complete a prompt with an Ollama LLM.
@@ -83,6 +91,12 @@ class OllamaLLM(LLM):
             StructuredOutputType: The structured output as the specified `mdl`
                 type.
         """
+        if self.json_prompt_mode:  # not included in the book
+            return await self._structured_output_json_prompt(
+                prompt,
+                mdl,
+                **kwargs,
+            )
         o_messages = [
             chat_message_to_ollama_message(
                 ChatMessage(role="user", content=prompt),
@@ -190,3 +204,50 @@ class OllamaLLM(LLM):
         )
 
         return tool_messages, ollama_message_to_chat_message(o_result.message)
+
+    async def _structured_output_json_prompt(
+        self,
+        prompt: str,
+        mdl: type[StructuredOutputType],
+        **kwargs: Any,
+    ) -> StructuredOutputType:
+        """Structured output via prompt-level JSON coercion.
+
+        NOTE: this is not included in the book since its a workaround for an
+        issue on Ollama side not using JSON mode with structured output API.
+
+        Wraps the prompt with explicit JSON instructions and parses the
+        response text directly — no reliance on the Ollama format parameter.
+
+        Args:
+            prompt (str): The original prompt.
+            mdl (type[StructuredOutputType]): The ~pydantic.BaseModel to output.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+            StructuredOutputType: The structured output as the specified `mdl`
+                type.
+        """
+        schema_str = json.dumps(mdl.model_json_schema(), indent=2)
+        wrapped = (
+            f"{prompt}\n\n"
+            f"Respond with a JSON object that strictly matches this schema:\n"
+            f"{schema_str}\n\n"
+            f"Return only the JSON object, no markdown fences or extra text."
+        )
+        o_messages = [
+            chat_message_to_ollama_message(
+                ChatMessage(role="user", content=wrapped),
+            ),
+        ]
+        result = await self._client.chat(
+            model=self.model,
+            messages=o_messages,
+            think=self.think,
+            **kwargs,
+        )
+        raw = result.message.content or ""
+        # strip optional ```json ... ``` fences the model may add anyway
+        raw = re.sub(r"^```(?:json)?\s*", "", raw.strip())
+        raw = re.sub(r"\s*```$", "", raw)
+        return mdl.model_validate_json(raw.strip())

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -107,6 +107,71 @@ async def test_structured_output(mock_async_client_class: MagicMock) -> None:
 
 @pytest.mark.asyncio
 @patch("llm_agents_from_scratch.llms.ollama.llm.AsyncClient")
+async def test_structured_output_json_prompt_mode(
+    mock_async_client_class: MagicMock,
+) -> None:
+    """Test structured_output delegates to json-prompt path when flag is set."""
+
+    class Pet(BaseModel):
+        animal: str
+        name: str
+
+    mock_instance = MagicMock()
+    mock_chat = AsyncMock()
+    mock_chat.return_value = ChatResponse(
+        model="glm-5.2",
+        message=OllamaMessage(
+            role="assistant",
+            content=Pet(animal="cat", name="whiskers").model_dump_json(),
+        ),
+    )
+    mock_instance.chat = mock_chat
+    mock_async_client_class.return_value = mock_instance
+
+    llm = OllamaLLM(model="glm-5.2", json_prompt_mode=True)
+    new_pet = await llm.structured_output("Generate a pet.", mdl=Pet)
+
+    assert isinstance(new_pet, Pet)
+    assert new_pet.animal == "cat"
+    assert new_pet.name == "whiskers"
+    # must NOT have passed format= kwarg
+    call_kwargs = mock_chat.call_args.kwargs
+    assert "format" not in call_kwargs
+
+
+@pytest.mark.asyncio
+@patch("llm_agents_from_scratch.llms.ollama.llm.AsyncClient")
+async def test_structured_output_json_prompt_mode_strips_fences(
+    mock_async_client_class: MagicMock,
+) -> None:
+    """Test _structured_output_json_prompt strips markdown fences."""
+
+    class Pet(BaseModel):
+        animal: str
+        name: str
+
+    mock_instance = MagicMock()
+    mock_chat = AsyncMock()
+    fenced = (
+        "```json\n" + Pet(animal="dog", name="rex").model_dump_json() + "\n```"
+    )
+    mock_chat.return_value = ChatResponse(
+        model="glm-5.2",
+        message=OllamaMessage(role="assistant", content=fenced),
+    )
+    mock_instance.chat = mock_chat
+    mock_async_client_class.return_value = mock_instance
+
+    llm = OllamaLLM(model="glm-5.2", json_prompt_mode=True)
+    new_pet = await llm.structured_output("Generate a pet.", mdl=Pet)
+
+    assert isinstance(new_pet, Pet)
+    assert new_pet.animal == "dog"
+    assert new_pet.name == "rex"
+
+
+@pytest.mark.asyncio
+@patch("llm_agents_from_scratch.llms.ollama.llm.AsyncClient")
 async def test_chat(mock_async_client_class: MagicMock) -> None:
     """Test chat method."""
     # arrange mocks


### PR DESCRIPTION
## Summary

- Adds `json_prompt_mode: bool = False` to `OllamaLLM.__init__` — when enabled, uses prompt-level JSON coercion for structured output instead of the Ollama `format` parameter
- Adds private `_structured_output_json_prompt()` method with markdown fence stripping for robustness
- Both additions are annotated as not covered in the book (workaround for an upstream Ollama cloud bug where the `format` param is ignored)
- Updates `skill_with_human_input.ipynb` to use `glm-5.2:cloud` when `OLLAMA_API_KEY` is present (falling back to `qwen3:14b`), with `json_prompt_mode=True`

Closes #734

## Test plan

- [ ] `OllamaLLM` default behaviour unchanged (`json_prompt_mode=False`) — existing tests pass
- [ ] `OllamaLLM(model="glm-5.2:cloud", json_prompt_mode=True)` returns valid structured output
- [ ] `skill_with_human_input.ipynb` executes end-to-end with cloud model

🤖 Generated with [Claude Code](https://claude.ai/claude-code)