### PR TITLE
refactor: rename TaskHandler.skills → skills_registry and UseSkillTool param skills → skills_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor: rename `TaskHandler.skills` → `skills_registry` and `UseSkillTool` param `skills` → `skills_registry` — consistent with the `_registry` suffix convention for dict-keyed stores (#758)
 - refactor: rename `UseSubAgentTool` constructor param `subagents` → `subagents_registry`; rename stored attribute to `_subagents_registry` — consistent with the `_registry` suffix convention for dict-keyed stores
 - refactor: rename `LLMAgent.subagents` attribute → `subagents_registry` — consistent with `tools_registry` naming convention (#756)
 - fix: `TaskHandler` parameterized as `asyncio.Future[TaskResult]` — `await agent.run(task)` now resolves to `TaskResult` rather than `Any` (#755)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- refactor: rename `TaskHandler.skills` → `skills_registry` and `UseSkillTool` param `skills` → `skills_registry` — consistent with the `_registry` suffix convention for dict-keyed stores (#758)
+- refactor: rename `TaskHandler.skills` → `skills_registry` and `UseSkillTool` param `skills` → `skills_registry` — consistent with the `_registry` suffix convention for dict-keyed stores; updates `examples/ch06.ipynb` and affected `more-examples/ch06/` notebooks (#758)
 - refactor: rename `UseSubAgentTool` constructor param `subagents` → `subagents_registry`; rename stored attribute to `_subagents_registry` — consistent with the `_registry` suffix convention for dict-keyed stores
 - refactor: rename `LLMAgent.subagents` attribute → `subagents_registry` — consistent with `tools_registry` naming convention (#756)
 - fix: `TaskHandler` parameterized as `asyncio.Future[TaskResult]` — `await agent.run(task)` now resolves to `TaskResult` rather than `Any` (#755)

--- a/examples/ch06.ipynb
+++ b/examples/ch06.ipynb
@@ -117,9 +117,9 @@
     "task = Task(instruction=\"Compute the stop-at-one sequence for 8.\")\n",
     "handler = LLMAgent.TaskHandler(llm_agent=agent, task=task)\n",
     "\n",
-    "print(handler.skills)\n",
-    "print(handler.skills[\"stop-at-one\"].frontmatter)\n",
-    "print(handler.skills[\"stop-at-one\"].scope)"
+    "print(handler.skills_registry)\n",
+    "print(handler.skills_registry[\"stop-at-one\"].frontmatter)\n",
+    "print(handler.skills_registry[\"stop-at-one\"].scope)"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "from llm_agents_from_scratch.data_structures import ToolCall\n",
     "from llm_agents_from_scratch.skills.tools import UseSkillTool\n",
     "\n",
-    "tool = UseSkillTool(skills=handler.skills)\n",
+    "tool = UseSkillTool(skills_registry=handler.skills_registry)\n",
     "tool_call = ToolCall(\n",
     "    tool_name=\"from_scratch__use_skill\",\n",
     "    arguments={\"name\": \"stop-at-one\"},\n",

--- a/more-examples/ch06/additional_resource_python.ipynb
+++ b/more-examples/ch06/additional_resource_python.ipynb
@@ -175,7 +175,7 @@
     "\n",
     "task = Task(instruction=\"placeholder\")\n",
     "handler = LLMAgent.TaskHandler(llm_agent=agent, task=task)\n",
-    "skill = handler.skills[\"word-frequency\"]\n",
+    "skill = handler.skills_registry[\"word-frequency\"]\n",
     "\n",
     "print(f\"Name:      {skill.frontmatter.name}\")\n",
     "print(f\"Scope:     {skill.scope}\")\n",

--- a/more-examples/ch06/skills_marketplace.ipynb
+++ b/more-examples/ch06/skills_marketplace.ipynb
@@ -356,7 +356,7 @@
     "\n",
     "task = Task(instruction=\"placeholder\")\n",
     "handler = LLMAgent.TaskHandler(llm_agent=agent, task=task)\n",
-    "skill = handler.skills[\"slack-gif-creator\"]\n",
+    "skill = handler.skills_registry[\"slack-gif-creator\"]\n",
     "\n",
     "print(f\"Name:      {skill.frontmatter.name}\")\n",
     "print(f\"Scope:     {skill.scope}\")\n",

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -137,8 +137,8 @@ class LLMAgent:
             rollout: The execution log of the task.
             step_counter: The number of TaskSteps executed.
             logger: TaskHandler logger.
-            skills (dict[str, Skill]): Skills discovered at the start of
-                each run, keyed by name. Added in Chapter 6.
+            skills_registry (dict[str, Skill]): Skills discovered at the
+                start of each run, keyed by name. Added in Chapter 6.
             _explicit_only_skills (set[str]): Skill names excluded from the
                 model-visible catalog for this run. They remain loadable via
                 ``run_with_skill()``. Added in Chapter 6.
@@ -187,14 +187,14 @@ class LLMAgent:
                 if skills_scopes is not None
                 else [SkillScope.USER, SkillScope.PROJECT]
             )
-            self.skills: dict[str, Skill] = discover_skills(_scopes)
+            self.skills_registry: dict[str, Skill] = discover_skills(_scopes)
             self._explicit_only_skills: set[str] = explicit_only_skills or set()
             self._use_skill_tool: UseSkillTool | None = (
                 UseSkillTool(
-                    skills=self.skills,
+                    skills_registry=self.skills_registry,
                     explicit_only_skills=self._explicit_only_skills,
                 )
-                if self.skills
+                if self.skills_registry
                 else None
             )
             # added in ch07
@@ -244,7 +244,7 @@ class LLMAgent:
             """
             visible = [
                 skill
-                for name, skill in self.skills.items()
+                for name, skill in self.skills_registry.items()
                 if name not in self._explicit_only_skills
             ]
             if not visible:

--- a/src/llm_agents_from_scratch/skills/tools.py
+++ b/src/llm_agents_from_scratch/skills/tools.py
@@ -13,28 +13,32 @@ class UseSkillTool(BaseTool):
     """A dedicated tool for activating a skill.
 
     Attributes:
-        skills (dict[str, Skill]): All discovered skills, keyed by name.
-            Skills in ``explicit_only_skills`` are excluded from the enum
-            but remain loadable if called directly via ``run_with_skill()``.
+        skills_registry (dict[str, Skill]): All discovered skills, keyed by
+            name. Skills in ``explicit_only_skills`` are excluded from the
+            enum but remain loadable if called directly via
+            ``run_with_skill()``.
     """
 
     def __init__(
         self,
-        skills: dict[str, Skill],
+        skills_registry: dict[str, Skill],
         explicit_only_skills: set[str] | None = None,
     ) -> None:
         """Initialize a UseSkillTool.
 
         Args:
-            skills (dict[str, Skill]): All discovered skills, keyed by name.
+            skills_registry (dict[str, Skill]): All discovered skills, keyed
+                by name.
             explicit_only_skills (set[str] | None): Skill names excluded from
                 the model-visible catalog. They remain loadable via
                 ``run_with_skill()``. Defaults to None.
         """
-        self._skills = skills
+        self._skills_registry = skills_registry
         self._explicit_only_skills = explicit_only_skills or set()
         self._visible = [
-            name for name in skills if name not in self._explicit_only_skills
+            name
+            for name in skills_registry
+            if name not in self._explicit_only_skills
         ]
 
     @property
@@ -75,7 +79,7 @@ class UseSkillTool(BaseTool):
         Returns:
             Formatted ``<skill_content>`` XML string.
         """
-        skill = self._skills[name]
+        skill = self._skills_registry[name]
         resources = skill.resources
         skill_resources = (
             SKILL_RESOURCES_TEMPLATE.format(
@@ -125,7 +129,7 @@ class UseSkillTool(BaseTool):
                 ),
                 error=True,
             )
-        if skill_name not in self._skills:
+        if skill_name not in self._skills_registry:
             return ToolCallResult(
                 tool_call_id=tool_call.id_,
                 content=json.dumps(

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -66,7 +66,7 @@ async def test_task_handler_init_discovers_skills(
         )
 
     mock_discover.assert_called_once_with([SkillScope.PROJECT])
-    assert handler.skills == mock_skills
+    assert handler.skills_registry == mock_skills
 
 
 @pytest.mark.asyncio
@@ -743,7 +743,7 @@ async def test_skills_catalog_returns_catalog_xml(mock_llm: BaseLLM) -> None:
         llm_agent=llm_agent,
         task=Task(instruction="mock instruction"),
     )
-    handler.skills = {"my-skill": mock_skill}
+    handler.skills_registry = {"my-skill": mock_skill}
 
     expected = default_templates["skills_catalog"].format(
         skills="<skill><name>my-skill</name></skill>",
@@ -763,7 +763,7 @@ async def test_skills_catalog_excludes_explicit_only_skills(
         llm_agent=llm_agent,
         task=Task(instruction="mock instruction"),
     )
-    handler.skills = {"my-skill": mock_skill}
+    handler.skills_registry = {"my-skill": mock_skill}
     handler._explicit_only_skills = {"my-skill"}
 
     assert handler._skills_catalog == ""
@@ -787,7 +787,7 @@ async def test_run_step_injects_skills_catalog() -> None:
         llm_agent=llm_agent,
         task=Task(instruction="mock instruction"),
     )
-    handler.skills = {"my-skill": mock_skill}
+    handler.skills_registry = {"my-skill": mock_skill}
 
     step = TaskStep(
         task_id=handler.task.id_,

--- a/tests/skills/test_tools.py
+++ b/tests/skills/test_tools.py
@@ -27,13 +27,13 @@ def make_skill(
 
 def test_use_skill_tool_name() -> None:
     """Tests UseSkillTool.name returns 'use_skill'."""
-    tool = UseSkillTool(skills={})
+    tool = UseSkillTool(skills_registry={})
     assert tool.name == "from_scratch__use_skill"
 
 
 def test_use_skill_tool_description() -> None:
     """Tests UseSkillTool.description mentions activation."""
-    tool = UseSkillTool(skills={})
+    tool = UseSkillTool(skills_registry={})
     assert "activate" in tool.description.lower()
 
 
@@ -43,7 +43,7 @@ def test_use_skill_tool_parameters_json_schema_enum() -> None:
         "skill-a": make_skill(name="skill-a"),
         "skill-b": make_skill(name="skill-b"),
     }
-    tool = UseSkillTool(skills=skills)
+    tool = UseSkillTool(skills_registry=skills)
 
     enum = tool.parameters_json_schema["properties"]["name"]["enum"]
     assert "skill-a" in enum
@@ -56,7 +56,7 @@ def test_use_skill_tool_parameters_json_schema_excludes_explicit_only() -> None:
         "visible": make_skill(name="visible"),
         "hidden": make_skill(name="hidden"),
     }
-    tool = UseSkillTool(skills=skills, explicit_only_skills={"hidden"})
+    tool = UseSkillTool(skills_registry=skills, explicit_only_skills={"hidden"})
 
     enum = tool.parameters_json_schema["properties"]["name"]["enum"]
     assert "visible" in enum
@@ -80,7 +80,7 @@ def test_use_skill_tool_build_skill_content_without_resources(
         location=skill_md,
         scope=SkillScope.PROJECT,
     )
-    tool = UseSkillTool(skills={"my-skill": skill})
+    tool = UseSkillTool(skills_registry={"my-skill": skill})
 
     content = tool._build_skill_content("my-skill")
 
@@ -110,7 +110,7 @@ def test_use_skill_tool_build_skill_content_with_resources(
         location=skill_md,
         scope=SkillScope.PROJECT,
     )
-    tool = UseSkillTool(skills={"my-skill": skill})
+    tool = UseSkillTool(skills_registry={"my-skill": skill})
 
     content = tool._build_skill_content("my-skill")
 
@@ -141,7 +141,7 @@ def test_use_skill_tool_call_returns_skill_content(tmp_path: Path) -> None:
         location=skill_md,
         scope=SkillScope.PROJECT,
     )
-    tool = UseSkillTool(skills={"my-skill": skill})
+    tool = UseSkillTool(skills_registry={"my-skill": skill})
     tool_call = ToolCall(tool_name="use_skill", arguments={"name": "my-skill"})
 
     result = tool(tool_call=tool_call)
@@ -170,7 +170,7 @@ def test_use_skill_tool_call_returns_error_on_invalid_name(
         location=skill_md,
         scope=SkillScope.PROJECT,
     )
-    tool = UseSkillTool(skills={"my-skill": skill})
+    tool = UseSkillTool(skills_registry={"my-skill": skill})
     tool_call = ToolCall(
         tool_name="use_skill",
         arguments={"name": "nonexistent"},
@@ -202,10 +202,10 @@ def test_use_skill_tool_call_returns_error_when_skill_missing_from_registry(
         location=skill_md,
         scope=SkillScope.PROJECT,
     )
-    tool = UseSkillTool(skills={"my-skill": skill})
+    tool = UseSkillTool(skills_registry={"my-skill": skill})
     # simulate divergence: name still in enum (_visible) but removed
     # from registry
-    del tool._skills["my-skill"]
+    del tool._skills_registry["my-skill"]
     tool_call = ToolCall(
         tool_name="use_skill",
         arguments={"name": "my-skill"},
@@ -219,7 +219,7 @@ def test_use_skill_tool_call_returns_error_when_skill_missing_from_registry(
 
 def test_use_skill_tool_call_returns_error_when_name_is_not_string() -> None:
     """Tests __call__ returns error when 'name' argument is not a string."""
-    tool = UseSkillTool(skills={})
+    tool = UseSkillTool(skills_registry={})
     tool_call = ToolCall(
         tool_name="use_skill",
         arguments={"name": 42},

--- a/tests/skills/test_tools.py
+++ b/tests/skills/test_tools.py
@@ -186,7 +186,7 @@ def test_use_skill_tool_call_returns_error_when_skill_missing_from_registry(
 ) -> None:
     """Tests __call__ guard when skill passes enum but is absent from registry.
 
-    Simulates a case where _skills and _visible diverge — the guard in
+    Simulates a case where _skills_registry and _visible diverge — the guard in
     __call__ catches this before _build_skill_content raises a KeyError.
     run_with_skill() piggybacks on this guard for unknown skill names.
     """


### PR DESCRIPTION
## Summary

- Renames `TaskHandler.skills: dict[str, Skill]` → `TaskHandler.skills_registry` to match the `_registry` suffix convention used by `tools_registry` and `subagents_registry`
- Renames `UseSkillTool.__init__` param `skills` → `skills_registry` (and internal `self._skills` → `self._skills_registry`) for the same reason

## Notes

- Purely cosmetic — no logic, control flow, or behaviour changed
- Closes #758

## Test plan

- [ ] `make lint` passes
- [ ] `pytest tests/` — 395 passed