### PR TITLE
feat(ch08): add Example 4 — Agent Inspector note

### DIFF
--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -5,7 +5,7 @@
    "id": "a1b2c3d4-0008-0000-0000-000000000001",
    "metadata": {},
    "source": [
-    "# Chapter 8 — Human in the Loop"
+    "# Chapter 8 \u2014 Human in the Loop"
    ]
   },
   {
@@ -55,7 +55,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Using Ollama Cloud\n"
+      "\u2713 Using Ollama Cloud\n"
      ]
     }
    ],
@@ -74,7 +74,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -103,14 +103,14 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
     "\n",
     "\n",
     "use_cloud = \"OLLAMA_API_KEY\" in os.environ\n",
-    "ensure_ollama() if not use_cloud else print(\"✓ Using Ollama Cloud\")"
+    "ensure_ollama() if not use_cloud else print(\"\u2713 Using Ollama Cloud\")"
    ]
   },
   {
@@ -172,23 +172,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask them ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator — ask th...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator \u2014 ask them ...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence step by step using next_number. The starting number must come from the human operator \u2014 ask th...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭────────────────────────────────────────────────── Human Input ──────────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What starting number should I use for the Hailstone sequence?                                                   <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> What starting number should I use for the Hailstone sequence?                                                   <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m─────────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m What starting number should I use for the Hailstone sequence?                                                   \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
+       "\u001b[33m\u2502\u001b[0m What starting number should I use for the Hailstone sequence?                                                   \u001b[33m\u2502\u001b[0m\n",
+       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -217,57 +217,57 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"26ae513d-d0f6-49cd-a257-648a88d152ab\",\n",
       "    \"tool_name\": \"from_scratch__use_skill...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to use the 'stop-at-one' skill with the provided ID and arguments.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to use the 'stop-at-one' skill with the provided ID and arguments.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to use the 'stop-at-one' skill with the provided ID and arguments.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to use the 'stop-at-one' skill with the provided ID and arguments.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
       "using the `next_num...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"0ccd40d6-dc42-4812-828d-84021196cf7f\",\n",
       "    \"tool_name\": \"from_scratch__next_numb...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'from_scratch__next_number' tool with argument x=4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'from_scratch__next_number' tool with argumen...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'from_scratch__next_number' tool with argument x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'from_scratch__next_number' tool with argumen...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"5beba308-d49f-409f-9ed9-f72348556539\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'next_number' tool with argument x=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'next_number' tool with argument x=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace through what we have:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'next_number' tool with argument x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence using the 'next_number' tool with argument x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace through what we have:\n",
       "\n",
       "- Starting number...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace through what we have:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace through what we have:\n",
       "\n",
       "- Starting num...[TRUNCATED]\n",
       "The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace through what we have:\n",
       "\n",
       "- Starting number: 4\n",
-      "- Step 1: next_number(4) → 2\n",
-      "- Step 2: next_number(2) → 1\n",
+      "- Step 1: next_number(4) \u2192 2\n",
+      "- Step 2: next_number(2) \u2192 1\n",
       "\n",
-      "The complete sequence is: 4 → 2 → 1\n",
+      "The complete sequence is: 4 \u2192 2 \u2192 1\n",
       "\n",
       "Now I need to report the results as specified in the skill instructions:\n",
       "- **Starting number**: 4\n",
       "- **Total steps taken**: 2 (we made 2 tool calls)\n",
       "- **Maximum value reached**: 4 (the starting number was the highest)\n",
       "\n",
-      "The full Hailstone sequence from 4 down to 1 is: **4 → 2 → 1**\n"
+      "The full Hailstone sequence from 4 down to 1 is: **4 \u2192 2 \u2192 1**\n"
      ]
     }
    ],
@@ -275,7 +275,7 @@
     "task = Task(\n",
     "    instruction=(\n",
     "        \"Compute the full Hailstone sequence step by step using next_number. \"\n",
-    "        \"The starting number must come from the human operator — ask them \"\n",
+    "        \"The starting number must come from the human operator \u2014 ask them \"\n",
     "        \"before beginning.\"\n",
     "    )\n",
     ")\n",
