### PR TITLE
feat(ch09): SubAgentSpec — named sub-agent specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- feat(ch09): `SubAgentSpec` — Pydantic model registering a named sub-agent (name, description, agent, max_steps) in the `subagents/` package (#752)
+- feat(ch09): `SubAgentSpec` — Pydantic model registering a named sub-agent (name, description, agent, max_steps) in the `subagents/` package (#754)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch09): `SubAgentSpec` — Pydantic model registering a named sub-agent (name, description, agent, max_steps) in the `subagents/` package (#752)
+
 ### Changed
 
 - feat(ch04-retro): concurrent tool execution in `run_step` via `asyncio.gather` — async tools run concurrently; sync tools wrapped in `asyncio.to_thread`; result ordering preserved (#751)

--- a/docs/api_reference/subagents/spec.md
+++ b/docs/api_reference/subagents/spec.md
@@ -1,0 +1,6 @@
+# SubAgentSpec
+
+::: llm_agents_from_scratch.subagents.spec
+    options:
+      members:
+        - SubAgentSpec

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
       - Discovery: api_reference/skills/discovery.md
       - UseSkillTool: api_reference/skills/tools.md
       - Constants: api_reference/skills/constants.md
+    - Subagents:
+      - SubAgentSpec: api_reference/subagents/spec.md
     - Errors: api_reference/errors/index.md
 plugins:
   - search

--- a/src/llm_agents_from_scratch/subagents/__init__.py
+++ b/src/llm_agents_from_scratch/subagents/__init__.py
@@ -1,0 +1,5 @@
+"""Subagents module."""
+
+from .spec import SubAgentSpec
+
+__all__ = ["SubAgentSpec"]

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -1,0 +1,53 @@
+"""SubAgentSpec — specification for a named sub-agent."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from llm_agents_from_scratch.agent import LLMAgent
+
+
+class SubAgentSpec(BaseModel):
+    """Specification for a named sub-agent in a multi-agent system.
+
+    Each ``SubAgentSpec`` entry registers a fully-built ``LLMAgent`` under a
+    human-readable name. The name serves as the registry key on the parent
+    coordinator and as the enum value the coordinator's ``UseSubAgentTool``
+    presents to the LLM for dispatch.
+
+    Attributes:
+        name: Unique registry key for this sub-agent. Appears as an enum
+            value in ``UseSubAgentTool``'s dispatch schema — must be
+            human-readable and stable.
+        description: Short routing signal shown to the coordinator LLM in
+            the ``<available_subagents>`` catalog. Should describe capability,
+            not implementation.
+        agent: The fully-built sub-agent. Held as a live object; Pydantic's
+            ``arbitrary_types_allowed`` is required for this field.
+        max_steps: Optional cap on the number of steps the sub-agent may
+            take per dispatch. Passed to ``agent.run()`` to bound runaway
+            executions. ``None`` uses the agent's own default.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str = Field(
+        description=(
+            "Unique registry key for this sub-agent. Appears as an enum "
+            "value in UseSubAgentTool's dispatch schema."
+        ),
+    )
+    description: str = Field(
+        description=(
+            "Routing signal shown to the coordinator LLM in the "
+            "<available_subagents> catalog."
+        ),
+    )
+    agent: LLMAgent = Field(
+        description="The fully-built sub-agent to dispatch tasks to.",
+    )
+    max_steps: int | None = Field(
+        default=None,
+        description=(
+            "Optional cap on sub-agent steps per dispatch. "
+            "None uses the agent's own default."
+        ),
+    )

--- a/tests/api/test_subagent_imports.py
+++ b/tests/api/test_subagent_imports.py
@@ -1,0 +1,15 @@
+import importlib
+
+import pytest
+
+from llm_agents_from_scratch.subagents import __all__ as _subagents_all
+
+
+@pytest.mark.parametrize("name", _subagents_all)
+def test_subagents_all_importable(name: str) -> None:
+    """Tests all names listed in subagents __all__ are importable."""
+    mod = importlib.import_module("llm_agents_from_scratch.subagents")
+    attr = getattr(mod, name)
+
+    assert hasattr(mod, name)
+    assert attr is not None

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -1,0 +1,56 @@
+"""Unit tests for SubAgentSpec."""
+
+import pytest
+from pydantic import ValidationError
+
+from llm_agents_from_scratch.agent import LLMAgent
+from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.subagents import SubAgentSpec
+
+MAX_STEPS = 10
+
+
+def test_subagentspec_init(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec initialises with required and optional fields."""
+    agent = LLMAgent(llm=mock_llm)
+    spec = SubAgentSpec(
+        name="researcher",
+        description="Searches the web and summarises findings.",
+        agent=agent,
+    )
+
+    assert spec.name == "researcher"
+    assert spec.description == "Searches the web and summarises findings."
+    assert spec.agent is agent
+    assert spec.max_steps is None
+
+
+def test_subagentspec_max_steps(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec stores an explicit max_steps value."""
+    agent = LLMAgent(llm=mock_llm)
+    spec = SubAgentSpec(
+        name="coder",
+        description="Writes and runs Python code.",
+        agent=agent,
+        max_steps=MAX_STEPS,
+    )
+
+    assert spec.max_steps == MAX_STEPS
+
+
+def test_subagentspec_requires_name(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec raises ValidationError when name is missing."""
+    with pytest.raises(ValidationError):
+        SubAgentSpec(  # type: ignore[call-arg]
+            description="no name provided",
+            agent=LLMAgent(llm=mock_llm),
+        )
+
+
+def test_subagentspec_requires_description(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec raises ValidationError when description is missing."""
+    with pytest.raises(ValidationError):
+        SubAgentSpec(  # type: ignore[call-arg]
+            name="coder",
+            agent=LLMAgent(llm=mock_llm),
+        )


### PR DESCRIPTION
Closes #752.

## Summary

- New `subagents/` top-level package (sibling to `skills/`)
- `SubAgentSpec` Pydantic model with `arbitrary_types_allowed` (holds a live `LLMAgent`)
- Fields use `Field(description=...)` instead of inline comments, consistent with codebase convention
- 4 tests covering init, `max_steps`, and validation errors for missing required fields

## Test plan

- [ ] `pytest tests/subagents/test_spec.py -v`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)