### PR TITLE
feat(ch10): Example 2 — building and manually calling UseA2AAgentTool

### DIFF
--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -336,6 +336,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8ef53d34",
+   "metadata": {},
+   "source": [
+    "### Example 2: Building and Manually Calling UseA2AAgentTool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e5a08db",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4,2,1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.a2a import UseA2AAgentTool\n",
+    "from llm_agents_from_scratch.data_structures import ToolCall\n",
+    "\n",
+    "tool = UseA2AAgentTool(a2a_agents_registry={spec.name: spec})\n",
+    "\n",
+    "tool_call = ToolCall(\n",
+    "    tool_name=\"from_scratch__use_a2a_agent\",\n",
+    "    arguments={\n",
+    "        \"name\": spec.name,\n",
+    "        \"task\": \"Give me the hailstone sequence starting at 4.\",\n",
+    "    },\n",
+    ")\n",
+    "result = await tool(tool_call=tool_call)\n",
+    "print(result.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b56ed568",
    "metadata": {},
    "source": [
@@ -344,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "0b3a7624",
    "metadata": {},
    "outputs": [

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -286,7 +286,15 @@
      "output_type": "stream",
      "text": [
       "spec name: crewai-hailstone\n",
-      "spec url: http://localhost:9200\n"
+      "spec url: http://localhost:9200\n",
+      "spec catalog:\n",
+      "<a2a_agent>\n",
+      "    <name>crewai-hailstone</name>\n",
+      "    <description>Computes the full Hailstone (Collatz) sequence.</description>\n",
+      "    <a2a_skills>\n",
+      "      <a2a_skill>hailstone_sequence</a2a_skill>\n",
+      "    </a2a_skills>\n",
+      "  </a2a_agent>\n"
      ]
     }
    ],
@@ -322,7 +330,8 @@
     "\n",
     "spec_hand_built = A2AAgentSpec.from_agent_card(agent_card=hand_built_card)\n",
     "print(f\"spec name: {spec_hand_built.name}\")\n",
-    "print(f\"spec url: {spec_hand_built.url}\")\n"
+    "print(f\"spec url: {spec_hand_built.url}\")\n",
+    "print(f\"spec catalog:\\n{spec_hand_built.catalog()}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Second example in `examples/ch10.ipynb` — builds `UseA2AAgentTool` around the `spec` from Example 1a and dispatches a manual `ToolCall` against the live CrewAI Hailstone peer, mirroring Ch9 Example 1's manual-dispatch-before-coordinator shape (hardcoded tool name, direct `ToolCall` construction, no agent loop yet).
- Placed before the `## Cleanup` section so the CrewAI server is still running when it executes.

## Test plan
- [x] Executed live against the running CrewAI Hailstone A2A server and Ollama — dispatched a hailstone-sequence request (input 4), correct output `4,2,1`

Closes #804