### PR TITLE
feat(ch09): UseSubAgentTool — async sub-agent dispatch tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- fix: `TaskHandler` parameterized as `asyncio.Future[TaskResult]` — `await agent.run(task)` now resolves to `TaskResult` rather than `Any` (#755)
 - feat(ch04-retro): concurrent tool execution in `run_step` via `asyncio.gather` — async tools run concurrently; sync tools wrapped in `asyncio.to_thread`; result ordering preserved (#751)
 
 ## [0.0.21] - 2026-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch09): `UseSubAgentTool` — async tool dispatching tasks to named sub-agents; catches all exceptions (incl. `MaxStepsReachedError`) as error results (#755)
 - feat(ch09): `SubAgentSpec` — Pydantic model registering a named sub-agent (name, description, agent, max_steps) in the `subagents/` package (#754)
 
 ### Changed

--- a/docs/api_reference/subagents/tools.md
+++ b/docs/api_reference/subagents/tools.md
@@ -1,0 +1,6 @@
+# UseSubAgentTool
+
+::: llm_agents_from_scratch.subagents.tools
+    options:
+      members:
+        - UseSubAgentTool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Constants: api_reference/skills/constants.md
     - Subagents:
       - SubAgentSpec: api_reference/subagents/spec.md
+      - UseSubAgentTool: api_reference/subagents/tools.md
     - Errors: api_reference/errors/index.md
 plugins:
   - search

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -107,7 +107,7 @@ class LLMAgent:
         self.tools_registry[tool.name] = tool
         return self
 
-    class TaskHandler(asyncio.Future):
+    class TaskHandler(asyncio.Future[TaskResult]):
         """Handler for processing tasks.
 
         Attributes:

--- a/src/llm_agents_from_scratch/errors/__init__.py
+++ b/src/llm_agents_from_scratch/errors/__init__.py
@@ -24,6 +24,7 @@ from .skill import (
     SkillValidationError,
     SkillValidationWarning,
 )
+from .subagents import SubAgentNotFoundError, SubAgentsError
 from .task_handler import RecordMemoryError, TaskHandlerError
 
 __all__ = [
@@ -59,4 +60,7 @@ __all__ = [
     # task handler
     "TaskHandlerError",
     "RecordMemoryError",
+    # subagents
+    "SubAgentsError",
+    "SubAgentNotFoundError",
 ]

--- a/src/llm_agents_from_scratch/errors/subagents.py
+++ b/src/llm_agents_from_scratch/errors/subagents.py
@@ -1,0 +1,15 @@
+"""Errors for the subagents subsystem."""
+
+from .core import LLMAgentsFromScratchError
+
+
+class SubAgentsError(LLMAgentsFromScratchError):
+    """Base error for all subagent-related exceptions."""
+
+    pass
+
+
+class SubAgentNotFoundError(SubAgentsError):
+    """Raised when a named sub-agent is not in the registry."""
+
+    pass

--- a/src/llm_agents_from_scratch/subagents/__init__.py
+++ b/src/llm_agents_from_scratch/subagents/__init__.py
@@ -1,5 +1,6 @@
 """Subagents module."""
 
 from .spec import SubAgentSpec
+from .tools import UseSubAgentTool
 
-__all__ = ["SubAgentSpec"]
+__all__ = ["SubAgentSpec", "UseSubAgentTool"]

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -66,7 +66,7 @@ class UseSubAgentTool(AsyncBaseTool):
             "properties": {
                 "name": {
                     "type": "string",
-                    "enum": list(self._subagents),
+                    "enum": sorted(self._subagents),
                     "description": (
                         "Name of the sub-agent to dispatch the task to."
                     ),

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -128,11 +128,10 @@ class UseSubAgentTool(AsyncBaseTool):
                 raise SubAgentNotFoundError(
                     f"Sub-agent '{subagent_name}' not found.",
                 )
-            task_handler = spec.agent.run(
+            result = await spec.agent.run(
                 Task(instruction=task_instruction),
                 max_steps=spec.max_steps,
             )
-            result = await task_handler
         except Exception as e:
             return ToolCallResult(
                 tool_call_id=tool_call.id_,

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -1,0 +1,160 @@
+"""UseSubAgentTool — dispatches a task to a named sub-agent."""
+
+import json
+from typing import Any
+
+from llm_agents_from_scratch.base.tool import AsyncBaseTool
+from llm_agents_from_scratch.data_structures import (
+    Task,
+    ToolCall,
+    ToolCallResult,
+)
+
+from .spec import SubAgentSpec
+
+
+class UseSubAgentTool(AsyncBaseTool):
+    """Async tool that dispatches a task to a registered sub-agent.
+
+    Each sub-agent registered with the parent coordinator is callable via this
+    single tool. The LLM selects a sub-agent by name (constrained to an enum
+    of registered names) and provides a free-text task instruction. The tool
+    runs the sub-agent to completion and returns only ``result.content``,
+    keeping trajectories isolated.
+
+    All sub-agent exceptions — including ``MaxStepsReachedError`` — are caught
+    and returned as ``ToolCallResult(error=True)`` so the coordinator can
+    re-plan rather than crash.
+
+    Attributes:
+        subagents (dict[str, SubAgentSpec]): Registered sub-agents, keyed by
+            name.
+    """
+
+    def __init__(self, subagents: dict[str, SubAgentSpec]) -> None:
+        """Initialise with a registry of sub-agents.
+
+        Args:
+            subagents (dict[str, SubAgentSpec]): Sub-agents to register, keyed
+                by name.
+        """
+        self._subagents = subagents
+
+    @property
+    def name(self) -> str:
+        """Name of the sub-agent dispatch tool."""
+        return "from_scratch__use_subagent"
+
+    @property
+    def description(self) -> str:
+        """Description of the sub-agent dispatch tool."""
+        return (
+            "Dispatch a task to a named sub-agent and return its result. "
+            "Only call this tool with a sub-agent name from the "
+            "<available_subagents> catalog."
+        )
+
+    @property
+    def parameters_json_schema(self) -> dict[str, Any]:
+        """JSON schema for tool parameters.
+
+        The ``name`` field is constrained to an enum of registered sub-agent
+        names so the LLM can only dispatch to agents that exist.
+        """
+        return {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "enum": list(self._subagents),
+                    "description": (
+                        "Name of the sub-agent to dispatch the task to."
+                    ),
+                },
+                "task": {
+                    "type": "string",
+                    "description": "The task instruction for the sub-agent.",
+                },
+            },
+            "required": ["name", "task"],
+        }
+
+    async def __call__(
+        self,
+        tool_call: ToolCall,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ToolCallResult:
+        """Dispatch a task to the named sub-agent and return its result.
+
+        Args:
+            tool_call (ToolCall): The tool call to execute.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+            ToolCallResult: The sub-agent's ``result.content`` on success, or
+                an error result if the sub-agent raises for any reason.
+        """
+        subagent_name = tool_call.arguments.get("name")
+        task_instruction = tool_call.arguments.get("task")
+
+        if not isinstance(subagent_name, str):
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                error=True,
+                content=json.dumps(
+                    {
+                        "error_type": "ValueError",
+                        "message": "'name' argument must be a string.",
+                    },
+                ),
+            )
+        if not isinstance(task_instruction, str):
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                error=True,
+                content=json.dumps(
+                    {
+                        "error_type": "ValueError",
+                        "message": "'task' argument must be a string.",
+                    },
+                ),
+            )
+        if subagent_name not in self._subagents:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                error=True,
+                content=json.dumps(
+                    {
+                        "error_type": "ValueError",
+                        "message": (f"Sub-agent '{subagent_name}' not found."),
+                    },
+                ),
+            )
+
+        spec = self._subagents[subagent_name]
+        try:
+            task_handler = spec.agent.run(
+                Task(instruction=task_instruction),
+                max_steps=spec.max_steps,
+            )
+            result = await task_handler
+        except Exception as e:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                error=True,
+                content=json.dumps(
+                    {
+                        "error_type": type(e).__name__,
+                        "subagent": subagent_name,
+                        "message": str(e),
+                    },
+                ),
+            )
+
+        return ToolCallResult(
+            tool_call_id=tool_call.id_,
+            error=False,
+            content=result.content,
+        )

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -9,6 +9,7 @@ from llm_agents_from_scratch.data_structures import (
     ToolCall,
     ToolCallResult,
 )
+from llm_agents_from_scratch.errors import SubAgentNotFoundError
 
 from .spec import SubAgentSpec
 
@@ -121,20 +122,12 @@ class UseSubAgentTool(AsyncBaseTool):
                     },
                 ),
             )
-        if subagent_name not in self._subagents:
-            return ToolCallResult(
-                tool_call_id=tool_call.id_,
-                error=True,
-                content=json.dumps(
-                    {
-                        "error_type": "ValueError",
-                        "message": (f"Sub-agent '{subagent_name}' not found."),
-                    },
-                ),
-            )
-
-        spec = self._subagents[subagent_name]
+        spec = self._subagents.get(subagent_name)
         try:
+            if spec is None:
+                raise SubAgentNotFoundError(
+                    f"Sub-agent '{subagent_name}' not found.",
+                )
             task_handler = spec.agent.run(
                 Task(instruction=task_instruction),
                 max_steps=spec.max_steps,

--- a/tests/subagents/test_tools.py
+++ b/tests/subagents/test_tools.py
@@ -65,7 +65,7 @@ async def test_use_subagent_tool_dispatches_task(mock_llm: BaseLLM) -> None:
     """Tests successful dispatch returns sub-agent result.content."""
     task_result = TaskResult(task_id="t1", content="42 is the answer")
     future: asyncio.Future[TaskResult] = (
-        asyncio.get_event_loop().create_future()
+        asyncio.get_running_loop().create_future()
     )
     future.set_result(task_result)
 
@@ -91,7 +91,7 @@ async def test_use_subagent_tool_dispatches_task(mock_llm: BaseLLM) -> None:
 async def test_use_subagent_tool_passes_max_steps(mock_llm: BaseLLM) -> None:
     """Tests max_steps from SubAgentSpec is forwarded to agent.run()."""
     future: asyncio.Future[TaskResult] = (
-        asyncio.get_event_loop().create_future()
+        asyncio.get_running_loop().create_future()
     )
     future.set_result(TaskResult(task_id="t1", content="done"))
 
@@ -113,7 +113,7 @@ async def test_use_subagent_tool_catches_max_steps_error(
 ) -> None:
     """Tests MaxStepsReachedError is caught and returned as error result."""
     future: asyncio.Future[TaskResult] = (
-        asyncio.get_event_loop().create_future()
+        asyncio.get_running_loop().create_future()
     )
     future.set_exception(MaxStepsReachedError("Max steps reached."))
 
@@ -138,7 +138,7 @@ async def test_use_subagent_tool_catches_unexpected_error(
 ) -> None:
     """Tests unexpected sub-agent exceptions are caught as error results."""
     future: asyncio.Future[TaskResult] = (
-        asyncio.get_event_loop().create_future()
+        asyncio.get_running_loop().create_future()
     )
     future.set_exception(RuntimeError("boom"))
 

--- a/tests/subagents/test_tools.py
+++ b/tests/subagents/test_tools.py
@@ -172,6 +172,7 @@ async def test_use_subagent_tool_unknown_name(mock_llm: BaseLLM) -> None:
 
     assert result.error is True
     details = json.loads(result.content)
+    assert details["error_type"] == "SubAgentNotFoundError"
     assert "not found" in details["message"]
 
 

--- a/tests/subagents/test_tools.py
+++ b/tests/subagents/test_tools.py
@@ -1,0 +1,205 @@
+"""Unit tests for UseSubAgentTool."""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from llm_agents_from_scratch.agent import LLMAgent
+from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.data_structures import Task, TaskResult, ToolCall
+from llm_agents_from_scratch.errors import MaxStepsReachedError
+from llm_agents_from_scratch.subagents import SubAgentSpec, UseSubAgentTool
+
+MAX_STEPS_CODER = 5
+
+
+def make_spec(
+    name: str,
+    mock_llm: BaseLLM,
+    max_steps: int | None = None,
+) -> SubAgentSpec:
+    return SubAgentSpec(
+        name=name,
+        description=f"Sub-agent: {name}",
+        agent=LLMAgent(llm=mock_llm),
+        max_steps=max_steps,
+    )
+
+
+def test_use_subagent_tool_name(mock_llm: BaseLLM) -> None:
+    """Tests UseSubAgentTool.name."""
+    tool = UseSubAgentTool(subagents={})
+    assert tool.name == "from_scratch__use_subagent"
+
+
+def test_use_subagent_tool_description(mock_llm: BaseLLM) -> None:
+    """Tests UseSubAgentTool.description mentions dispatch."""
+    tool = UseSubAgentTool(subagents={})
+    assert "dispatch" in tool.description.lower()
+
+
+def test_use_subagent_tool_schema_enum(mock_llm: BaseLLM) -> None:
+    """Tests parameters_json_schema enum contains registered subagent names."""
+    subagents = {
+        "researcher": make_spec("researcher", mock_llm),
+        "coder": make_spec("coder", mock_llm),
+    }
+    tool = UseSubAgentTool(subagents=subagents)
+    enum = tool.parameters_json_schema["properties"]["name"]["enum"]
+    assert "researcher" in enum
+    assert "coder" in enum
+
+
+def test_use_subagent_tool_schema_required(mock_llm: BaseLLM) -> None:
+    """Tests parameters_json_schema requires both name and task."""
+    tool = UseSubAgentTool(subagents={})
+    required = tool.parameters_json_schema["required"]
+    assert "name" in required
+    assert "task" in required
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_dispatches_task(mock_llm: BaseLLM) -> None:
+    """Tests successful dispatch returns sub-agent result.content."""
+    task_result = TaskResult(task_id="t1", content="42 is the answer")
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_event_loop().create_future()
+    )
+    future.set_result(task_result)
+
+    spec = make_spec("researcher", mock_llm)
+    with patch.object(spec.agent, "run", return_value=future) as mock_run:
+        tool = UseSubAgentTool(subagents={"researcher": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "researcher", "task": "What is the answer?"},
+        )
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is False
+    assert result.content == "42 is the answer"
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    assert isinstance(call_args.args[0], Task)
+    assert call_args.args[0].instruction == "What is the answer?"
+    assert call_args.kwargs.get("max_steps") is None
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_passes_max_steps(mock_llm: BaseLLM) -> None:
+    """Tests max_steps from SubAgentSpec is forwarded to agent.run()."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_event_loop().create_future()
+    )
+    future.set_result(TaskResult(task_id="t1", content="done"))
+
+    spec = make_spec("coder", mock_llm, max_steps=MAX_STEPS_CODER)
+    with patch.object(spec.agent, "run", return_value=future) as mock_run:
+        tool = UseSubAgentTool(subagents={"coder": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "coder", "task": "Write a sort function."},
+        )
+        await tool(tool_call=tool_call)
+
+    assert mock_run.call_args.kwargs.get("max_steps") == MAX_STEPS_CODER
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_catches_max_steps_error(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests MaxStepsReachedError is caught and returned as error result."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_event_loop().create_future()
+    )
+    future.set_exception(MaxStepsReachedError("Max steps reached."))
+
+    spec = make_spec("researcher", mock_llm)
+    with patch.object(spec.agent, "run", return_value=future):
+        tool = UseSubAgentTool(subagents={"researcher": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "researcher", "task": "Find everything."},
+        )
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    details = json.loads(result.content)
+    assert details["error_type"] == "MaxStepsReachedError"
+    assert details["subagent"] == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_catches_unexpected_error(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests unexpected sub-agent exceptions are caught as error results."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_event_loop().create_future()
+    )
+    future.set_exception(RuntimeError("boom"))
+
+    spec = make_spec("coder", mock_llm)
+    with patch.object(spec.agent, "run", return_value=future):
+        tool = UseSubAgentTool(subagents={"coder": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "coder", "task": "Do something."},
+        )
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    details = json.loads(result.content)
+    assert details["error_type"] == "RuntimeError"
+    assert details["subagent"] == "coder"
+    assert "boom" in details["message"]
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_unknown_name(mock_llm: BaseLLM) -> None:
+    """Tests unknown subagent name returns error result."""
+    tool = UseSubAgentTool(
+        subagents={"researcher": make_spec("researcher", mock_llm)},
+    )
+    tool_call = ToolCall(
+        tool_name="from_scratch__use_subagent",
+        arguments={"name": "unknown", "task": "Do something."},
+    )
+    result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    details = json.loads(result.content)
+    assert "not found" in details["message"]
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_missing_name_arg(mock_llm: BaseLLM) -> None:
+    """Tests missing name argument returns error result."""
+    tool = UseSubAgentTool(subagents={})
+    tool_call = ToolCall(
+        tool_name="from_scratch__use_subagent",
+        arguments={"task": "Do something."},
+    )
+    result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    details = json.loads(result.content)
+    assert "'name'" in details["message"]
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_missing_task_arg(mock_llm: BaseLLM) -> None:
+    """Tests missing task argument returns error result."""
+    tool = UseSubAgentTool(subagents={})
+    tool_call = ToolCall(
+        tool_name="from_scratch__use_subagent",
+        arguments={"name": "researcher"},
+    )
+    result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    details = json.loads(result.content)
+    assert "'task'" in details["message"]


### PR DESCRIPTION
Closes #753.

## Summary

- `UseSubAgentTool` (`subagents/tools.py`) — `AsyncBaseTool` with name `from_scratch__use_subagent`
- Schema: `name` (enum over registered sub-agent names) + `task` (free string)
- Dispatches `spec.agent.run(Task(instruction=task), max_steps=spec.max_steps)` and awaits the `TaskHandler` future
- All exceptions (incl. `MaxStepsReachedError`) caught and returned as `ToolCallResult(error=True)` with structured JSON (`error_type`, `subagent`, `message`) — sub-agent failure becomes coordinator information, not a crash
- Trajectory isolation: only `result.content` crosses the boundary
- `UseSubAgentTool` exported from `subagents/__init__.py`; docs page added; mkdocs nav updated

## Test plan

- [ ] `pytest tests/subagents/ -v` (11 spec + 11 tool tests)
- [ ] `pytest tests/api/test_subagent_imports.py -v`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)