### PR TITLE
chore: sync CITATION.cff date-released in version-bump skill

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: version-bump
-description: Bump the package version (major, minor, or patch), then sync CITATION.cff, src/_version.py, and CHANGELOG.md. Use when asked to cut a release or bump the version.
+description: Bump the package version (major, minor, or patch), then sync CITATION.cff (version + date-released), src/_version.py, and CHANGELOG.md. Use when asked to cut a release or bump the version.
 ---
 
 # Version Bump
@@ -35,10 +35,11 @@ Capture the new version from the output (e.g. `0.0.15`). Strip the leading `v` i
 
 ### 2. Update `CITATION.cff`
 
-In `CITATION.cff`, replace the `version:` line with the new version:
+In `CITATION.cff`, replace the `version:` line with the new version, and replace the `date-released:` line with today's date in `YYYY-MM-DD` format:
 
 ```yaml
 version: "<new_version>"
+date-released: "<today_date>"
 ```
 
 ### 3. Update `src/llm_agents_from_scratch/_version.py`


### PR DESCRIPTION
## Summary

PR #794's Copilot review caught that `CITATION.cff`'s `date-released` stayed pinned to the original 0.0.1 release date (2025-07-01) while `version` bumped to 0.0.22 — the two fields describe the same release event and should move together (a citer using `version: 0.0.22` needs the real 0.0.22 release date, not the project's original date).

Updates the `version-bump` skill's Step 2 so `date-released` gets updated alongside `version` on every future bump, instead of drifting out of sync.

## Test plan

- N/A — skill/documentation change only, no code