@@ -332,47 +332,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence starting from 5, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"c3d2ebae-42fc-49f0-bb2b-56fca08abeb6\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id 'c3d2ebae-42fc-49f0-bb2b-56fca08abeb6' using the tool 'next_number' and argument x=16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id 'c3d2ebae-42fc-49f0-bb2b-56fca08abeb6' using the tool 'next_number' and argument x=16.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id 'c3d2ebae-42fc-49f0-bb2b-56fca08abeb6' using the tool 'next_number' and argument x=16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id 'c3d2ebae-42fc-49f0-bb2b-56fca08abeb6' using the tool 'next_number' and argument x=16.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"54b901af-bc59-49d8-a838-8edfdf998a96\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '54b901af-bc59-49d8-a838-8edfdf998a96' using the tool 'next_number' and argument x=8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '54b901af-bc59-49d8-a838-8edfdf998a96' using the tool 'next_number' and argument x=8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '54b901af-bc59-49d8-a838-8edfdf998a96' using the tool 'next_number' and argument x=8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '54b901af-bc59-49d8-a838-8edfdf998a96' using the tool 'next_number' and argument x=8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"05de6699-0429-42fe-9906-5b93207fb395\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '05de6699-0429-42fe-9906-5b93207fb395' using the tool 'next_number' and argument x=4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '05de6699-0429-42fe-9906-5b93207fb395' using the tool 'next_number' and argument x=4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '05de6699-0429-42fe-9906-5b93207fb395' using the tool 'next_number' and argument x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '05de6699-0429-42fe-9906-5b93207fb395' using the tool 'next_number' and argument x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"69cc3192-4b9a-4653-b732-8d4cbda0d5e5\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '69cc3192-4b9a-4653-b732-8d4cbda0d5e5' using the tool 'next_number' and argument x=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '69cc3192-4b9a-4653-b732-8d4cbda0d5e5' using the tool 'next_number' and argument x=2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full sequence:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '69cc3192-4b9a-4653-b732-8d4cbda0d5e5' using the tool 'next_number' and argument x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '69cc3192-4b9a-4653-b732-8d4cbda0d5e5' using the tool 'next_number' and argument x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full sequence:\n",
       "\n",
       "- Starting from...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
@@ -381,39 +381,39 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full    <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> sequence:                                                                                                       <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Starting from 5                                                                                               <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - next_number(5) = 16                                                                                           <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - next_number(16) = 8                                                                                           <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - next_number(8) = 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - next_number(4) = 2                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - next_number(2) = 1                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> The complete Hailstone sequence starting from 5 is: 5 → 16 → 8 → 4 → 2 → 1                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> We have successfully computed the full Hailstone sequence until reaching 1.                                     <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Proposed Task Result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full    <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> sequence:                                                                                                       <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - Starting from 5                                                                                               <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - next_number(5) = 16                                                                                           <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - next_number(16) = 8                                                                                           <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - next_number(8) = 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - next_number(4) = 2                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - next_number(2) = 1                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> The complete Hailstone sequence starting from 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                      <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> We have successfully computed the full Hailstone sequence until reaching 1.                                     <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full    \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m sequence:                                                                                                       \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Starting from 5                                                                                               \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - next_number(5) = 16                                                                                           \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - next_number(16) = 8                                                                                           \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - next_number(8) = 4                                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - next_number(4) = 2                                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - next_number(2) = 1                                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m The complete Hailstone sequence starting from 5 is: 5 → 16 → 8 → 4 → 2 → 1                                      \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m We have successfully computed the full Hailstone sequence until reaching 1.                                     \u001b[36m│\u001b[0m\n",
-       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[36m\u256d\u2500\u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m\u2500\u256e\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full    \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m sequence:                                                                                                       \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - Starting from 5                                                                                               \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - next_number(5) = 16                                                                                           \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - next_number(16) = 8                                                                                           \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - next_number(8) = 4                                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - next_number(4) = 2                                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - next_number(2) = 1                                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m The complete Hailstone sequence starting from 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1                                      \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m We have successfully computed the full Hailstone sequence until reaching 1.                                     \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -442,7 +442,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full sequence:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full sequence:\n",
       "\n",
       "- Starting f...[TRUNCATED]\n",
       "The tool returned 1, which means we've reached the end of the Hailstone sequence. Let me trace back the full sequence:\n",
@@ -454,7 +454,7 @@
       "- next_number(4) = 2\n",
       "- next_number(2) = 1\n",
       "\n",
-      "The complete Hailstone sequence starting from 5 is: 5 → 16 → 8 → 4 → 2 → 1\n",
+      "The complete Hailstone sequence starting from 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
       "\n",
       "We have successfully computed the full Hailstone sequence until reaching 1.\n"
      ]
@@ -558,10 +558,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence starting from 4, step by step using next_number, until you reach 1.\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence starting from 4, step by step using next_number, until you reach 1.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"31db3c2f-19c0-4b62-b159-c2f0c9e23a10\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -594,7 +594,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      🧠 New Step: Execute the tool call with id '31db3c2f-19c0-4b62-b159-c2f0c9e23a10' to compute the next number in the Hailstone sequence for x=2.\n"
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '31db3c2f-19c0-4b62-b159-c2f0c9e23a10' to compute the next number in the Hailstone sequence for x=2.\n"
      ]
     },
     {
@@ -623,10 +623,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '31db3c2f-19c0-4b62-b159-c2f0c9e23a10' to compute the next number in the Hailstone sequence for x=2.\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.SupervisedTaskHandler) :      ✅ Step Result: The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '31db3c2f-19c0-4b62-b159-c2f0c9e23a10' to compute the next number in the Hailstone sequence for x=2.\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.SupervisedTaskHandler) :      \u2705 Step Result: The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\n",
       "\n",
       "Let me trace the full sequence I've computed ...[TRUNCATED]\n"
      ]
