### PR TITLE
feat(ch10): Example 1 — constructing an A2AAgentSpec from an agent card / URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ core concepts to full multi-agent systems.
 
 | Ch | Title | Notebook |
 | -- | ----- | -------- |
-| 9 | Building MAS with Subagents | [Ch 9](https://masfromscratch.com/notebooks/ch09/) |
+| 9 | Assembling MAS with Subagents | [Ch 9](https://masfromscratch.com/notebooks/ch09/) |
+| 10 | Assembling Interoperable MAS with A2A | [Ch 10](https://masfromscratch.com/notebooks/ch10/) |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,8 @@ from core concepts to full multi-agent systems:
 
 | Ch | Title | Notebook |
 | -- | ----- | -------- |
-| 9 | Building MAS with Subagents | [Ch 9](notebooks/ch09.ipynb) |
+| 9 | Assembling MAS with Subagents | [Ch 9](notebooks/ch09.ipynb) |
+| 10 | Assembling Interoperable MAS with A2A | [Ch 10](notebooks/ch10.ipynb) |
 
 ---
 

--- a/docs/notebooks/ch10.ipynb
+++ b/docs/notebooks/ch10.ipynb
@@ -1,0 +1,1 @@
+../../examples/ch10.ipynb

--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -5,7 +5,7 @@
    "id": "a1b2c3d4-0009-0000-0000-000000000001",
    "metadata": {},
    "source": [
-    "# Chapter 9 — Multi-Agent Systems"
+    "# Chapter 9 — Assembling MAS with Subagents"
    ]
   },
   {

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -233,13 +233,26 @@
       "name: crewai-hailstone\n",
       "url: http://localhost:9200\n",
       "timeout: 60.0\n",
-      "<a2a_agent>\n",
-      "    <name>crewai-hailstone</name>\n",
-      "    <description>Computes the full Hailstone (Collatz) sequence for a positive integer via a CrewAI agent.</description>\n",
-      "    <a2a_skills>\n",
-      "      <a2a_skill>hailstone_sequence</a2a_skill>\n",
-      "    </a2a_skills>\n",
-      "  </a2a_agent>\n"
+      "name: \"crewai-hailstone\"\n",
+      "description: \"Computes the full Hailstone (Collatz) sequence for a positive integer via a CrewAI agent.\"\n",
+      "supported_interfaces {\n",
+      "  url: \"http://localhost:9200\"\n",
+      "  protocol_binding: \"JSONRPC\"\n",
+      "  protocol_version: \"1.0\"\n",
+      "}\n",
+      "version: \"0.1.0\"\n",
+      "capabilities {\n",
+      "  streaming: false\n",
+      "}\n",
+      "default_input_modes: \"text/plain\"\n",
+      "default_output_modes: \"text/plain\"\n",
+      "skills {\n",
+      "  id: \"hailstone_sequence\"\n",
+      "  name: \"hailstone_sequence\"\n",
+      "  description: \"Compute the full hailstone sequence for a positive integer x, repeatedly applying x / 2 (if even) or 3x + 1 (if odd) until reaching 1.\"\n",
+      "  tags: \"math\"\n",
+      "}\n",
+      "\n"
      ]
     }
    ],
@@ -251,7 +264,7 @@
     "print(f\"name: {spec.name}\")\n",
     "print(f\"url: {spec.url}\")\n",
     "print(f\"timeout: {spec.timeout}\")\n",
