### PR TITLE
feat: distinguishing log prefix for dispatched sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch09): `current_subagent_name` — `contextvars.ContextVar` set by `UseSubAgentTool` around a dispatched sub-agent's `run()`; `ColoredFormatter` prepends `[name]` to every log line emitted while that sub-agent is in flight, so console output distinguishes coordinator logs from sub-agent logs (#775)
 - feat(ch09): `subagents/recipes.py` — `general_subagent()` (`DEFAULT_TOOLS`-equipped) and `explore_subagent()` (`ReadFileTool`-only, lower `max_steps`) default subagent factories, mirroring `memory/recipes.py`; use directly with `with_subagents([general_subagent(llm), ...])`, no builder sugar (#765)
 - feat(ch09): `SharedConsoleHumanInputTool` — async sibling to `HumanInputTool` safe under concurrent tool execution; class-level `asyncio.Lock` serializes all prompts to a single stdin; optional `agent_name` label rendered in the panel title; extracts `_prompt_human` module-level helper shared by both classes (#747)
 - feat(ch09): `LLMAgent.subagents_registry` param, `TaskHandler._use_subagent_tool`, `TaskHandler._subagents_catalog`, and `DEFAULT_SUBAGENTS_CATALOG` template — wires sub-agent registry and `<available_subagents>` catalog into the coordinator; `LLMAgentBuilder.with_subagent()` / `with_subagents()` fluent methods (#756, #746)

--- a/src/llm_agents_from_scratch/logger.py
+++ b/src/llm_agents_from_scratch/logger.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from contextvars import ContextVar
 
 from colorama import Fore, Style, init
 from typing_extensions import override
@@ -12,6 +13,14 @@ init(autoreset=True)
 ROOT_LOGGER_NAME = "llm_agents_fs"
 DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_MSG_MAX_LENGTH = 150
+
+# Set by UseSubAgentTool around a dispatched sub-agent's run() so every log
+# line emitted from within that run — coordinator and sub-agent share the
+# same logger names — can be tagged with which agent it came from.
+current_subagent_name: ContextVar[str | None] = ContextVar(
+    "current_subagent_name",
+    default=None,
+)
 
 
 class ColoredFormatter(logging.Formatter):
@@ -40,7 +49,11 @@ class ColoredFormatter(logging.Formatter):
             f"{self.COLORS.get(levelname, '')}{levelname}{Style.RESET_ALL}"
         )
 
-        return f"{colored_levelname} ({logger_name}) :      {log_msg}"
+        prefix = ""
+        if subagent_name := current_subagent_name.get():
+            prefix = f"{Fore.CYAN}[{subagent_name}]{Style.RESET_ALL} "
+
+        return f"{prefix}{colored_levelname} ({logger_name}) :      {log_msg}"
 
 
 def get_logger(name: str | None = None) -> logging.Logger:

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -125,7 +125,19 @@ class UseSubAgentTool(AsyncBaseTool):
             )
         spec = self._subagents_registry.get(subagent_name)
         # set before spec.agent.run() so the task it creates copies a
-        # context with the name already set — reset once it settles
+        # context with the name already set — reset once it settles.
+        #
+        # Safe under normal usage: this is the only call site that ever
+        # sets current_subagent_name, and run_step() always reaches it
+        # through asyncio.gather (even for a single tool call), so the
+        # context mutated here is already a fork of the coordinator's own
+        # context, never the coordinator's context itself — concurrent or
+        # nested dispatches can't collide (see learnings/LEARNING-001).
+        # Calling this tool directly, bypassing run_step (e.g. for manual
+        # dispatch demos), is the one path where set() lands on whatever
+        # context the caller happens to be in — still safe as long as
+        # nothing else concurrently shares that same context, which the
+        # try/finally reset here guarantees for this call in isolation.
         token = current_subagent_name.set(subagent_name)
         try:
             if spec is None:

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -89,6 +89,24 @@ class UseSubAgentTool(AsyncBaseTool):
     ) -> ToolCallResult:
         """Dispatch a task to the named sub-agent and return its result.
 
+        Sets ``current_subagent_name`` before calling ``spec.agent.run()``
+        so the ``asyncio.Task`` it creates copies a context with the name
+        already set, and resets it once the dispatch settles. This is the
+        only call site that ever sets ``current_subagent_name``.
+
+        Safe under normal usage: ``run_step()`` always reaches this method
+        through ``asyncio.gather`` (even for a single tool call), so the
+        context mutated here is already a fork of the coordinator's own
+        context, never the coordinator's context itself — concurrent or
+        nested dispatches can't collide, since each fork owns an
+        independent copy from the moment it's created, before any
+        ``set()`` runs. Calling this tool directly, bypassing
+        ``run_step()`` (e.g. for a manual dispatch demo), is the one path
+        where ``set()`` lands on whatever context the caller happens to
+        be in — still safe as long as nothing else concurrently shares
+        that context, which the ``try``/``finally`` reset below
+        guarantees for this call in isolation.
+
         Args:
             tool_call (ToolCall): The tool call to execute.
             *args (Any): Additional positional arguments.
@@ -124,20 +142,6 @@ class UseSubAgentTool(AsyncBaseTool):
                 ),
             )
         spec = self._subagents_registry.get(subagent_name)
-        # set before spec.agent.run() so the task it creates copies a
-        # context with the name already set — reset once it settles.
-        #
-        # Safe under normal usage: this is the only call site that ever
-        # sets current_subagent_name, and run_step() always reaches it
-        # through asyncio.gather (even for a single tool call), so the
-        # context mutated here is already a fork of the coordinator's own
-        # context, never the coordinator's context itself — concurrent or
-        # nested dispatches can't collide (see learnings/LEARNING-001).
-        # Calling this tool directly, bypassing run_step (e.g. for manual
-        # dispatch demos), is the one path where set() lands on whatever
-        # context the caller happens to be in — still safe as long as
-        # nothing else concurrently shares that same context, which the
-        # try/finally reset here guarantees for this call in isolation.
         token = current_subagent_name.set(subagent_name)
         try:
             if spec is None:

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -10,6 +10,7 @@ from llm_agents_from_scratch.data_structures import (
     ToolCallResult,
 )
 from llm_agents_from_scratch.errors import SubAgentNotFoundError
+from llm_agents_from_scratch.logger import current_subagent_name
 
 from .spec import SubAgentSpec
 
@@ -123,6 +124,9 @@ class UseSubAgentTool(AsyncBaseTool):
                 ),
             )
         spec = self._subagents_registry.get(subagent_name)
+        # set before spec.agent.run() so the task it creates copies a
+        # context with the name already set — reset once it settles
+        token = current_subagent_name.set(subagent_name)
         try:
             if spec is None:
                 raise SubAgentNotFoundError(
@@ -144,6 +148,8 @@ class UseSubAgentTool(AsyncBaseTool):
                     },
                 ),
             )
+        finally:
+            current_subagent_name.reset(token)
 
         return ToolCallResult(
             tool_call_id=tool_call.id_,

--- a/tests/subagents/test_tools.py
+++ b/tests/subagents/test_tools.py
@@ -10,6 +10,7 @@ from llm_agents_from_scratch.agent import LLMAgent
 from llm_agents_from_scratch.base.llm import BaseLLM
 from llm_agents_from_scratch.data_structures import Task, TaskResult, ToolCall
 from llm_agents_from_scratch.errors import MaxStepsReachedError
+from llm_agents_from_scratch.logger import current_subagent_name
 from llm_agents_from_scratch.subagents import SubAgentSpec, UseSubAgentTool
 
 MAX_STEPS_CODER = 5
@@ -105,6 +106,56 @@ async def test_use_subagent_tool_passes_max_steps(mock_llm: BaseLLM) -> None:
         await tool(tool_call=tool_call)
 
     assert mock_run.call_args.kwargs.get("max_steps") == MAX_STEPS_CODER
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_sets_current_subagent_name_during_run(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests current_subagent_name is set while spec.agent.run() executes."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_running_loop().create_future()
+    )
+    future.set_result(TaskResult(task_id="t1", content="done"))
+    observed: dict[str, str | None] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> asyncio.Future[TaskResult]:
+        observed["name"] = current_subagent_name.get()
+        return future
+
+    spec = make_spec("researcher", mock_llm)
+    with patch.object(spec.agent, "run", side_effect=fake_run):
+        tool = UseSubAgentTool(subagents_registry={"researcher": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "researcher", "task": "do it"},
+        )
+        await tool(tool_call=tool_call)
+
+    assert observed["name"] == "researcher"
+    assert current_subagent_name.get() is None
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_resets_current_subagent_name_on_error(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests current_subagent_name resets even when the sub-agent raises."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_running_loop().create_future()
+    )
+    future.set_exception(RuntimeError("boom"))
+
+    spec = make_spec("coder", mock_llm)
+    with patch.object(spec.agent, "run", return_value=future):
+        tool = UseSubAgentTool(subagents_registry={"coder": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "coder", "task": "do it"},
+        )
+        await tool(tool_call=tool_call)
+
+    assert current_subagent_name.get() is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,48 @@
+"""Unit tests for the logging module."""
+
+import logging
+
+from llm_agents_from_scratch.logger import (
+    ColoredFormatter,
+    current_subagent_name,
+)
+
+
+def make_record(msg: str = "a message") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="llm_agents_fs.TaskHandler",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_colored_formatter_no_prefix_by_default() -> None:
+    """Tests format() omits the subagent prefix when unset."""
+    formatted = ColoredFormatter().format(make_record())
+
+    assert not formatted.startswith("\x1b[36m")
+
+
+def test_colored_formatter_includes_subagent_prefix() -> None:
+    """Tests format() prepends the subagent name when the contextvar is set."""
+    token = current_subagent_name.set("hailstone")
+    try:
+        formatted = ColoredFormatter().format(make_record())
+    finally:
+        current_subagent_name.reset(token)
+
+    assert formatted.startswith("\x1b[36m[hailstone]")
+
+
+def test_colored_formatter_prefix_reverts_after_reset() -> None:
+    """Tests the prefix disappears once the contextvar is reset."""
+    token = current_subagent_name.set("hailstone")
+    current_subagent_name.reset(token)
+
+    formatted = ColoredFormatter().format(make_record())
+
+    assert "[hailstone]" not in formatted


### PR DESCRIPTION
## Summary

`LLMAgent.logger` and `TaskHandler.logger` are `get_logger(self.__class__.__name__)` — every instance of a given class shares the same logger name, so once a coordinator dispatches to a sub-agent, the sub-agent's own step-by-step logs print to the console indistinguishably from the coordinator's.

- `logger.py`: adds `current_subagent_name: ContextVar[str | None]`. `ColoredFormatter.format()` reads it and prepends `[name]` (cyan) to the line when set.
- `subagents/tools.py`: `UseSubAgentTool.__call__` sets it to the dispatched sub-agent's name before calling `spec.agent.run(...)` and resets it in a `finally` block once the run settles.

## Why contextvars, not a `name` param on `LLMAgent`

- No change to `LLMAgent`'s public constructor for a purely cosmetic logging concern.
- Correctly isolates concurrent dispatches: each `asyncio.Task` created by `asyncio.gather` (the parallel fan-out pattern) copies the context at creation time, before any `.set()` runs, so concurrent dispatches — even to the same sub-agent name — never collide. Verified empirically (two concurrent `"general"` dispatches + one concurrent `"explore"` dispatch, each retains its own value across an `await`, no cross-contamination, parent context untouched after `gather` completes).
- `asyncio.to_thread` (used for sync tools) explicitly propagates a copy of the calling context into worker threads, so sync tools inside a dispatched sub-agent's step log with the correct prefix too.

## Test plan

- [x] `make lint` passes
- [x] `pytest tests/` — 432 passed

Closes #774