### PR TITLE
feat(ch09): SharedConsoleHumanInputTool + _prompt_human helper refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
         entry: mypy --config-file=mypy.ini --explicit-package-bases src
         additional_dependencies:
           - pydantic>=2.10.5
+          - rich>=13.9.0
           - types-PyYAML>=6.0.12
         # https://github.com/python/mypy/issues/13916 -- duplicate module error with .pyi and .py files
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch09): `SharedConsoleHumanInputTool` — async sibling to `HumanInputTool` safe under concurrent tool execution; class-level `asyncio.Lock` serializes all prompts to a single stdin; optional `owner` label rendered in the panel title; extracts `_prompt_human` module-level helper shared by both classes (#747)
 - feat(ch09): `LLMAgent.subagents_registry` param, `TaskHandler._use_subagent_tool`, `TaskHandler._subagents_catalog`, and `DEFAULT_SUBAGENTS_CATALOG` template — wires sub-agent registry and `<available_subagents>` catalog into the coordinator; `LLMAgentBuilder.with_subagent()` / `with_subagents()` fluent methods (#756, #746)
 - feat(ch09): `SubAgentSpec.catalog()` and `CATALOG_SPEC_TEMPLATE` — XML catalog entry for a sub-agent, mirroring `Skill.catalog()` / `CATALOG_SKILL_TEMPLATE` from Ch06 (#756)
 - feat(ch09): `UseSubAgentTool` — async tool dispatching tasks to named sub-agents; catches all exceptions (incl. `MaxStepsReachedError`) as error results (#755)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- feat(ch09): `SharedConsoleHumanInputTool` — async sibling to `HumanInputTool` safe under concurrent tool execution; class-level `asyncio.Lock` serializes all prompts to a single stdin; optional `owner` label rendered in the panel title; extracts `_prompt_human` module-level helper shared by both classes (#747)
+- feat(ch09): `SharedConsoleHumanInputTool` — async sibling to `HumanInputTool` safe under concurrent tool execution; class-level `asyncio.Lock` serializes all prompts to a single stdin; optional `agent_name` label rendered in the panel title; extracts `_prompt_human` module-level helper shared by both classes (#747)
 - feat(ch09): `LLMAgent.subagents_registry` param, `TaskHandler._use_subagent_tool`, `TaskHandler._subagents_catalog`, and `DEFAULT_SUBAGENTS_CATALOG` template — wires sub-agent registry and `<available_subagents>` catalog into the coordinator; `LLMAgentBuilder.with_subagent()` / `with_subagents()` fluent methods (#756, #746)
 - feat(ch09): `SubAgentSpec.catalog()` and `CATALOG_SPEC_TEMPLATE` — XML catalog entry for a sub-agent, mirroring `Skill.catalog()` / `CATALOG_SKILL_TEMPLATE` from Ch06 (#756)
 - feat(ch09): `UseSubAgentTool` — async tool dispatching tasks to named sub-agents; catches all exceptions (incl. `MaxStepsReachedError`) as error results (#755)

--- a/src/llm_agents_from_scratch/tools/default/__init__.py
+++ b/src/llm_agents_from_scratch/tools/default/__init__.py
@@ -1,7 +1,7 @@
 """Default tools included with every LLMAgent."""
 
 from ...base.tool import BaseTool
-from .human_input import HumanInputTool
+from .human_input import HumanInputTool, SharedConsoleHumanInputTool
 from .interpreter import PythonInterpreterTool
 from .read_file import ReadFileTool
 
@@ -12,4 +12,5 @@ __all__ = [
     "HumanInputTool",
     "PythonInterpreterTool",
     "ReadFileTool",
+    "SharedConsoleHumanInputTool",
 ]

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -1,7 +1,7 @@
 """Human in the loop via HumanInputTool and SharedConsoleHumanInputTool."""
 
 import asyncio
-from typing import Any, cast
+from typing import Any
 
 from rich.console import Console
 from rich.panel import Panel
@@ -10,14 +10,11 @@ from rich.prompt import Prompt
 from ...base.tool import AsyncBaseTool, BaseTool
 from ...data_structures import ToolCall, ToolCallResult
 
-_PANEL_BORDER = "yellow"
-_PROMPT_MARKER = ">"
-
 
 def _prompt_human(
     prompt: str,
     choices: list[str] | None,
-    owner: str | None = None,
+    agent_name: str | None = None,
 ) -> str:
     """Render a human-input panel and return the operator's response.
 
@@ -26,14 +23,11 @@ def _prompt_human(
         KeyboardInterrupt: If the operator interrupts.
     """
     console = Console()
-    title = f"Human Input — {owner}" if owner else "Human Input"
-    console.print(Panel(prompt, title=title, border_style=_PANEL_BORDER))
+    title = f"Human Input — {agent_name}" if agent_name else "Human Input"
+    console.print(Panel(prompt, title=title, border_style="yellow"))
     if choices:
-        return cast(
-            str,
-            Prompt.ask(_PROMPT_MARKER, choices=choices, console=console),
-        )
-    return cast(str, Prompt.ask(_PROMPT_MARKER, console=console))
+        return Prompt.ask(">", choices=choices, console=console)
+    return Prompt.ask(">", console=console)
 
 
 class HumanInputTool(BaseTool):
@@ -141,8 +135,8 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     concurrently. The class-level lock serializes all prompts to a
     single stdin so concurrent agents take turns rather than racing.
 
-    The optional ``owner`` label is rendered in the panel title so the
-    operator knows which sub-agent is asking. Typically set to
+    The optional ``agent_name`` label is rendered in the panel title so
+    the operator knows which sub-agent is asking. Typically set to
     ``SubAgentSpec.name`` at construction.
 
     The class-level ``_console_lock`` is shared by all instances, so
@@ -169,7 +163,7 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     autouse fixture that handles 3.10-3.11 test isolation.
 
     Attributes:
-        owner (str | None): Label shown in the panel title, e.g.
+        agent_name (str | None): Label shown in the panel title, e.g.
             ``"Human Input — researcher"``. ``None`` renders the
             default ``"Human Input"`` title.
     """
@@ -179,14 +173,14 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     # behaviour.
     _console_lock: asyncio.Lock = asyncio.Lock()
 
-    def __init__(self, owner: str | None = None) -> None:
-        """Initialise with an optional owner label.
+    def __init__(self, agent_name: str | None = None) -> None:
+        """Initialise with an optional agent-name label.
 
         Args:
-            owner (str | None): Sub-agent name rendered in the panel
-                title. Defaults to None.
+            agent_name (str | None): Sub-agent name rendered in the
+                panel title. Defaults to None.
         """
-        self.owner = owner
+        self.agent_name = agent_name
 
     @property
     def name(self) -> str:
@@ -263,7 +257,7 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
                     _prompt_human,
                     prompt,
                     choices,
-                    self.owner,
+                    self.agent_name,
                 )
         except EOFError:
             return ToolCallResult(

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -18,6 +18,17 @@ def _prompt_human(
 ) -> str:
     """Render a human-input panel and return the operator's response.
 
+    Args:
+        prompt (str): The question or prompt to present to the human.
+        choices (list[str] | None): Optional list of valid responses.
+            When provided, the human is re-prompted until they enter
+            one of the listed values.
+        agent_name (str | None): Name of the coordinator or sub-agent
+            rendered in the panel title. Defaults to None.
+
+    Returns:
+        str: The human's response.
+
     Raises:
         EOFError: If stdin is closed.
         KeyboardInterrupt: If the operator interrupts.
@@ -136,8 +147,9 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     single stdin so concurrent agents take turns rather than racing.
 
     The optional ``agent_name`` label is rendered in the panel title so
-    the operator knows which sub-agent is asking. Typically set to
-    ``SubAgentSpec.name`` at construction.
+    the operator knows which agent is asking — the coordinator or one
+    of its sub-agents. Typically set to ``SubAgentSpec.name`` for a
+    sub-agent, or left ``None`` for the coordinator.
 
     The class-level ``_console_lock`` is shared by all instances, so
     concurrent agents take turns at a single stdin rather than racing.
@@ -177,8 +189,9 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
         """Initialise with an optional agent-name label.
 
         Args:
-            agent_name (str | None): Sub-agent name rendered in the
-                panel title. Defaults to None.
+            agent_name (str | None): Name of the coordinator or
+                sub-agent rendered in the panel title. Defaults to
+                None.
         """
         self.agent_name = agent_name
 

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -151,9 +151,23 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
             default ``"Human Input"`` title.
     """
 
-    # Class-level lock: all instances share one stdin, so one lock.
-    # In Python 3.10+ asyncio.Lock binds to the running loop on first
-    # acquire(), not at construction, so this is safe to initialise here.
+    # Class-level lock — all instances share one stdin, so one lock suffices.
+    #
+    # asyncio.Lock behaviour by Python version:
+    #   ≤3.9  : __init__ called get_event_loop() at construction, binding the
+    #           lock to the import-time loop.  Class-level creation was unsafe.
+    #   3.10–3.11 : _LoopBoundMixin defers binding to the first acquire().
+    #           Construction is safe; the lock binds on first use and then
+    #           rejects any other event loop.  Tests that spin up a fresh loop
+    #           per function must reset this attribute to a new asyncio.Lock()
+    #           in an autouse fixture so each test gets an unbound lock.
+    #   3.12+ : _LoopBoundMixin removed; every acquire() calls
+    #           get_running_loop() fresh — no caching, no cross-loop errors.
+    #
+    # This project requires >=3.10, so class-level creation is safe in
+    # production (all agents run as create_task() coroutines within a single
+    # asyncio.run()).  See tests/tools/test_default.py::reset_console_lock for
+    # the autouse fixture that handles 3.10–3.11 test isolation.
     _console_lock: asyncio.Lock = asyncio.Lock()
 
     def __init__(self, owner: str | None = None) -> None:

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -1,13 +1,39 @@
-"""Human in the loop via HumanInputTool."""
+"""Human in the loop via HumanInputTool and SharedConsoleHumanInputTool."""
 
-from typing import Any
+import asyncio
+from typing import Any, cast
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
 
-from ...base.tool import BaseTool
+from ...base.tool import AsyncBaseTool, BaseTool
 from ...data_structures import ToolCall, ToolCallResult
+
+_PANEL_BORDER = "yellow"
+_PROMPT_MARKER = ">"
+
+
+def _prompt_human(
+    prompt: str,
+    choices: list[str] | None,
+    owner: str | None = None,
+) -> str:
+    """Render a human-input panel and return the operator's response.
+
+    Raises:
+        EOFError: If stdin is closed.
+        KeyboardInterrupt: If the operator interrupts.
+    """
+    console = Console()
+    title = f"Human Input — {owner}" if owner else "Human Input"
+    console.print(Panel(prompt, title=title, border_style=_PANEL_BORDER))
+    if choices:
+        return cast(
+            str,
+            Prompt.ask(_PROMPT_MARKER, choices=choices, console=console),
+        )
+    return cast(str, Prompt.ask(_PROMPT_MARKER, console=console))
 
 
 class HumanInputTool(BaseTool):
@@ -88,14 +114,7 @@ class HumanInputTool(BaseTool):
             )
         choices = tool_call.arguments.get("choices")
         try:
-            console = Console()
-            console.print(
-                Panel(prompt, title="Human Input", border_style="yellow"),
-            )
-            if choices:
-                response = Prompt.ask(">", choices=choices, console=console)
-            else:
-                response = Prompt.ask(">", console=console)
+            response = _prompt_human(prompt, choices)
         except EOFError:
             return ToolCallResult(
                 tool_call_id=tool_call.id_,
@@ -108,7 +127,132 @@ class HumanInputTool(BaseTool):
                 content="Human declined to provide input (KeyboardInterrupt).",
                 error=True,
             )
+        return ToolCallResult(
+            tool_call_id=tool_call.id_,
+            content=response,
+        )
 
+
+class SharedConsoleHumanInputTool(AsyncBaseTool):
+    """Async human-input tool safe under concurrent tool execution.
+
+    Drop-in async replacement for ``HumanInputTool`` for use in
+    multi-agent systems where ``asyncio.gather`` may run tools
+    concurrently. The class-level lock serializes all prompts to a
+    single stdin so concurrent agents take turns rather than racing.
+
+    The optional ``owner`` label is rendered in the panel title so the
+    operator knows which sub-agent is asking. Typically set to
+    ``SubAgentSpec.name`` at construction.
+
+    Attributes:
+        owner (str | None): Label shown in the panel title, e.g.
+            ``"Human Input — researcher"``. ``None`` renders the
+            default ``"Human Input"`` title.
+    """
+
+    # Class-level lock: all instances share one stdin, so one lock.
+    # Binds to the running event loop on first use — fine for single-loop use.
+    _console_lock: asyncio.Lock = asyncio.Lock()
+
+    def __init__(self, owner: str | None = None) -> None:
+        """Initialise with an optional owner label.
+
+        Args:
+            owner (str | None): Sub-agent name rendered in the panel
+                title. Defaults to None.
+        """
+        self.owner = owner
+
+    @property
+    def name(self) -> str:
+        """Name of the shared-console human-input tool."""
+        return "from_scratch__human_input"
+
+    @property
+    def description(self) -> str:
+        """Description of the shared-console human-input tool."""
+        return (
+            "Ask the human operator a question and wait for their response. "
+            "Use this tool when you need clarification or additional "
+            "information that is not available from the task context. "
+            "Optionally provide a list of choices to constrain the response."
+        )
+
+    @property
+    def parameters_json_schema(self) -> dict[str, Any]:
+        """JSON schema for human input parameters."""
+        return {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": (
+                        "The question or prompt to present to the human."
+                    ),
+                },
+                "choices": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional list of valid responses. When provided, "
+                        "the human is re-prompted until they enter one of "
+                        "the listed values."
+                    ),
+                },
+            },
+            "required": ["prompt"],
+        }
+
+    async def __call__(
+        self,
+        tool_call: ToolCall,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ToolCallResult:
+        """Acquire the console lock, then prompt the human in a thread.
+
+        Serializes concurrent prompts via ``_console_lock`` and runs
+        ``_prompt_human`` in a worker thread so the event loop stays free
+        while waiting for stdin.
+
+        Args:
+            tool_call (ToolCall): The tool call containing the ``prompt``
+                argument and optional ``choices`` list.
+            *args (Any): Additional positional arguments (unused).
+            **kwargs (Any): Additional keyword arguments (unused).
+
+        Returns:
+            ToolCallResult: The human's response as the content.
+        """
+        prompt = tool_call.arguments.get("prompt", "")
+        if not prompt:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="No prompt provided.",
+                error=True,
+            )
+        choices = tool_call.arguments.get("choices")
+        try:
+            async with self._console_lock:
+                response = await asyncio.to_thread(
+                    _prompt_human,
+                    prompt,
+                    choices,
+                    self.owner,
+                )
+        except EOFError:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="No input received (stdin closed).",
+                error=True,
+            )
+        except KeyboardInterrupt:
+            return ToolCallResult(
+                tool_call_id=tool_call.id_,
+                content="Human declined to provide input (KeyboardInterrupt).",
+                error=True,
+            )
         return ToolCallResult(
             tool_call_id=tool_call.id_,
             content=response,

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -152,9 +152,9 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     """
 
     # Class-level lock: all instances share one stdin, so one lock.
-    # Initialized lazily inside __call__ so it binds to the running event loop,
-    # not to the import-time default loop.
-    _console_lock: asyncio.Lock | None = None
+    # In Python 3.10+ asyncio.Lock binds to the running loop on first
+    # acquire(), not at construction, so this is safe to initialise here.
+    _console_lock: asyncio.Lock = asyncio.Lock()
 
     def __init__(self, owner: str | None = None) -> None:
         """Initialise with an optional owner label.
@@ -234,8 +234,6 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
                 error=True,
             )
         choices: list[str] | None = tool_call.arguments.get("choices")
-        if SharedConsoleHumanInputTool._console_lock is None:
-            SharedConsoleHumanInputTool._console_lock = asyncio.Lock()
         try:
             async with SharedConsoleHumanInputTool._console_lock:
                 response = await asyncio.to_thread(

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -112,7 +112,7 @@ class HumanInputTool(BaseTool):
                 content="No prompt provided.",
                 error=True,
             )
-        choices = tool_call.arguments.get("choices")
+        choices: list[str] | None = tool_call.arguments.get("choices")
         try:
             response = _prompt_human(prompt, choices)
         except EOFError:
@@ -152,8 +152,9 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     """
 
     # Class-level lock: all instances share one stdin, so one lock.
-    # Binds to the running event loop on first use — fine for single-loop use.
-    _console_lock: asyncio.Lock = asyncio.Lock()
+    # Initialized lazily inside __call__ so it binds to the running event loop,
+    # not to the import-time default loop.
+    _console_lock: asyncio.Lock | None = None
 
     def __init__(self, owner: str | None = None) -> None:
         """Initialise with an optional owner label.
@@ -232,9 +233,11 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
                 content="No prompt provided.",
                 error=True,
             )
