### PR TITLE
feat: skill scope control for dispatched sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch09): `SubAgentSpec.skills_scopes` and `SubAgentSpec.explicit_only_skills` — per-sub-agent skill scope control, mirroring `max_steps`; `UseSubAgentTool` forwards both to `spec.agent.run()`; `None` (default) preserves prior behaviour (#781)
 - feat(ch09): `current_subagent_name` — `contextvars.ContextVar` set by `UseSubAgentTool` around a dispatched sub-agent's `run()`; `ColoredFormatter` prepends `[name]` to every log line emitted while that sub-agent is in flight, so console output distinguishes coordinator logs from sub-agent logs (#775)
 - feat(ch09): `subagents/recipes.py` — `general_subagent()` (`DEFAULT_TOOLS`-equipped) and `explore_subagent()` (`ReadFileTool`-only, lower `max_steps`) default subagent factories, mirroring `memory/recipes.py`; use directly with `with_subagents([general_subagent(llm), ...])`, no builder sugar (#765)
 - feat(ch09): `SharedConsoleHumanInputTool` — async sibling to `HumanInputTool` safe under concurrent tool execution; class-level `asyncio.Lock` serializes all prompts to a single stdin; optional `agent_name` label rendered in the panel title; extracts `_prompt_human` module-level helper shared by both classes (#747)

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -3,6 +3,7 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 from llm_agents_from_scratch.agent import LLMAgent
+from llm_agents_from_scratch.data_structures.skill import SkillScope
 
 from .constants import CATALOG_SPEC_TEMPLATE
 
@@ -27,6 +28,13 @@ class SubAgentSpec(BaseModel):
         max_steps: Optional cap on the number of steps the sub-agent may
             take per dispatch. Passed to ``agent.run()`` to bound runaway
             executions. ``None`` uses the agent's own default.
+        skills_scopes: Optional scopes to scan for skills on this
+            sub-agent's dispatches. Passed to ``agent.run()``. ``None``
+            uses the agent's own default (``[USER, PROJECT]``).
+        explicit_only_skills: Optional skill names to exclude from this
+            sub-agent's model catalog on dispatch. Passed to
+            ``agent.run()``. ``None`` uses the agent's own default (no
+            exclusions).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -51,6 +59,20 @@ class SubAgentSpec(BaseModel):
         description=(
             "Optional cap on sub-agent steps per dispatch. "
             "None uses the agent's own default."
+        ),
+    )
+    skills_scopes: list[SkillScope] | None = Field(
+        default=None,
+        description=(
+            "Optional scopes to scan for skills on this sub-agent's "
+            "dispatches. None uses the agent's own default."
+        ),
+    )
+    explicit_only_skills: set[str] | None = Field(
+        default=None,
+        description=(
+            "Optional skill names to exclude from this sub-agent's model "
+            "catalog on dispatch. None uses the agent's own default."
         ),
     )
 

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -151,6 +151,8 @@ class UseSubAgentTool(AsyncBaseTool):
             result = await spec.agent.run(
                 Task(instruction=task_instruction),
                 max_steps=spec.max_steps,
+                skills_scopes=spec.skills_scopes,
+                explicit_only_skills=spec.explicit_only_skills,
             )
         except Exception as e:
             return ToolCallResult(

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from llm_agents_from_scratch.agent import LLMAgent
 from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.data_structures.skill import SkillScope
 from llm_agents_from_scratch.subagents import SubAgentSpec
 
 MAX_STEPS = 10
@@ -23,6 +24,34 @@ def test_subagentspec_init(mock_llm: BaseLLM) -> None:
     assert spec.description == "Searches the web and summarises findings."
     assert spec.agent is agent
     assert spec.max_steps is None
+    assert spec.skills_scopes is None
+    assert spec.explicit_only_skills is None
+
+
+def test_subagentspec_skills_scopes(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec stores an explicit skills_scopes value."""
+    agent = LLMAgent(llm=mock_llm)
+    spec = SubAgentSpec(
+        name="coder",
+        description="Writes and runs Python code.",
+        agent=agent,
+        skills_scopes=[SkillScope.PROJECT],
+    )
+
+    assert spec.skills_scopes == [SkillScope.PROJECT]
+
+
+def test_subagentspec_explicit_only_skills(mock_llm: BaseLLM) -> None:
+    """Tests SubAgentSpec stores an explicit explicit_only_skills value."""
+    agent = LLMAgent(llm=mock_llm)
+    spec = SubAgentSpec(
+        name="coder",
+        description="Writes and runs Python code.",
+        agent=agent,
+        explicit_only_skills={"stop-at-one"},
+    )
+
+    assert spec.explicit_only_skills == {"stop-at-one"}
 
 
 def test_subagentspec_max_steps(mock_llm: BaseLLM) -> None:

--- a/tests/subagents/test_tools.py
+++ b/tests/subagents/test_tools.py
@@ -9,6 +9,7 @@ import pytest
 from llm_agents_from_scratch.agent import LLMAgent
 from llm_agents_from_scratch.base.llm import BaseLLM
 from llm_agents_from_scratch.data_structures import Task, TaskResult, ToolCall
+from llm_agents_from_scratch.data_structures.skill import SkillScope
 from llm_agents_from_scratch.errors import MaxStepsReachedError
 from llm_agents_from_scratch.logger import current_subagent_name
 from llm_agents_from_scratch.subagents import SubAgentSpec, UseSubAgentTool
@@ -20,12 +21,16 @@ def make_spec(
     name: str,
     mock_llm: BaseLLM,
     max_steps: int | None = None,
+    skills_scopes: list[SkillScope] | None = None,
+    explicit_only_skills: set[str] | None = None,
 ) -> SubAgentSpec:
     return SubAgentSpec(
         name=name,
         description=f"Sub-agent: {name}",
         agent=LLMAgent(llm=mock_llm),
         max_steps=max_steps,
+        skills_scopes=skills_scopes,
+        explicit_only_skills=explicit_only_skills,
     )
 
 
@@ -86,6 +91,8 @@ async def test_use_subagent_tool_dispatches_task(mock_llm: BaseLLM) -> None:
     assert isinstance(call_args.args[0], Task)
     assert call_args.args[0].instruction == "What is the answer?"
     assert call_args.kwargs.get("max_steps") is None
+    assert call_args.kwargs.get("skills_scopes") is None
+    assert call_args.kwargs.get("explicit_only_skills") is None
 
 
 @pytest.mark.asyncio
@@ -106,6 +113,62 @@ async def test_use_subagent_tool_passes_max_steps(mock_llm: BaseLLM) -> None:
         await tool(tool_call=tool_call)
 
     assert mock_run.call_args.kwargs.get("max_steps") == MAX_STEPS_CODER
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_passes_skills_scopes(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests skills_scopes from SubAgentSpec is forwarded to agent.run()."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_running_loop().create_future()
+    )
+    future.set_result(TaskResult(task_id="t1", content="done"))
+
+    spec = make_spec(
+        "coder",
+        mock_llm,
+        skills_scopes=[SkillScope.PROJECT],
+    )
+    with patch.object(spec.agent, "run", return_value=future) as mock_run:
+        tool = UseSubAgentTool(subagents_registry={"coder": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "coder", "task": "Write a sort function."},
+        )
+        await tool(tool_call=tool_call)
+
+    assert mock_run.call_args.kwargs.get("skills_scopes") == [
+        SkillScope.PROJECT,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_use_subagent_tool_passes_explicit_only_skills(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests explicit_only_skills is forwarded to agent.run()."""
+    future: asyncio.Future[TaskResult] = (
+        asyncio.get_running_loop().create_future()
+    )
+    future.set_result(TaskResult(task_id="t1", content="done"))
+
+    spec = make_spec(
+        "coder",
+        mock_llm,
+        explicit_only_skills={"stop-at-one"},
+    )
+    with patch.object(spec.agent, "run", return_value=future) as mock_run:
+        tool = UseSubAgentTool(subagents_registry={"coder": spec})
+        tool_call = ToolCall(
+            tool_name="from_scratch__use_subagent",
+            arguments={"name": "coder", "task": "Write a sort function."},
+        )
+        await tool(tool_call=tool_call)
+
+    assert mock_run.call_args.kwargs.get("explicit_only_skills") == {
+        "stop-at-one",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`SubAgentSpec` had a `max_steps: int | None` field controlling the per-dispatch step budget, but nothing analogous for skills. Every dispatched sub-agent silently fell back to `LLMAgent.run()`'s default `[SkillScope.USER, SkillScope.PROJECT]` skill discovery, with no way for a `SubAgentSpec` author to restrict or exclude skill discovery per sub-agent.

- Adds `skills_scopes: list[SkillScope] | None = None` and `explicit_only_skills: set[str] | None = None` fields to `SubAgentSpec`, mirroring `max_steps`.
- `UseSubAgentTool.__call__` forwards both to `spec.agent.run(...)`, same as it already forwards `max_steps`.
- Default behaviour (fields unset) is unchanged — `None` means "use the agent's own default," matching the `max_steps` precedent. No change unless a spec author opts in.

## Concrete failure mode this fixes

If a reader still has Ch6's `stop-at-one` skill registered at project scope, `general`/`explore` (or any sub-agent, regardless of its `description`) would discover and get offered that skill in its `<available_skills>` catalog on every dispatch — with no way to say "this sub-agent shouldn't see skills at all" or "only skill X."

## Test plan

- [x] `make lint` passes
- [x] `pytest tests/` — 436 passed (4 new tests: `SubAgentSpec` field defaults/storage, `UseSubAgentTool` forwarding for both fields)

Closes #779