-    "print(spec.catalog())"
+    "print(spec.agent_card)"
    ]
   },
   {
@@ -309,7 +322,7 @@
     "\n",
     "spec_hand_built = A2AAgentSpec.from_agent_card(agent_card=hand_built_card)\n",
     "print(f\"spec name: {spec_hand_built.name}\")\n",
-    "print(f\"spec url: {spec_hand_built.url}\")"
+    "print(f\"spec url: {spec_hand_built.url}\")\n"
    ]
   },
   {

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -1,0 +1,368 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3d6cda68",
+   "metadata": {},
+   "source": [
+    "# Chapter 10 — Assembling Interoperable MAS with A2A"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e774fd8a",
+   "metadata": {},
+   "source": [
+    "## Setup Instructions\n",
+    "\n",
+    "To ensure you have the required dependencies to run this notebook, you'll need to have our `llm-agents-from-scratch` framework installed on the running Jupyter kernel. To do this, you can launch this notebook with the following command while within the project's root directory:\n",
+    "\n",
+    "```sh\n",
+    "uv run --with jupyter jupyter lab\n",
+    "```\n",
+    "\n",
+    "Alternatively, if you just want to use the published version of `llm-agents-from-scratch` without local development, you can install it from PyPi by uncommenting the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "791a535b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the line below to install `llm-agents-from-scratch` from PyPi\n",
+    "# !pip install llm-agents-from-scratch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "432c3996",
+   "metadata": {},
+   "source": [
+    "## Running an Ollama service\n",
+    "\n",
+    "To execute the code provided in this notebook, you'll need to have Ollama installed on your local machine and have its LLM hosting service running. To download Ollama, follow the instructions found on this page: https://ollama.com/download. After downloading and installing Ollama, you can start a service by opening a terminal and running the command `ollama serve`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4a235a38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Using Ollama Cloud\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, shutil, subprocess, time, urllib.request, urllib.error\n",
+    "\n",
+    "\n",
+    "def ensure_ollama(host=\"http://localhost:11434\", timeout=15):\n",
+    "    \"\"\"Start Ollama if not already running and wait until responsive.\"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(f\"{host}/api/tags\", timeout=1)\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "\n",
+    "    # Lightning persistent path first, then standard locations\n",
+    "    ollama_path = shutil.which(\"ollama\")\n",
+    "    if ollama_path is None:\n",
+    "        for candidate in [\n",
+    "            \"/teamspace/studios/this_studio/.local/bin/ollama\",\n",
+    "            \"/usr/local/bin/ollama\",\n",
+    "            \"/usr/bin/ollama\",\n",
+    "        ]:\n",
+    "            if os.path.exists(candidate):\n",
+    "                ollama_path = candidate\n",
+    "                break\n",
+    "    if ollama_path is None:\n",
+    "        raise RuntimeError(\n",
+    "            \"Could not find the ollama binary. Install with: \"\n",
+    "            \"curl -fsSL https://ollama.com/install.sh | sh\"\n",
+    "        )\n",
+    "\n",
+    "    print(f\"Starting Ollama server ({ollama_path})...\")\n",
+    "    subprocess.Popen(\n",
+    "        [ollama_path, \"serve\"],\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "use_cloud = \"OLLAMA_API_KEY\" in os.environ\n",
+    "ensure_ollama() if not use_cloud else print(\"✓ Using Ollama Cloud\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3184b009",
+   "metadata": {},
+   "source": [
+    "## The CrewAI Hailstone A2A server\n",
+    "\n",
+    "The examples in this notebook demonstrate the framework's A2A integration using a toy peer that exposes the Hailstone sequence as an A2A skill, built with a different agent stack (CrewAI) than the rest of this repo. This is intentional: it's a genuine external peer, not another `LLMAgent`.\n",
+    "\n",
+    "Unlike the MCP Hailstone server (Chapter 5), which speaks stdio and is spawned per-session automatically by `MCPToolProvider`, A2A peers are standalone HTTP services, and a client just points at a URL. This notebook launches the CrewAI Hailstone agent as a background process so it's reachable below.\n",
+    "\n",
+    "**Important:** Run this notebook from within the project's root directory.\n",
+    "\n",
+    "The code for the A2A server is located at: https://github.com/nerdai/llm-agents-from-scratch/tree/main/extra/a2a-crewai-hailstone"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2bef5aed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting CrewAI Hailstone A2A server at http://localhost:9200...\n",
+      "✓ CrewAI Hailstone A2A server up at http://localhost:9200\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess, time, urllib.request, urllib.error\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def ensure_a2a_crewai_hailstone(\n",
+    "    host=\"http://localhost:9200\",\n",
+    "    timeout=15,\n",
+    "):\n",
+    "    \"\"\"Start the CrewAI Hailstone A2A server if not already running.\n",
+    "\n",
+    "    Returns the Popen handle if this call started the server, or\n",
+    "    None if it was already running (so we know not to tear it down).\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def _up():\n",
+    "        try:\n",
+    "            urllib.request.urlopen(\n",
+    "                f\"{host}/.well-known/agent-card.json\",\n",
+    "                timeout=1,\n",
+    "            )\n",
+    "            return True\n",
+    "        except (urllib.error.URLError, ConnectionError, TimeoutError):\n",
+    "            return False\n",
+    "\n",
+    "    if _up():\n",
+    "        print(f\"✓ CrewAI Hailstone A2A server already running at {host}\")\n",
+    "        return None\n",
+    "\n",
+    "    server_path = Path.cwd().parent / \"extra/a2a-crewai-hailstone\"\n",
+    "    print(f\"Starting CrewAI Hailstone A2A server at {host}...\")\n",
+    "    process = subprocess.Popen(\n",
+    "        [\"uv\", \"run\", \"uvicorn\", \"main:app\", \"--host\", \"0.0.0.0\", \"--port\", \"9200\"],\n",
+    "        cwd=server_path,\n",
+    "        stdout=subprocess.DEVNULL,\n",
+    "        stderr=subprocess.DEVNULL,\n",
+    "    )\n",
+    "\n",
+    "    deadline = time.time() + timeout\n",
+    "    while time.time() < deadline:\n",
+    "        if _up():\n",
+    "            print(f\"✓ CrewAI Hailstone A2A server up at {host}\")\n",
+    "            return process\n",
+    "        time.sleep(0.5)\n",
+    "\n",
+    "    process.terminate()\n",
+    "    raise RuntimeError(f\"A2A server did not start within {timeout}s\")\n",
+    "\n",
+    "\n",
+    "a2a_server_process = ensure_a2a_crewai_hailstone()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52db7475",
+   "metadata": {},
+   "source": [
+    "## Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6085363",
+   "metadata": {},
+   "source": [
+    "### Example 1: Constructing an A2AAgentSpec from an Agent Card / URL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e3345e6",
+   "metadata": {},
+   "source": [
+    "#### 1a. From a URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1dda9c5f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "name: crewai-hailstone\n",
+      "url: http://localhost:9200\n",
+      "timeout: 60.0\n",
+      "<a2a_agent>\n",
+      "    <name>crewai-hailstone</name>\n",
+      "    <description>Computes the full Hailstone (Collatz) sequence for a positive integer via a CrewAI agent.</description>\n",
+      "    <a2a_skills>\n",
+      "      <a2a_skill>hailstone_sequence</a2a_skill>\n",
+      "    </a2a_skills>\n",
+      "  </a2a_agent>\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.a2a import A2AAgentSpec\n",
+    "\n",
+    "spec = await A2AAgentSpec.from_url(\"http://localhost:9200\")\n",
+    "\n",
+    "print(f\"name: {spec.name}\")\n",
+    "print(f\"url: {spec.url}\")\n",
+    "print(f\"timeout: {spec.timeout}\")\n",
+    "print(spec.catalog())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a5dc6c0",
+   "metadata": {},
+   "source": [
+    "#### 1b. From an Agent Card"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b76afc3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spec name: crewai-hailstone\n",
+      "spec url: http://localhost:9200\n"
+     ]
+    }
+   ],
+   "source": [
+    "from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill\n",
+    "from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol\n",
+    "\n",
+    "# hand-built, no network call -- useful for tests, fixtures, or a peer\n",
+    "# whose card details you already know ahead of time\n",
+    "hand_built_card = AgentCard(\n",
+    "    name=\"crewai-hailstone\",\n",
+    "    description=\"Computes the full Hailstone (Collatz) sequence.\",\n",
+    "    supported_interfaces=[\n",
+    "        AgentInterface(\n",
+    "            url=\"http://localhost:9200\",\n",
+    "            protocol_binding=TransportProtocol.JSONRPC,\n",
+    "            protocol_version=PROTOCOL_VERSION_1_0,\n",
+    "        ),\n",
+    "    ],\n",
+    "    version=\"0.1.0\",\n",
+    "    capabilities=AgentCapabilities(streaming=False),\n",
+    "    default_input_modes=[\"text/plain\"],\n",
+    "    default_output_modes=[\"text/plain\"],\n",
+    "    skills=[\n",
+    "        AgentSkill(\n",
+    "            id=\"hailstone_sequence\",\n",
+    "            name=\"hailstone_sequence\",\n",
+    "            description=\"Compute the full hailstone sequence for x.\",\n",
+    "            tags=[\"math\"],\n",
+    "        ),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "spec_hand_built = A2AAgentSpec.from_agent_card(agent_card=hand_built_card)\n",
+    "print(f\"spec name: {spec_hand_built.name}\")\n",
+    "print(f\"spec url: {spec_hand_built.url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b56ed568",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0b3a7624",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Stopped CrewAI Hailstone A2A server\n"
+     ]
+    }
+   ],
+   "source": [
+    "if a2a_server_process is not None:\n",
+    "    a2a_server_process.terminate()\n",
+    "    a2a_server_process.wait(timeout=5)\n",
+    "    print(\"✓ Stopped CrewAI Hailstone A2A server\")\n",
+    "else:\n",
+    "    print(\"A2A server wasn't started by this notebook -- leaving it running\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Chapter 7: notebooks/ch07.ipynb
     - Chapter 8: notebooks/ch08.ipynb
     - Chapter 9: notebooks/ch09.ipynb
+    - Chapter 10: notebooks/ch10.ipynb
   - More Examples:
     - more-examples/index.md
     # Symlinked from more-examples/ — do not copy directly.


### PR DESCRIPTION
## Summary
- New `examples/ch10.ipynb` (symlinked into `docs/notebooks/`, wired into `mkdocs.yml`) — Example 1 covers both `A2AAgentSpec` construction paths:
  - **1a.** `A2AAgentSpec.from_url()` against a live CrewAI Hailstone A2A peer (`extra/a2a-crewai-hailstone`, #802), launched as a background process from the notebook (`ensure_a2a_crewai_hailstone()`, mirroring `ensure_ollama()`'s idiom).
  - **1b.** `A2AAgentSpec.from_agent_card()` with a hand-built `AgentCard` (no network call).
- A `## Cleanup` section terminates the CrewAI server process, but only if this notebook run actually started it (returns `None` from the ensure-helper if it was already running) — unlike the MCP Hailstone server, whose stdio-spawned process lifecycle is owned by `MCPToolProvider`'s session itself, this uvicorn process has no owner object unless we capture it explicitly.
- Renamed the Ch9/Ch10 book chapter titles (notebook title cells, `README.md`, `docs/index.md`): **"Assembling MAS with Subagents"** / **"Assembling Interoperable MAS with A2A"** — the word choice ("Building" → "Interoperable") signals the real conceptual split between same-process subagents and cross-framework A2A peers.
- `mkdocs.yml` nav entries kept as plain `Chapter 9`/`Chapter 10`, matching every other chapter's nav label.

## Test plan
- [x] Notebook executed locally end-to-end against a live Ollama instance and the CrewAI Hailstone A2A server
- [x] Verified `ch09.ipynb`'s diff is exactly the one-line title change (re-serialized with `ensure_ascii=False` to avoid a spurious unicode-escaping diff across the whole file)
- [x] Pre-commit hooks pass (symlink check, ruff, yaml, etc.)

Closes #803