@@ -634,7 +634,7 @@
     {
      "data": {
       "text/plain": [
-       "TaskStepResult(task_step_id='5a99143b-94af-48ed-9d7c-4149f7864725', content=\"The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\\n\\nLet me trace the full sequence I've computed so far:\\n- Starting from 4\\n- next_number(4) = 2\\n- next_number(2) = 1\\n\\nSince I've reached 1, the Hailstone sequence is complete. The full sequence is: 4 → 2 → 1\\n\\nThe task asked me to compute the full Hailstone sequence starting from 4 until reaching 1, and I have successfully done that. The sequence is: **4, 2, 1**.\")"
+       "TaskStepResult(task_step_id='5a99143b-94af-48ed-9d7c-4149f7864725', content=\"The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\\n\\nLet me trace the full sequence I've computed so far:\\n- Starting from 4\\n- next_number(4) = 2\\n- next_number(2) = 1\\n\\nSince I've reached 1, the Hailstone sequence is complete. The full sequence is: 4 \u2192 2 \u2192 1\\n\\nThe task asked me to compute the full Hailstone sequence starting from 4 until reaching 1, and I have successfully done that. The sequence is: **4, 2, 1**.\")"
       ]
      },
      "execution_count": 11,
@@ -663,7 +663,7 @@
     {
      "data": {
       "text/plain": [
-       "TaskResult(task_id='5dd0f1dd-b259-4138-b515-4efd353be772', content=\"The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\\n\\nLet me trace the full sequence I've computed so far:\\n- Starting from 4\\n- next_number(4) = 2\\n- next_number(2) = 1\\n\\nSince I've reached 1, the Hailstone sequence is complete. The full sequence is: 4 → 2 → 1\\n\\nThe task asked me to compute the full Hailstone sequence starting from 4 until reaching 1, and I have successfully done that. The sequence is: **4, 2, 1**.\")"
+       "TaskResult(task_id='5dd0f1dd-b259-4138-b515-4efd353be772', content=\"The tool returned 1, which means the next number in the Hailstone sequence after 2 is 1.\\n\\nLet me trace the full sequence I've computed so far:\\n- Starting from 4\\n- next_number(4) = 2\\n- next_number(2) = 1\\n\\nSince I've reached 1, the Hailstone sequence is complete. The full sequence is: 4 \u2192 2 \u2192 1\\n\\nThe task asked me to compute the full Hailstone sequence starting from 4 until reaching 1, and I have successfully done that. The sequence is: **4, 2, 1**.\")"
       ]
      },
      "execution_count": 12,
@@ -695,7 +695,7 @@
       "- next_number(4) = 2\n",
       "- next_number(2) = 1\n",
       "\n",
-      "The complete Hailstone sequence starting from 5 is: 5 → 16 → 8 → 4 → 2 → 1\n",
+      "The complete Hailstone sequence starting from 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
       "\n",
       "We have successfully computed the full Hailstone sequence until reaching 1.\n"
      ]
@@ -705,6 +705,70 @@
     "# since result is a TaskResult, we can call complete()\n",
     "await task_handler.complete(step)\n",
     "print(result.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000011",
+   "metadata": {},
+   "source": [
+    "### Example 4: Inspecting the Agent with the Agent Inspector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000012",
+   "metadata": {},
+   "source": [
+    "The agent from Example 3 can be driven step-by-step through a browser UI\n",
+    "using the **Agent Inspector**\n",
+    "([`llm-agents-from-scratch-inspector`](https://github.com/nerdai/llm-agents-from-scratch-inspector)).\n",
+    "\n",
+    "**Install**\n",
+    "\n",
+    "```bash\n",
+    "pip install llm-agents-from-scratch-inspector\n",
+    "```\n",
+    "\n",
+    "**Create a launch script** \u2014 save the following as `main.py` in any directory:\n",
+    "\n",
+    "```python\n",
+    "# main.py\n",
+    "from llm_agents_from_scratch import LLMAgentBuilder\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.tools import SimpleFunctionTool\n",
+    "\n",
+    "\n",
+    "def next_number(x: int) -> int:\n",
+    "    if x % 2 == 0:\n",
+    "        return x // 2\n",
+    "    return 3 * x + 1\n",
+    "\n",
+    "\n",
+    "agent_builder = (\n",
+    "    LLMAgentBuilder()\n",
+    "    .with_llm(OllamaLLM(model=\"qwen3:14b\"))\n",
+    "    .with_tool(SimpleFunctionTool(func=next_number))\n",
+    ")\n",
+    "\n",
+    "default_task = Task(\n",
+    "    instruction=(\n",
+    "        \"Compute the full Hailstone sequence starting from 4, \"\n",
+    "        \"step by step using next_number, until you reach 1.\"\n",
+    "    )\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "**Launch**\n",
+    "\n",
+    "```bash\n",
+    "agent-inspector launch main.py\n",
+    "```\n",
+    "\n",
+    "A browser tab opens at the Inspector UI. Enter a task, create a session, and\n",
+    "step through `get_next_step()` / `run_step()` at your own pace \u2014 the same\n",
+    "calls the notebook makes above, now driven interactively."
    ]
   }
  ],

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -712,25 +712,15 @@
    "id": "a1b2c3d4-0008-0000-0000-000000000011",
    "metadata": {},
    "source": [
-    "### Example 4: Inspecting the Agent with the Agent Inspector"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4-0008-0000-0000-000000000012",
-   "metadata": {},
-   "source": [
-    "The agent from Example 3 can be driven step-by-step through a browser UI\n",
-    "using the **Agent Inspector**\n",
-    "([`llm-agents-from-scratch-inspector`](https://github.com/nerdai/llm-agents-from-scratch-inspector)).\n",
+    "---\n",
     "\n",
-    "**Install**\n",
-    "\n",
-    "```bash\n",
-    "pip install llm-agents-from-scratch-inspector\n",
-    "```\n",
-    "\n",
-    "**Create a launch script** \u2014 save the following as `main.py` in any directory:\n",
+    "> **Note \u2014 Agent Inspector**\n",
+    ">\n",
+    "> The agent above can also be driven step-by-step through a browser UI using\n",
+    "> the **Agent Inspector**\n",
+    "> ([`llm-agents-from-scratch-inspector`](https://github.com/nerdai/llm-agents-from-scratch-inspector)).\n",
+    "> Install it with `pip install llm-agents-from-scratch-inspector`, then create\n",
+    "> a launch script that exposes an `agent_builder` at module scope:\n",
     "\n",
     "```python\n",
     "# main.py\n",
@@ -760,15 +750,14 @@
     ")\n",
     "```\n",
     "\n",
-    "**Launch**\n",
-    "\n",
-    "```bash\n",
-    "agent-inspector launch main.py\n",
-    "```\n",
-    "\n",
-    "A browser tab opens at the Inspector UI. Enter a task, create a session, and\n",
-    "step through `get_next_step()` / `run_step()` at your own pace \u2014 the same\n",
-    "calls the notebook makes above, now driven interactively."
+    "> Then launch:\n",
+    ">\n",
+    "> ```bash\n",
+    "> agent-inspector launch main.py\n",
+    "> ```\n",
+    ">\n",
+    "> A browser tab opens where you can enter a task, create a session, and step\n",
+    "> through `get_next_step()` / `run_step()` interactively."
    ]
   }
  ],

