### PR TITLE
feat(ch10): configurable A2AAgentSpec.timeout for UseA2AAgentTool dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch10): `A2AAgentSpec.timeout` (default 60.0) — configurable per-peer dispatch timeout for `UseA2AAgentTool`, passed through to `httpx.AsyncClient`; overridable via `from_agent_card()`/`from_url()` (#807)
 - feat(ch10): `UseA2AAgentTool` — dispatch schema `name` + `task` + optional `task_id` to resume a peer task parked in `TASK_STATE_INPUT_REQUIRED`; creates an SDK client fresh per dispatch and always closes it; `TaskHandler._use_a2a_agent_tool`/`_a2a_agents_catalog` wired into `run_step` (#800)
 - feat(ch10): `LLMAgent.a2a_agents_registry` (keyed by plain peer name, unlike `MCPToolProvider`'s prefixed tool names — A2A dispatch is one generic tool with `name` as an enum value); `LLMAgentBuilder.with_a2a_agent()`/`with_a2a_agents()` fluent methods and `build()` pass-through (#799)
 - feat(ch10): `a2a/` package — `A2AAgentSpec`, the registry value type for a peer A2A agent; `from_agent_card()`/`from_url()` construction, `.catalog()` with nested `<a2a_skills>`; `errors/a2a.py` — `A2AAgentCardMissingInterfaceError` (#798)

--- a/src/llm_agents_from_scratch/a2a/spec.py
+++ b/src/llm_agents_from_scratch/a2a/spec.py
@@ -65,7 +65,9 @@ class A2AAgentSpec(BaseModel):
             peer before timing out. Defaults to 60.0 rather than
             ``httpx``'s own default (5.0s, applied to connect/read/
             write/pool combined) — too low for a peer that makes one or
-            more LLM calls per task.
+            more LLM calls per task. Explicitly setting this to
+            ``None`` disables the timeout entirely (unbounded), since
+            it is passed straight through to ``httpx.AsyncClient``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -99,8 +101,8 @@ class A2AAgentSpec(BaseModel):
         default=60.0,
         description=(
             "Seconds UseA2AAgentTool allows a dispatch to this peer "
-            "before timing out. None falls back to httpx's own default "
-            "(5.0s combined), which is too low for most peers."
+            "before timing out. Explicitly setting this to None "
+            "disables the timeout entirely (unbounded)."
         ),
     )
 

--- a/src/llm_agents_from_scratch/a2a/spec.py
+++ b/src/llm_agents_from_scratch/a2a/spec.py
@@ -61,6 +61,11 @@ class A2AAgentSpec(BaseModel):
             one.
         agent_card: The peer's resolved ``AgentCard``, fetched eagerly at
             construction time.
+        timeout: Seconds ``UseA2AAgentTool`` allows a dispatch to this
+            peer before timing out. Defaults to 60.0 rather than
+            ``httpx``'s own default (5.0s, applied to connect/read/
+            write/pool combined) — too low for a peer that makes one or
+            more LLM calls per task.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -90,12 +95,21 @@ class A2AAgentSpec(BaseModel):
     agent_card: AgentCard = Field(
         description="The peer's resolved AgentCard.",
     )
+    timeout: float | None = Field(
+        default=60.0,
+        description=(
+            "Seconds UseA2AAgentTool allows a dispatch to this peer "
+            "before timing out. None falls back to httpx's own default "
+            "(5.0s combined), which is too low for most peers."
+        ),
+    )
 
     @classmethod
     def from_agent_card(
         cls,
         agent_card: AgentCard,
         headers: dict[str, str] | None = None,
+        timeout: float | None = 60.0,
     ) -> A2AAgentSpec:
         """Builds a spec from an ``AgentCard`` already in hand.
 
@@ -105,6 +119,8 @@ class A2AAgentSpec(BaseModel):
         Args:
             agent_card: The peer's already-resolved ``AgentCard``.
             headers: Optional HTTP headers sent on requests to this peer.
+            timeout: Seconds ``UseA2AAgentTool`` allows a dispatch to
+                this peer before timing out.
 
         Returns:
             A2AAgentSpec: The constructed spec.
@@ -123,6 +139,7 @@ class A2AAgentSpec(BaseModel):
             url=agent_card.supported_interfaces[0].url,
             agent_card=agent_card,
             headers=headers,
+            timeout=timeout,
         )
 
     @classmethod
@@ -131,6 +148,7 @@ class A2AAgentSpec(BaseModel):
         url: str,
         headers: dict[str, str] | None = None,
         agent_card_path: str | None = None,
+        timeout: float | None = 60.0,
     ) -> A2AAgentSpec:
         """Fetches the peer's ``AgentCard`` from ``url``, then builds a spec.
 
@@ -147,6 +165,9 @@ class A2AAgentSpec(BaseModel):
             headers: Optional HTTP headers sent on requests to this peer.
             agent_card_path: Optional override for the well-known agent
                 card path. ``None`` uses the SDK's own default.
+            timeout: Seconds ``UseA2AAgentTool`` allows a dispatch to
+                this peer before timing out. Also applied to this card
+                resolution itself.
 
         Returns:
             A2AAgentSpec: The constructed spec.
@@ -155,7 +176,10 @@ class A2AAgentSpec(BaseModel):
             A2AAgentCardMissingInterfaceError: If the fetched card
                 declares no ``supported_interfaces``.
         """
-        async with httpx.AsyncClient(headers=headers) as httpx_client:
+        async with httpx.AsyncClient(
+            headers=headers,
+            timeout=timeout,
+        ) as httpx_client:
             resolver_kwargs: dict[str, str] = {}
             if agent_card_path is not None:
                 resolver_kwargs["agent_card_path"] = agent_card_path
@@ -169,6 +193,7 @@ class A2AAgentSpec(BaseModel):
         return cls.from_agent_card(
             agent_card=agent_card,
             headers=headers,
+            timeout=timeout,
         )
 
     def catalog(self) -> str:

--- a/src/llm_agents_from_scratch/a2a/spec.py
+++ b/src/llm_agents_from_scratch/a2a/spec.py
@@ -165,9 +165,9 @@ class A2AAgentSpec(BaseModel):
             headers: Optional HTTP headers sent on requests to this peer.
             agent_card_path: Optional override for the well-known agent
                 card path. ``None`` uses the SDK's own default.
-            timeout: Seconds ``UseA2AAgentTool`` allows a dispatch to
-                this peer before timing out. Also applied to this card
-                resolution itself.
+            timeout: Timeout in seconds, applied both to this card
+                resolution and, via the returned spec, to every future
+                ``UseA2AAgentTool`` dispatch to this peer.
 
         Returns:
             A2AAgentSpec: The constructed spec.

--- a/src/llm_agents_from_scratch/a2a/tools.py
+++ b/src/llm_agents_from_scratch/a2a/tools.py
@@ -224,7 +224,10 @@ class UseA2AAgentTool(AsyncBaseTool):
         # not httpx_client. A harmless double-close of httpx_client can
         # happen on transports that do route through it (aclose() is
         # idempotent).
-        async with httpx.AsyncClient(headers=spec.headers) as httpx_client:
+        async with httpx.AsyncClient(
+            headers=spec.headers,
+            timeout=spec.timeout,
+        ) as httpx_client:
             client = None
             try:
                 client = await create_client(

--- a/tests/a2a/test_spec.py
+++ b/tests/a2a/test_spec.py
@@ -37,6 +37,7 @@ def test_a2aagentspec_from_agent_card() -> None:
     assert spec.url == DISPATCH_URL
     assert spec.agent_card == card
     assert spec.headers is None
+    assert spec.timeout == 60.0  # noqa: PLR2004
 
 
 def test_a2aagentspec_from_agent_card_with_headers() -> None:
@@ -48,6 +49,14 @@ def test_a2aagentspec_from_agent_card_with_headers() -> None:
     )
 
     assert spec.headers == {"Authorization": "Bearer token"}
+
+
+def test_a2aagentspec_from_agent_card_with_timeout() -> None:
+    """Tests A2AAgentSpec.from_agent_card stores an explicit timeout."""
+    card = _agent_card()
+    spec = A2AAgentSpec.from_agent_card(agent_card=card, timeout=120.0)
+
+    assert spec.timeout == 120.0  # noqa: PLR2004
 
 
 def test_a2aagentspec_from_agent_card_uses_first_interface() -> None:
@@ -81,6 +90,7 @@ def test_a2aagentspec_has_no_client_field() -> None:
         "url",
         "headers",
         "agent_card",
+        "timeout",
     }
 
 
@@ -101,6 +111,7 @@ async def test_a2aagentspec_from_url() -> None:
     assert spec.agent_card == card
     # spec.url comes from the card's own interface, not the resolution url.
     assert spec.url == DISPATCH_URL
+    assert spec.timeout == 60.0  # noqa: PLR2004
 
 
 @pytest.mark.asyncio
@@ -131,6 +142,34 @@ async def test_a2aagentspec_from_url_passes_headers_and_card_path() -> None:
 
     assert captured["kwargs"]["base_url"] == "http://127.0.0.1:9999"
     assert captured["kwargs"]["agent_card_path"] == "/custom/card.json"
+
+
+@pytest.mark.asyncio
+async def test_a2aagentspec_from_url_passes_timeout_to_httpx_client() -> None:
+    """Tests from_url's card-resolution client receives spec.timeout."""
+    card = _agent_card()
+    captured_kwargs: dict[str, object] = {}
+    real_init = httpx.AsyncClient.__init__
+
+    def _capturing_init(self: httpx.AsyncClient, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+        real_init(self, **kwargs)
+
+    with (
+        patch.object(httpx.AsyncClient, "__init__", new=_capturing_init),
+        patch(
+            "llm_agents_from_scratch.a2a.spec.A2ACardResolver.get_agent_card",
+            new_callable=AsyncMock,
+            return_value=card,
+        ),
+    ):
+        spec = await A2AAgentSpec.from_url(
+            url="http://127.0.0.1:9999",
+            timeout=99.0,
+        )
+
+    assert captured_kwargs["timeout"] == 99.0  # noqa: PLR2004
+    assert spec.timeout == 99.0  # noqa: PLR2004
 
 
 @pytest.mark.asyncio

--- a/tests/a2a/test_tools.py
+++ b/tests/a2a/test_tools.py
@@ -369,6 +369,43 @@ async def test_use_a2a_agent_tool_closes_httpx_client_on_create_failure() -> (
 
 
 @pytest.mark.asyncio
+async def test_use_a2a_agent_tool_passes_spec_timeout() -> None:
+    """Tests spec.timeout reaches the dispatch httpx.AsyncClient."""
+    captured_kwargs: dict[str, Any] = {}
+
+    class _TrackedAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            super().__init__(*args, **kwargs)
+
+    client = _fake_client(StreamResponse(message=Message(role=Role.ROLE_AGENT)))
+    spec = A2AAgentSpec.from_agent_card(
+        agent_card=AgentCard(
+            name="researcher",
+            description="A peer agent.",
+            supported_interfaces=[AgentInterface(url="http://peer:9999")],
+        ),
+        timeout=123.0,
+    )
+
+    with (
+        patch(
+            "llm_agents_from_scratch.a2a.tools.httpx.AsyncClient",
+            new=_TrackedAsyncClient,
+        ),
+        _patch_create_client(client),
+    ):
+        tool = UseA2AAgentTool(a2a_agents_registry={"researcher": spec})
+        tool_call = ToolCall(
+            tool_name=TOOL_NAME,
+            arguments={"name": "researcher", "task": "do it"},
+        )
+        await tool(tool_call=tool_call)
+
+    assert captured_kwargs["timeout"] == 123.0  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
 async def test_use_a2a_agent_tool_suppresses_close_error() -> None:
     """Tests a close()-time exception doesn't override a computed result."""
     task = Task(


### PR DESCRIPTION
## Summary
- `A2AAgentSpec.timeout: float | None` (default `60.0`), settable via `from_agent_card()`/`from_url()`, mirroring the existing `headers` field's per-peer-config pattern.
- `UseA2AAgentTool.__call__` and `A2AAgentSpec.from_url()`'s own card-resolution client both pass `spec.timeout`/`timeout` through to `httpx.AsyncClient`.
- Fixes a real gap: `a2a-sdk` has no special timeout guidance of its own — `ClientFactory` falls back to a bare `httpx.AsyncClient()` (`client_factory.py:81`) when no client is supplied, which inherits httpx's plain 5.0s combined default. That's too low for any peer making one or more LLM calls per task — confirmed live against `extra/a2a-crewai-hailstone` (#802) computing a multi-step hailstone sequence, which hit `A2AClientTimeoutError` through `UseA2AAgentTool` while succeeding fine through a raw `a2a-sdk` client with a longer timeout.

## Test plan
- [x] New tests: `A2AAgentSpec` default/override timeout (`from_agent_card`, `from_url`), `UseA2AAgentTool` passes `spec.timeout` through to its dispatch `httpx.AsyncClient`
- [x] Existing `test_a2aagentspec_has_no_client_field` updated for the new field
- [x] `uv run pytest tests/a2a -q` — 49 passed
- [x] `ruff check`/`ruff format --check` clean; pre-commit's mypy hook passed

Closes #806