-        choices = tool_call.arguments.get("choices")
+        choices: list[str] | None = tool_call.arguments.get("choices")
+        if SharedConsoleHumanInputTool._console_lock is None:
+            SharedConsoleHumanInputTool._console_lock = asyncio.Lock()
         try:
-            async with self._console_lock:
+            async with SharedConsoleHumanInputTool._console_lock:
                 response = await asyncio.to_thread(
                     _prompt_human,
                     prompt,

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -145,29 +145,38 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     operator knows which sub-agent is asking. Typically set to
     ``SubAgentSpec.name`` at construction.
 
+    The class-level ``_console_lock`` is shared by all instances, so
+    concurrent agents take turns at a single stdin rather than racing.
+    ``asyncio.Lock`` binding behaviour differs by Python version:
+
+    - ``<=3.9``: ``__init__`` called ``get_event_loop()`` at
+      construction, binding the lock to the import-time loop.
+      Class-level creation was unsafe.
+    - ``3.10-3.11``: ``_LoopBoundMixin`` defers binding to the first
+      ``acquire()``. Construction is safe; the lock binds on first use
+      and then rejects any other event loop. Tests that spin up a
+      fresh loop per function must reset this attribute to a new
+      ``asyncio.Lock()`` in an autouse fixture so each test gets an
+      unbound lock.
+    - ``3.12+``: ``_LoopBoundMixin`` removed; every ``acquire()`` calls
+      ``get_running_loop()`` fresh, so there is no caching and no
+      cross-loop errors.
+
+    This project requires ``>=3.10``, so class-level creation is safe
+    in production (all agents run as ``create_task()`` coroutines
+    within a single ``asyncio.run()``). See
+    ``tests/tools/test_default.py::reset_console_lock`` for the
+    autouse fixture that handles 3.10-3.11 test isolation.
+
     Attributes:
         owner (str | None): Label shown in the panel title, e.g.
             ``"Human Input — researcher"``. ``None`` renders the
             default ``"Human Input"`` title.
     """
 
-    # Class-level lock — all instances share one stdin, so one lock suffices.
-    #
-    # asyncio.Lock behaviour by Python version:
-    #   ≤3.9  : __init__ called get_event_loop() at construction, binding the
-    #           lock to the import-time loop.  Class-level creation was unsafe.
-    #   3.10–3.11 : _LoopBoundMixin defers binding to the first acquire().
-    #           Construction is safe; the lock binds on first use and then
-    #           rejects any other event loop.  Tests that spin up a fresh loop
-    #           per function must reset this attribute to a new asyncio.Lock()
-    #           in an autouse fixture so each test gets an unbound lock.
-    #   3.12+ : _LoopBoundMixin removed; every acquire() calls
-    #           get_running_loop() fresh — no caching, no cross-loop errors.
-    #
-    # This project requires >=3.10, so class-level creation is safe in
-    # production (all agents run as create_task() coroutines within a single
-    # asyncio.run()).  See tests/tools/test_default.py::reset_console_lock for
-    # the autouse fixture that handles 3.10–3.11 test isolation.
+    # Class-level lock — all instances share one stdin, so one lock
+    # suffices. See the class docstring for version-specific binding
+    # behaviour.
     _console_lock: asyncio.Lock = asyncio.Lock()
 
     def __init__(self, owner: str | None = None) -> None:

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -1,5 +1,6 @@
 """Unit tests for default tools."""
 
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,9 +20,9 @@ from llm_agents_from_scratch.tools.default.human_input import _prompt_human
 @pytest.fixture(autouse=True)
 def reset_console_lock() -> None:
     """Reset the class-level lock between tests to avoid event-loop binding."""
-    SharedConsoleHumanInputTool._console_lock = None
+    SharedConsoleHumanInputTool._console_lock = asyncio.Lock()
     yield
-    SharedConsoleHumanInputTool._console_lock = None
+    SharedConsoleHumanInputTool._console_lock = asyncio.Lock()
 
 
 def test_read_file_tool_name() -> None:
@@ -475,22 +476,11 @@ def test_shared_console_human_input_tool_owner_stored() -> None:
     assert tool.owner == "researcher"
 
 
-@pytest.mark.asyncio
-async def test_shared_console_human_input_tool_lock_is_class_level() -> None:
-    """Tests all instances share the same _console_lock after initialization."""
+def test_shared_console_human_input_tool_lock_is_class_level() -> None:
+    """Tests all instances share the same _console_lock."""
     a = SharedConsoleHumanInputTool(owner="researcher")
     b = SharedConsoleHumanInputTool(owner="coder")
-    tool_call = ToolCall(
-        tool_name="from_scratch__human_input",
-        arguments={"prompt": "Hello?"},
-    )
-    with patch(
-        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
-        return_value="yes",
-    ):
-        await a(tool_call=tool_call)
 
-    assert SharedConsoleHumanInputTool._console_lock is not None
     assert a._console_lock is b._console_lock
     assert a._console_lock is SharedConsoleHumanInputTool._console_lock
 

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -417,8 +417,8 @@ def test_human_input_tool_keyboard_interrupt() -> None:
 # --- _prompt_human ---
 
 
-def test_prompt_human_with_owner_sets_panel_title() -> None:
-    """Tests _prompt_human includes the owner in the panel title."""
+def test_prompt_human_with_agent_name_sets_panel_title() -> None:
+    """Tests _prompt_human includes the agent_name in the panel title."""
     with (
         patch("rich.console.Console.print") as mock_print,
         patch("rich.prompt.Prompt.ask", return_value="answer"),
@@ -430,8 +430,8 @@ def test_prompt_human_with_owner_sets_panel_title() -> None:
     assert "researcher" in str(panel.title)
 
 
-def test_prompt_human_without_owner_uses_default_title() -> None:
-    """Tests _prompt_human uses 'Human Input' title when owner is None."""
+def test_prompt_human_without_agent_name_uses_default_title() -> None:
+    """Tests _prompt_human uses 'Human Input' title when agent_name is None."""
     with (
         patch("rich.console.Console.print") as mock_print,
         patch("rich.prompt.Prompt.ask", return_value="answer"),
@@ -465,21 +465,21 @@ def test_shared_console_human_input_tool_parameters_json_schema() -> None:
     assert schema["required"] == ["prompt"]
 
 
-def test_shared_console_human_input_tool_owner_defaults_to_none() -> None:
-    """Tests SharedConsoleHumanInputTool.owner defaults to None."""
-    assert SharedConsoleHumanInputTool().owner is None
+def test_shared_console_human_input_tool_agent_name_defaults_to_none() -> None:
+    """Tests SharedConsoleHumanInputTool.agent_name defaults to None."""
+    assert SharedConsoleHumanInputTool().agent_name is None
 
 
-def test_shared_console_human_input_tool_owner_stored() -> None:
-    """Tests SharedConsoleHumanInputTool stores the owner label."""
-    tool = SharedConsoleHumanInputTool(owner="researcher")
-    assert tool.owner == "researcher"
+def test_shared_console_human_input_tool_agent_name_stored() -> None:
+    """Tests SharedConsoleHumanInputTool stores the agent_name label."""
+    tool = SharedConsoleHumanInputTool(agent_name="researcher")
+    assert tool.agent_name == "researcher"
 
 
 def test_shared_console_human_input_tool_lock_is_class_level() -> None:
     """Tests all instances share the same _console_lock."""
-    a = SharedConsoleHumanInputTool(owner="researcher")
-    b = SharedConsoleHumanInputTool(owner="coder")
+    a = SharedConsoleHumanInputTool(agent_name="researcher")
+    b = SharedConsoleHumanInputTool(agent_name="coder")
 
     assert a._console_lock is b._console_lock
     assert a._console_lock is SharedConsoleHumanInputTool._console_lock
@@ -504,9 +504,9 @@ async def test_shared_console_human_input_tool_returns_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shared_console_human_input_tool_passes_owner_to_prompt() -> None:
-    """Tests SharedConsoleHumanInputTool passes owner to _prompt_human."""
-    tool = SharedConsoleHumanInputTool(owner="researcher")
+async def test_shared_console_human_input_tool_passes_agent_name() -> None:
+    """Tests SharedConsoleHumanInputTool passes agent_name to _prompt_human."""
+    tool = SharedConsoleHumanInputTool(agent_name="researcher")
     tool_call = ToolCall(
         tool_name="from_scratch__human_input",
         arguments={"prompt": "Help?"},

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -3,13 +3,17 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from llm_agents_from_scratch.data_structures import ToolCall
 from llm_agents_from_scratch.tools.default import (
     DEFAULT_TOOLS,
     HumanInputTool,
     PythonInterpreterTool,
     ReadFileTool,
+    SharedConsoleHumanInputTool,
 )
+from llm_agents_from_scratch.tools.default.human_input import _prompt_human
 
 
 def test_read_file_tool_name() -> None:
@@ -398,4 +402,190 @@ def test_human_input_tool_keyboard_interrupt() -> None:
 
     assert result.error is True
     assert result.content is not None
+    assert "declined" in result.content.lower()
+
+
+# --- _prompt_human ---
+
+
+def test_prompt_human_with_owner_sets_panel_title() -> None:
+    """Tests _prompt_human includes the owner in the panel title."""
+    with (
+        patch("rich.console.Console.print") as mock_print,
+        patch("rich.prompt.Prompt.ask", return_value="answer"),
+    ):
+        result = _prompt_human("Ask something?", None, "researcher")
+
+    assert result == "answer"
+    panel = mock_print.call_args[0][0]
+    assert "researcher" in str(panel.title)
+
+
+def test_prompt_human_without_owner_uses_default_title() -> None:
+    """Tests _prompt_human uses 'Human Input' title when owner is None."""
+    with (
+        patch("rich.console.Console.print") as mock_print,
+        patch("rich.prompt.Prompt.ask", return_value="answer"),
+    ):
+        result = _prompt_human("Ask something?", None)
+
+    assert result == "answer"
+    panel = mock_print.call_args[0][0]
+    assert panel.title == "Human Input"
+
+
+# --- SharedConsoleHumanInputTool ---
+
+
+def test_shared_console_human_input_tool_name() -> None:
+    """Tests SharedConsoleHumanInputTool.name matches HumanInputTool."""
+    assert SharedConsoleHumanInputTool().name == "from_scratch__human_input"
+
+
+def test_shared_console_human_input_tool_description() -> None:
+    """Tests SharedConsoleHumanInputTool.description mentions human."""
+    assert "human" in SharedConsoleHumanInputTool().description.lower()
+
+
+def test_shared_console_human_input_tool_parameters_json_schema() -> None:
+    """Tests SharedConsoleHumanInputTool schema matches HumanInputTool."""
+    schema = SharedConsoleHumanInputTool().parameters_json_schema
+    assert schema["type"] == "object"
+    assert "prompt" in schema["properties"]
+    assert "choices" in schema["properties"]
+    assert schema["required"] == ["prompt"]
+
+
+def test_shared_console_human_input_tool_owner_defaults_to_none() -> None:
+    """Tests SharedConsoleHumanInputTool.owner defaults to None."""
+    assert SharedConsoleHumanInputTool().owner is None
+
+
+def test_shared_console_human_input_tool_owner_stored() -> None:
+    """Tests SharedConsoleHumanInputTool stores the owner label."""
+    tool = SharedConsoleHumanInputTool(owner="researcher")
+    assert tool.owner == "researcher"
+
+
+def test_shared_console_human_input_tool_lock_is_class_level() -> None:
+    """Tests all instances share the same _console_lock."""
+    a = SharedConsoleHumanInputTool(owner="researcher")
+    b = SharedConsoleHumanInputTool(owner="coder")
+    assert a._console_lock is b._console_lock
+    assert a._console_lock is SharedConsoleHumanInputTool._console_lock
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_returns_response() -> None:
+    """Tests SharedConsoleHumanInputTool returns the human's response."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "What is your name?"},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        return_value="Alice",
+    ):
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is False
+    assert result.content == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_passes_owner_to_prompt() -> None:
+    """Tests SharedConsoleHumanInputTool passes owner to _prompt_human."""
+    tool = SharedConsoleHumanInputTool(owner="researcher")
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "Help?"},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        return_value="yes",
+    ) as mock_prompt:
+        await tool(tool_call=tool_call)
+
+    mock_prompt.assert_called_once_with("Help?", None, "researcher")
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_missing_prompt_error() -> None:
+    """Tests SharedConsoleHumanInputTool returns error when prompt is absent."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={},
+    )
+    result = await tool(tool_call=tool_call)
+    assert result.error is True
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_empty_prompt_returns_error() -> (
+    None
+):
+    """Tests SharedConsoleHumanInputTool returns error for empty prompt."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": ""},
+    )
+    result = await tool(tool_call=tool_call)
+    assert result.error is True
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_choices_passed() -> None:
+    """Tests SharedConsoleHumanInputTool passes choices to _prompt_human."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "Pick one:", "choices": ["yes", "no"]},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        return_value="yes",
+    ) as mock_prompt:
+        result = await tool(tool_call=tool_call)
+
+    mock_prompt.assert_called_once_with("Pick one:", ["yes", "no"], None)
+    assert result.error is False
+    assert result.content == "yes"
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_eof_error() -> None:
+    """Tests SharedConsoleHumanInputTool returns error on EOFError."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "Enter value:"},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        side_effect=EOFError,
+    ):
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is True
+    assert "stdin" in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_keyboard_interrupt() -> None:
+    """Tests SharedConsoleHumanInputTool returns error on KeyboardInterrupt."""
+    tool = SharedConsoleHumanInputTool()
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "Enter value:"},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        side_effect=KeyboardInterrupt,
+    ):
+        result = await tool(tool_call=tool_call)
+
+    assert result.error is True
     assert "declined" in result.content.lower()

