### PR TITLE
feat(ch08): add more-example — approval gate inside a skill (email drafter)

### DIFF
--- a/more-examples/ch08/.agents/skills/email-drafter/SKILL.md
+++ b/more-examples/ch08/.agents/skills/email-drafter/SKILL.md
@@ -1,31 +1,9 @@
 ---
 name: email-drafter
-description: Draft a reply to an email provided by the user, then ask the operator to confirm before sending.
+description: Draft a professional reply to an email provided by the user.
 ---
 
 # Email Drafter
 
-Draft a professional reply to the email provided by the user, then seek
-operator confirmation before the reply is sent.
-
-## Steps
-
-### 1. Draft the reply
-
-Read the email and compose a clear, professional reply that addresses all
-points raised.
-
-### 2. Ask for confirmation
-
-Call `from_scratch__human_input` with:
-- `prompt`: "Draft ready — send or discard?"
-- `choices`: `["send", "discard"]`
-
-Record the response as `decision`.
-
-### 3. Act on the decision
-
-- If `decision` is `send`: report that the email has been sent and include the
-  full draft in your final response.
-- If `decision` is `discard`: report that the draft has been discarded without
-  sending.
+Draft a clear, professional reply to the email provided by the user, addressing
+all points raised. Return only the draft reply — do not send it.

--- a/more-examples/ch08/.agents/skills/email-drafter/SKILL.md
+++ b/more-examples/ch08/.agents/skills/email-drafter/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: email-drafter
+description: Draft a reply to an email provided by the user, then ask the operator to confirm before sending.
+---
+
+# Email Drafter
+
+Draft a professional reply to the email provided by the user, then seek
+operator confirmation before the reply is sent.
+
+## Steps
+
+### 1. Draft the reply
+
+Read the email and compose a clear, professional reply that addresses all
+points raised.
+
+### 2. Ask for confirmation
+
+Call `from_scratch__human_input` with:
+- `prompt`: "Draft ready — send or discard?"
+- `choices`: `["send", "discard"]`
+
+Record the response as `decision`.
+
+### 3. Act on the decision
+
+- If `decision` is `send`: report that the email has been sent and include the
+  full draft in your final response.
+- If `decision` is `discard`: report that the draft has been discarded without
+  sending.

--- a/more-examples/ch08/approval_gate_in_skill.ipynb
+++ b/more-examples/ch08/approval_gate_in_skill.ipynb
@@ -52,10 +52,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "c8-agas-0004",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Ollama already running at http://localhost:11434\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -116,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "c8-agas-0005",
    "metadata": {},
    "outputs": [],
@@ -127,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "c8-agas-0006",
    "metadata": {},
    "outputs": [],
@@ -146,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c8-agas-0007",
    "metadata": {},
    "outputs": [],
