### PR TITLE
feat(ch04-retro): concurrent tool execution in run_step via asyncio.gather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch04-retro): concurrent tool execution in `run_step` via `asyncio.gather` — async tools run concurrently; sync tools wrapped in `asyncio.to_thread`; result ordering preserved (#751)
+
 ## [0.0.21] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+### Changed
+
 - feat(ch04-retro): concurrent tool execution in `run_step` via `asyncio.gather` — async tools run concurrently; sync tools wrapped in `asyncio.to_thread`; result ordering preserved (#751)
 
 ## [0.0.21] - 2026-07-23

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -350,7 +350,7 @@ class LLMAgent:
 
             return retval
 
-        async def run_step(self, step: TaskStep) -> TaskStepResult:  # noqa: PLR0912
+        async def run_step(self, step: TaskStep) -> TaskStepResult:  # noqa: PLR0912, PLR0915
             """Run next step of a given task.
 
             A single step is executed through a single-turn conversation that
@@ -445,19 +445,37 @@ class LLMAgent:
                             else None
                         )
                     ):
-                        if isinstance(tool, AsyncBaseTool):
-                            tool_call_result = await tool(tool_call=tool_call)
-                        else:
-                            # run sync tools in a thread so the event loop
-                            # stays free for concurrent async tool calls
-                            tool_call_result = await asyncio.to_thread(
-                                tool,
-                                tool_call=tool_call,
+                        try:
+                            if isinstance(tool, AsyncBaseTool):
+                                tool_call_result = await tool(
+                                    tool_call=tool_call,
+                                )
+                            else:
+                                # run sync tools in a thread so the event loop
+                                # stays free for concurrent async tool calls
+                                tool_call_result = await asyncio.to_thread(
+                                    tool,
+                                    tool_call=tool_call,
+                                )
+                        except Exception as e:
+                            tool_call_result = ToolCallResult(
+                                tool_call_id=tool_call.id_,
+                                error=True,
+                                content=(
+                                    f"Unexpected error in tool "
+                                    f"'{tool_call.tool_name}': {e}"
+                                ),
                             )
-                        self.logger.info(
-                            "✅ Successful Tool Call: "
-                            f"{tool_call_result.content}",
-                        )
+                        if tool_call_result.error:
+                            self.logger.info(
+                                "❌ Tool Call Failure: "
+                                f"{tool_call_result.content}",
+                            )
+                        else:
+                            self.logger.info(
+                                "✅ Successful Tool Call: "
+                                f"{tool_call_result.content}",
+                            )
                     else:
                         error_msg = (
                             f"Tool with name {tool_call.tool_name} "

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -20,6 +20,7 @@ from llm_agents_from_scratch.data_structures import (
     TaskResult,
     TaskStep,
     TaskStepResult,
+    ToolCall,
     ToolCallResult,
 )
 from llm_agents_from_scratch.data_structures.memory import Episode
@@ -426,8 +427,10 @@ class LLMAgent:
 
             # check if there are tool calls
             if response_message.tool_calls:
-                tool_call_results = []
-                for tool_call in response_message.tool_calls:
+
+                async def _execute_tool_call(
+                    tool_call: ToolCall,
+                ) -> ToolCallResult:
                     self.logger.info(
                         f"🛠️ Executing Tool Call: {tool_call.tool_name}",
                     )
@@ -445,12 +448,16 @@ class LLMAgent:
                         if isinstance(tool, AsyncBaseTool):
                             tool_call_result = await tool(tool_call=tool_call)
                         else:
-                            tool_call_result = tool(tool_call=tool_call)
-                        msg = (
+                            # run sync tools in a thread so the event loop
+                            # stays free for concurrent async tool calls
+                            tool_call_result = await asyncio.to_thread(
+                                tool,
+                                tool_call=tool_call,
+                            )
+                        self.logger.info(
                             "✅ Successful Tool Call: "
-                            f"{tool_call_result.content}"
+                            f"{tool_call_result.content}",
                         )
-                        self.logger.info(msg)
                     else:
                         error_msg = (
                             f"Tool with name {tool_call.tool_name} "
@@ -464,7 +471,18 @@ class LLMAgent:
                         self.logger.info(
                             f"❌ Tool Call Failure: {tool_call_result.content}",
                         )
-                    tool_call_results.append(tool_call_result)
+                    return tool_call_result
+
+                # independent tool calls in one LLM response have no ordering
+                # dependency — run them concurrently; gather preserves order
+                tool_call_results = list(
+                    await asyncio.gather(
+                        *[
+                            _execute_tool_call(tc)
+                            for tc in response_message.tool_calls
+                        ],
+                    ),
+                )
 
                 # send tool call results back to llm to get result
                 (

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -473,15 +473,11 @@ class LLMAgent:
                         )
                     return tool_call_result
 
-                # independent tool calls in one LLM response have no ordering
-                # dependency — run them concurrently; gather preserves order
-                tool_call_results = list(
-                    await asyncio.gather(
-                        *[
-                            _execute_tool_call(tc)
-                            for tc in response_message.tool_calls
-                        ],
-                    ),
+                tool_call_results = await asyncio.gather(
+                    *[
+                        _execute_tool_call(tc)
+                        for tc in response_message.tool_calls
+                    ],
                 )
 
                 # send tool call results back to llm to get result

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -1,6 +1,7 @@
 """Agent Module."""
 
 import asyncio
+import json
 from typing import Any
 
 from rich.console import Console
@@ -458,13 +459,17 @@ class LLMAgent:
                                     tool_call=tool_call,
                                 )
                         except Exception as e:
+                            error_details = {
+                                "error_type": e.__class__.__name__,
+                                "message": (
+                                    f"Internal error while executing "
+                                    f"tool: {e!s}"
+                                ),
+                            }
                             tool_call_result = ToolCallResult(
                                 tool_call_id=tool_call.id_,
                                 error=True,
-                                content=(
-                                    f"Unexpected error in tool "
-                                    f"'{tool_call.tool_name}': {e}"
-                                ),
+                                content=json.dumps(error_details),
                             )
                         if tool_call_result.error:
                             self.logger.info(

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1,5 +1,7 @@
 import asyncio
 import contextlib
+import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +9,7 @@ import pytest
 from llm_agents_from_scratch.agent import LLMAgent
 from llm_agents_from_scratch.agent.templates import default_templates
 from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.base.tool import AsyncBaseTool, BaseTool
 from llm_agents_from_scratch.data_structures import (
     ChatMessage,
     ChatRole,
@@ -17,6 +20,7 @@ from llm_agents_from_scratch.data_structures import (
     TaskStep,
     TaskStepResult,
     ToolCall,
+    ToolCallResult,
 )
 from llm_agents_from_scratch.data_structures.skill import SkillScope
 from llm_agents_from_scratch.errors import TaskHandlerError
@@ -415,6 +419,128 @@ async def test_run_step() -> None:
     mock_llm.continue_chat_with_tool_results.assert_awaited_once()
     assert step_result.task_step_id == step.id_
     assert step_result.content == "The final response."
+
+
+@pytest.mark.asyncio
+async def test_run_step_async_tool_raises_exception() -> None:
+    """Tests run_step converts an unhandled async tool exception to error."""
+
+    class RaisingAsyncTool(AsyncBaseTool):
+        @property
+        def name(self) -> str:
+            return "raising_async_tool"
+
+        @property
+        def description(self) -> str:
+            return "always raises"
+
+        @property
+        def parameters_json_schema(self) -> dict[str, Any]:
+            return {}
+
+        async def __call__(
+            self,
+            tool_call: ToolCall,
+            *args: Any,
+            **kwargs: Any,
+        ) -> ToolCallResult:
+            raise ValueError("async boom")
+
+    mock_llm = AsyncMock()
+    tool_call = ToolCall(tool_name="raising_async_tool", arguments={})
+    mock_llm.chat.return_value = (
+        ChatMessage(role=ChatRole.USER, content="do it"),
+        ChatMessage(
+            role=ChatRole.ASSISTANT,
+            content="",
+            tool_calls=[tool_call],
+        ),
+    )
+    mock_llm.continue_chat_with_tool_results.return_value = (
+        [ChatMessage(role=ChatRole.TOOL, content="err")],
+        ChatMessage(role=ChatRole.ASSISTANT, content="done"),
+    )
+
+    llm_agent = LLMAgent(llm=mock_llm, tools=[RaisingAsyncTool()])
+    handler = LLMAgent.TaskHandler(
+        llm_agent=llm_agent,
+        task=Task(instruction="mock instruction"),
+    )
+    step = TaskStep(
+        task_id=handler.task.id_,
+        instruction="do it",
+    )
+
+    step_result = await handler.run_step(step)
+
+    assert step_result.content == "done"
+    _, kwargs = mock_llm.continue_chat_with_tool_results.call_args
+    (result,) = kwargs["tool_call_results"]
+    assert result.error is True
+    error_details = json.loads(result.content)
+    assert error_details["error_type"] == "ValueError"
+    assert "async boom" in error_details["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_step_sync_tool_raises_exception() -> None:
+    """Tests run_step converts an unhandled sync tool exception to error."""
+
+    class RaisingSyncTool(BaseTool):
+        @property
+        def name(self) -> str:
+            return "raising_sync_tool"
+
+        @property
+        def description(self) -> str:
+            return "always raises"
+
+        @property
+        def parameters_json_schema(self) -> dict[str, Any]:
+            return {}
+
+        def __call__(
+            self,
+            tool_call: ToolCall,
+            *args: Any,
+            **kwargs: Any,
+        ) -> ToolCallResult:
+            raise RuntimeError("sync boom")
+
+    mock_llm = AsyncMock()
+    tool_call = ToolCall(tool_name="raising_sync_tool", arguments={})
+    mock_llm.chat.return_value = (
+        ChatMessage(role=ChatRole.USER, content="do it"),
+        ChatMessage(
+            role=ChatRole.ASSISTANT,
+            content="",
+            tool_calls=[tool_call],
+        ),
+    )
+    mock_llm.continue_chat_with_tool_results.return_value = (
+        [ChatMessage(role=ChatRole.TOOL, content="err")],
+        ChatMessage(role=ChatRole.ASSISTANT, content="done"),
+    )
+
+    llm_agent = LLMAgent(llm=mock_llm, tools=[RaisingSyncTool()])
+    handler = LLMAgent.TaskHandler(
+        llm_agent=llm_agent,
+        task=Task(instruction="mock instruction"),
+    )
+    step = TaskStep(
+        task_id=handler.task.id_,
+        instruction="do it",
+    )
+
+    step_result = await handler.run_step(step)
+
+    assert step_result.content == "done"
+    _, kwargs = mock_llm.continue_chat_with_tool_results.call_args
+    (result,) = kwargs["tool_call_results"]
+    assert result.error is True
+    error_details = json.loads(result.content)
+    assert error_details["error_type"] == "RuntimeError"
+    assert "sync boom" in error_details["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import json
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,7 +19,6 @@ from llm_agents_from_scratch.data_structures import (
     TaskStep,
     TaskStepResult,
     ToolCall,
-    ToolCallResult,
 )
 from llm_agents_from_scratch.data_structures.skill import SkillScope
 from llm_agents_from_scratch.errors import TaskHandlerError
@@ -424,27 +422,9 @@ async def test_run_step() -> None:
 @pytest.mark.asyncio
 async def test_run_step_async_tool_raises_exception() -> None:
     """Tests run_step converts an unhandled async tool exception to error."""
-
-    class RaisingAsyncTool(AsyncBaseTool):
-        @property
-        def name(self) -> str:
-            return "raising_async_tool"
-
-        @property
-        def description(self) -> str:
-            return "always raises"
-
-        @property
-        def parameters_json_schema(self) -> dict[str, Any]:
-            return {}
-
-        async def __call__(
-            self,
-            tool_call: ToolCall,
-            *args: Any,
-            **kwargs: Any,
-        ) -> ToolCallResult:
-            raise ValueError("async boom")
+    mock_tool = AsyncMock(spec=AsyncBaseTool)
+    mock_tool.name = "raising_async_tool"
+    mock_tool.side_effect = ValueError("async boom")
 
     mock_llm = AsyncMock()
     tool_call = ToolCall(tool_name="raising_async_tool", arguments={})
@@ -461,17 +441,14 @@ async def test_run_step_async_tool_raises_exception() -> None:
         ChatMessage(role=ChatRole.ASSISTANT, content="done"),
     )
 
-    llm_agent = LLMAgent(llm=mock_llm, tools=[RaisingAsyncTool()])
+    llm_agent = LLMAgent(llm=mock_llm, tools=[mock_tool])
     handler = LLMAgent.TaskHandler(
         llm_agent=llm_agent,
         task=Task(instruction="mock instruction"),
     )
-    step = TaskStep(
-        task_id=handler.task.id_,
-        instruction="do it",
+    step_result = await handler.run_step(
+        TaskStep(task_id=handler.task.id_, instruction="do it"),
     )
-
-    step_result = await handler.run_step(step)
 
     assert step_result.content == "done"
     _, kwargs = mock_llm.continue_chat_with_tool_results.call_args
@@ -485,27 +462,9 @@ async def test_run_step_async_tool_raises_exception() -> None:
 @pytest.mark.asyncio
 async def test_run_step_sync_tool_raises_exception() -> None:
     """Tests run_step converts an unhandled sync tool exception to error."""
-
-    class RaisingSyncTool(BaseTool):
-        @property
-        def name(self) -> str:
-            return "raising_sync_tool"
-
-        @property
-        def description(self) -> str:
-            return "always raises"
-
-        @property
-        def parameters_json_schema(self) -> dict[str, Any]:
-            return {}
-
-        def __call__(
-            self,
-            tool_call: ToolCall,
-            *args: Any,
-            **kwargs: Any,
-        ) -> ToolCallResult:
-            raise RuntimeError("sync boom")
+    mock_tool = MagicMock(spec=BaseTool)
+    mock_tool.name = "raising_sync_tool"
+    mock_tool.side_effect = RuntimeError("sync boom")
 
     mock_llm = AsyncMock()
     tool_call = ToolCall(tool_name="raising_sync_tool", arguments={})
@@ -522,17 +481,14 @@ async def test_run_step_sync_tool_raises_exception() -> None:
         ChatMessage(role=ChatRole.ASSISTANT, content="done"),
     )
 
-    llm_agent = LLMAgent(llm=mock_llm, tools=[RaisingSyncTool()])
+    llm_agent = LLMAgent(llm=mock_llm, tools=[mock_tool])
     handler = LLMAgent.TaskHandler(
         llm_agent=llm_agent,
         task=Task(instruction="mock instruction"),
     )
-    step = TaskStep(
-        task_id=handler.task.id_,
-        instruction="do it",
+    step_result = await handler.run_step(
+        TaskStep(task_id=handler.task.id_, instruction="do it"),
     )
-
-    step_result = await handler.run_step(step)
 
     assert step_result.content == "done"
     _, kwargs = mock_llm.continue_chat_with_tool_results.call_args


### PR DESCRIPTION
Closes #743

## What

Replaces the sequential `for` loop over batched tool calls in `run_step` with `asyncio.gather`:

- Async tools (`AsyncBaseTool`) called directly and gathered concurrently
- Sync tools wrapped in `asyncio.to_thread` — event loop stays free
- `gather` preserves input order — tool-call result ordering unchanged
- Error semantics unchanged — tools self-report failures as `ToolCallResult(error=True)`; an unhandled raise still propagates

## Why

Independent tool calls in one LLM response have no ordering dependency. This makes parallel sub-agent fan-out in Ch9 free by the time readers arrive, without touching the loop again in Ch9. The `to_thread` wrapping for sync tools is also what makes `SharedConsoleHumanInputTool`'s lock meaningful (#747).

All 361 tests pass.