--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -16,6 +16,14 @@ from llm_agents_from_scratch.tools.default import (
 from llm_agents_from_scratch.tools.default.human_input import _prompt_human
 
 
+@pytest.fixture(autouse=True)
+def reset_console_lock() -> None:
+    """Reset the class-level lock between tests to avoid event-loop binding."""
+    SharedConsoleHumanInputTool._console_lock = None
+    yield
+    SharedConsoleHumanInputTool._console_lock = None
+
+
 def test_read_file_tool_name() -> None:
     """Tests ReadFileTool.name."""
     tool = ReadFileTool()
@@ -467,10 +475,22 @@ def test_shared_console_human_input_tool_owner_stored() -> None:
     assert tool.owner == "researcher"
 
 
-def test_shared_console_human_input_tool_lock_is_class_level() -> None:
-    """Tests all instances share the same _console_lock."""
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_lock_is_class_level() -> None:
+    """Tests all instances share the same _console_lock after initialization."""
     a = SharedConsoleHumanInputTool(owner="researcher")
     b = SharedConsoleHumanInputTool(owner="coder")
+    tool_call = ToolCall(
+        tool_name="from_scratch__human_input",
+        arguments={"prompt": "Hello?"},
+    )
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        return_value="yes",
+    ):
+        await a(tool_call=tool_call)
+
+    assert SharedConsoleHumanInputTool._console_lock is not None
     assert a._console_lock is b._console_lock
     assert a._console_lock is SharedConsoleHumanInputTool._console_lock
 


### PR DESCRIPTION
## Summary

- Extracts `_prompt_human(prompt, choices, agent_name)` as a module-level helper — handles rich panel rendering and EOF/KeyboardInterrupt; shared by both classes
- Refactors `HumanInputTool.__call__` to delegate to `_prompt_human` — public surface and behaviour unchanged
- Adds `SharedConsoleHumanInputTool(AsyncBaseTool)` — async sibling safe under concurrent tool execution (`asyncio.gather`):
  - Class-level `_console_lock: asyncio.Lock` serializes all prompts to a single stdin across instances
  - `agent_name: str | None` rendered in the panel title for attribution (e.g. `"Human Input — researcher"`) — names the coordinator agent or a sub-agent
  - Prompt runs in `asyncio.to_thread` so the event loop stays free while waiting for stdin

## Teaching arc

Ch8 `to_thread` (don't freeze the loop) → Ch4-amended `gather` (run independent work concurrently) → Ch9 `Lock` (serialize access to a shared resource)

## Test plan

- [x] `make lint` passes
- [x] `pytest tests/` — 395 passed
- [x] Tests for `SharedConsoleHumanInputTool` tracked in #748

Closes #747