@@ -193,10 +201,130 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "c8-agas-0009",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: This is a user-explicit skill activation. Call the from_scratch__use_skill tool with name='email-drafter'. Use exactly this name — it...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: This is a user-explicit skill activation. Call the from_scratch__use_skill tool with name='email-drafter'. Use exactly this name —...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"email-drafter\">\n",
+      "# Email Drafter\n",
+      "\n",
+      "Draft a clear, professional reply to the email provided by the user, add...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Hi Sarah,\n",
+      "\n",
+      "Thank you for your email and for taking the time to review the Q3 partnership proposal. I appreciate your enthusiasm and the...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Hi Sarah,                                                                                                       <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Thank you for your email and for taking the time to review the Q3 partnership proposal. I appreciate your       <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> enthusiasm and the feedback you've shared.                                                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Regarding your points:                                                                                          <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> 1. **Revenue Share**: We understand that your standard agreement starts at 15%. We're open to discussing        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> flexibility and finding a middle ground that works for both parties.                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> 2. **Exclusivity Clause**: We can certainly adjust the exclusivity clause to limit it to the retail vertical in <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> North America, as you suggested.                                                                                <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> 3. **Start Date**: September 1 is feasible for us. We're happy to align with that date.                         <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> We'd be delighted to schedule a call this week to discuss these points in more detail and move forward. Please  <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> let us know a time that works best for you.                                                                     <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Looking forward to speaking with you soon.                                                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Best regards,                                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Alex                                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Alex@MyCompany.com                                                                                              <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Hi Sarah,                                                                                                       \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Thank you for your email and for taking the time to review the Q3 partnership proposal. I appreciate your       \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m enthusiasm and the feedback you've shared.                                                                      \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Regarding your points:                                                                                          \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m 1. **Revenue Share**: We understand that your standard agreement starts at 15%. We're open to discussing        \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m flexibility and finding a middle ground that works for both parties.                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m 2. **Exclusivity Clause**: We can certainly adjust the exclusivity clause to limit it to the retail vertical in \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m North America, as you suggested.                                                                                \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m 3. **Start Date**: September 1 is feasible for us. We're happy to align with that date.                         \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m We'd be delighted to schedule a call this week to discuss these points in more detail and move forward. Please  \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m let us know a time that works best for you.                                                                     \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Looking forward to speaking with you soon.                                                                      \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Best regards,                                                                                                   \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Alex                                                                                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Alex@MyCompany.com                                                                                              \u001b[36m│\u001b[0m\n",
+       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Approve this result? <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[y/n]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "Approve this result? \u001b[1;35m[y/n]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Hi Sarah,\n",
+      "\n",
+      "Thank you for your email and for taking the time to review the Q3 partnership proposal. I appreciate your enthusiasm and ...[TRUNCATED]\n",
+      "Hi Sarah,\n",
+      "\n",
+      "Thank you for your email and for taking the time to review the Q3 partnership proposal. I appreciate your enthusiasm and the feedback you've shared.\n",
+      "\n",
+      "Regarding your points:\n",
+      "\n",
+      "1. **Revenue Share**: We understand that your standard agreement starts at 15%. We're open to discussing flexibility and finding a middle ground that works for both parties.\n",
+      "2. **Exclusivity Clause**: We can certainly adjust the exclusivity clause to limit it to the retail vertical in North America, as you suggested.\n",
+      "3. **Start Date**: September 1 is feasible for us. We're happy to align with that date.\n",
+      "\n",
+      "We'd be delighted to schedule a call this week to discuss these points in more detail and move forward. Please let us know a time that works best for you.\n",
+      "\n",
+      "Looking forward to speaking with you soon.\n",
+      "\n",
+      "Best regards,  \n",
+      "Alex  \n",
+      "Alex@MyCompany.com\n"
+     ]
+    }
+   ],
    "source": [
     "result = await agent.run_with_skill(\n",
     "    \"email-drafter\",\n",
@@ -209,13 +337,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/more-examples/ch08/approval_gate_in_skill.ipynb
+++ b/more-examples/ch08/approval_gate_in_skill.ipynb
@@ -5,28 +5,24 @@
    "id": "c8-agas-0001",
    "metadata": {},
    "source": [
-    "# Approval Gate Inside a Skill — Email Drafter\n",
+    "# Approval Gate with a Skill — Email Drafter\n",
     "\n",
-    "This notebook shows that a skill can own its own HITL gate — not just\n",
-    "collect preferences, but enforce an irreversible-action checkpoint.\n",
+    "This notebook shows how to combine the framework's built-in approval gate\n",
+    "with a skill run using `run_with_skill(with_approval=True)`.\n",
     "\n",
-    "The `email-drafter` skill drafts a reply to an email, then calls\n",
-    "`HumanInputTool` with `choices=[\"send\", \"discard\"]` before the reply\n",
-    "is \"sent\". The agent invokes the skill and receives the final outcome;\n",
-    "it never sees or controls the approval step.\n",
+    "The `email-drafter` skill drafts a reply to an email. Before that draft is\n",
+    "accepted as the task result, the framework pauses and asks the operator to\n",
+    "approve or reject it — the same `request_approval` mechanic from `ch08.ipynb`\n",
+    "Example 2, now applied at the skill level.\n",
     "\n",
     "## What a reader learns\n",
     "\n",
-    "- A skill can be the HITL boundary itself, not just a behaviour wrapper\n",
-    "- This pattern is appropriate for any irreversible action — send, deploy,\n",
-    "  delete, push — where the gate belongs at the action level, not the\n",
-    "  agent or operator level\n",
-    "- Contrasts with the patterns in `ch08.ipynb`:\n",
-    "  - **Example 1** — `HumanInputTool` used by the agent mid-task (agent-initiated)\n",
-    "  - **Example 2** — `request_approval` at the end of the loop (operator-gated,\n",
-    "    result-level)\n",
-    "  - **Here** — gate is skill-encapsulated and action-level; the agent is\n",
-    "    unaware it exists"
+    "- `run_with_skill()` accepts `with_approval=True`, wiring the end-of-loop\n",
+    "  approval gate into any skill-activated run\n",
+    "- The skill itself stays simple — it focuses on the task; the gate is\n",
+    "  the caller's concern\n",
+    "- Contrasts with `skill_with_human_input.ipynb`, where `HumanInputTool`\n",
+    "  is embedded inside the skill to collect preferences mid-execution"
    ]
   },
   {
@@ -141,13 +137,11 @@
     "from llm_agents_from_scratch import LLMAgent\n",
     "from llm_agents_from_scratch.llms import OllamaLLM\n",
     "from llm_agents_from_scratch.logger import enable_console_logging\n",
-    "from llm_agents_from_scratch.tools.default import HumanInputTool\n",
     "\n",
     "enable_console_logging(logging.INFO)\n",
     "\n",
-    "human_input_tool = HumanInputTool()\n",
     "llm = OllamaLLM(host=host, model=model, think=False, json_prompt_mode=use_cloud)\n",
-    "agent = LLMAgent(llm=llm, tools=[human_input_tool])"
+    "agent = LLMAgent(llm=llm)"
    ]
   },
   {
@@ -191,15 +185,10 @@
    "source": [
     "## Running the Skill\n",
     "\n",
-    "When the agent activates the `email-drafter` skill, it will:\n",
-    "\n",
-    "1. Draft a reply addressing Sarah's three points\n",
-    "2. Pause and present the draft via `HumanInputTool` — asking you to **send**\n",
-    "   or **discard**\n",
-    "3. Act on your choice and return the outcome\n",
-    "\n",
-    "The agent receives only the final outcome. It has no visibility into the\n",
-    "approval step — that gate lives entirely inside the skill."
+    "Passing `with_approval=True` to `run_with_skill()` adds the end-of-loop\n",
+    "approval gate to the skill run. Once the agent has drafted the reply, the\n",
+    "framework will pause and ask you to **approve** or **reject** before the\n",
+    "result is finalised."
    ]
   },
   {
@@ -212,6 +201,7 @@
     "result = await agent.run_with_skill(\n",
     "    \"email-drafter\",\n",
     "    prompt=f\"Draft a reply to the following email:\\n\\n{EMAIL}\",\n",
+    "    with_approval=True,\n",
     ")\n",
     "print(result.content)"
    ]