--- a/examples/ch08.ipynb
+++ b/examples/ch08.ipynb
@@ -756,8 +756,15 @@
     "> agent-inspector launch main.py\n",
     "> ```\n",
     ">\n",
+    "> This requires an Ollama server running locally (`ollama serve`). Alternatively,\n",
+    "> point the agent at an Ollama cloud model by setting `OLLAMA_API_KEY` in your\n",
+    "> environment and passing `host=\"https://ollama.com\"` and `json_prompt_mode=True`\n",
+    "> to `OllamaLLM` \u2014 the Inspector works the same either way.\n",
+    ">\n",
     "> A browser tab opens where you can enter a task, create a session, and step\n",
-    "> through `get_next_step()` / `run_step()` interactively."
+    "> through `get_next_step()` / `run_step()` interactively. See the\n",
+    "> [Inspector repository](https://github.com/nerdai/llm-agents-from-scratch-inspector)\n",
+    "> for full usage instructions."
    ]
   }
  ],


### PR DESCRIPTION
Adds a new Example 4 markdown note at the end of `examples/ch08.ipynb` pointing readers to the [Agent Inspector](https://github.com/nerdai/llm-agents-from-scratch-inspector) as a way to interactively drive the Example 3 agent.

The note covers:
- Install (`pip install llm-agents-from-scratch-inspector`)
- Minimal `main.py` launch script mirroring the Example 3 agent setup
- Launch command (`agent-inspector launch main.py`)

**TODO before merge**: add the screenshot (drag-drop the PNG into the note's markdown cell in JupyterLab to embed it as an attachment).