--- a/more-examples/ch08/approval_gate_in_skill.ipynb
+++ b/more-examples/ch08/approval_gate_in_skill.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c8-agas-0001",
+   "metadata": {},
+   "source": [
+    "# Approval Gate Inside a Skill — Email Drafter\n",
+    "\n",
+    "This notebook shows that a skill can own its own HITL gate — not just\n",
+    "collect preferences, but enforce an irreversible-action checkpoint.\n",
+    "\n",
+    "The `email-drafter` skill drafts a reply to an email, then calls\n",
+    "`HumanInputTool` with `choices=[\"send\", \"discard\"]` before the reply\n",
+    "is \"sent\". The agent invokes the skill and receives the final outcome;\n",
+    "it never sees or controls the approval step.\n",
+    "\n",
+    "## What a reader learns\n",
+    "\n",
+    "- A skill can be the HITL boundary itself, not just a behaviour wrapper\n",
+    "- This pattern is appropriate for any irreversible action — send, deploy,\n",
+    "  delete, push — where the gate belongs at the action level, not the\n",
+    "  agent or operator level\n",
+    "- Contrasts with the patterns in `ch08.ipynb`:\n",
+    "  - **Example 1** — `HumanInputTool` used by the agent mid-task (agent-initiated)\n",
+    "  - **Example 2** — `request_approval` at the end of the loop (operator-gated,\n",
+    "    result-level)\n",
+    "  - **Here** — gate is skill-encapsulated and action-level; the agent is\n",
+    "    unaware it exists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPI\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-agas-0003",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama\n",
+    "installed on your local machine and have its LLM hosting service running.\n",
+    "To download Ollama, follow the instructions found on this page:\n",
+    "https://ollama.com/download. After downloading and installing Ollama, you\n",
+    "can start a service by opening a terminal and running `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import time\n",
+    "import urllib.error\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"\\u2713 Ollama already running at {host}\")\n",
+    "\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\",\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"\\u2713 Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "use_cloud = \"OLLAMA_API_KEY\" in os.environ\n",
+    "ensure_ollama() if not use_cloud else print(\"\\u2713 Using Ollama Cloud\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"qwen3.5:397b-cloud\" if use_cloud else \"qwen3:14b\"\n",
+    "host = \"https://ollama.com\" if use_cloud else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from llm_agents_from_scratch import LLMAgent\n",
+    "from llm_agents_from_scratch.llms import OllamaLLM\n",
+    "from llm_agents_from_scratch.logger import enable_console_logging\n",
+    "from llm_agents_from_scratch.tools.default import HumanInputTool\n",
+    "\n",
+    "enable_console_logging(logging.INFO)\n",
+    "\n",
+    "human_input_tool = HumanInputTool()\n",
+    "llm = OllamaLLM(host=host, model=model, think=False, json_prompt_mode=use_cloud)\n",
+    "agent = LLMAgent(llm=llm, tools=[human_input_tool])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EMAIL = \"\"\"\\\n",
+    "From: sarah.chen@acmecorp.com\n",
+    "To: alex@mycompany.com\n",
+    "Subject: Re: Q3 Partnership Proposal\n",
+    "\n",
+    "Hi Alex,\n",
+    "\n",
+    "Thanks for sending over the Q3 partnership proposal last week. We reviewed it\n",
+    "with the team and we're excited about the direction.\n",
+    "\n",
+    "A few things we'd like to clarify before signing:\n",
+    "\n",
+    "1. Revenue share — the proposal mentions 20% for the first year, but our\n",
+    "   standard agreement starts at 15%. Is there flexibility here?\n",
+    "2. The exclusivity clause covers our North America region, but we'd need it\n",
+    "   limited to the retail vertical only.\n",
+    "3. Start date — we're targeting September 1. Does that work on your end?\n",
+    "\n",
+    "If these points can be addressed, we'd like to move quickly. Can we get on a\n",
+    "call this week to align?\n",
+    "\n",
+    "Best,\n",
+    "Sarah\n",
+    "Sarah Chen | Head of Partnerships | Acme Corp\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8-agas-0008",
+   "metadata": {},
+   "source": [
+    "## Running the Skill\n",
+    "\n",
+    "When the agent activates the `email-drafter` skill, it will:\n",
+    "\n",
+    "1. Draft a reply addressing Sarah's three points\n",
+    "2. Pause and present the draft via `HumanInputTool` — asking you to **send**\n",
+    "   or **discard**\n",
+    "3. Act on your choice and return the outcome\n",
+    "\n",
+    "The agent receives only the final outcome. It has no visibility into the\n",
+    "approval step — that gate lives entirely inside the skill."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-agas-0009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await agent.run_with_skill(\n",
+    "    \"email-drafter\",\n",
+    "    prompt=f\"Draft a reply to the following email:\\n\\n{EMAIL}\",\n",
+    ")\n",
+    "print(result.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #698

## What's added

**Skill**: `more-examples/ch08/.agents/skills/email-drafter/SKILL.md`
- Drafts a professional reply to an email
- Calls `HumanInputTool(choices=["send", "discard"])` internally before acting
- The gate is fully encapsulated — the agent never sees it

**Notebook**: `more-examples/ch08/approval_gate_in_skill.ipynb`
- Introduces the email-drafter scenario and explains what the reader learns
- Contrasts explicitly with Example 1 (agent-initiated HumanInputTool) and Example 2 (operator-gated `request_approval`) from `ch08.ipynb`
- Includes `use_cloud` / `ensure_ollama()` setup pattern consistent with other ch08 notebooks
- Single `agent.run_with_skill("email-drafter", ...)` call — needs execution before merge

## TODO before merge
- [ ] Execute the notebook and commit outputs