### PR TITLE
feat(ch10): StreamingLLMAgentA2AExecutor + build_streaming_agent_card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- feat(ch10): `a2a/server/streaming_executor.py` — `StreamingLLMAgentA2AExecutor` (streaming-capable sibling to `LLMAgentA2AExecutor`, self-contained, drives `LLMAgent.run_supervised()`'s caller-controlled `get_next_step()`/`run_step()` loop directly, publishing two `TASK_STATE_WORKING` updates per step instead of only a final terminal state) and `build_streaming_agent_card()` (mirrors `build_agent_card()`, differing only in `capabilities=AgentCapabilities(streaming=True)`); `a2a/server/__init__.py`/`a2a/__init__.py` re-export both (#817)
 - feat(ch10): `a2a/server/` — `LLMAgentA2AExecutor` (bridges inbound A2A tasks to an `LLMAgent`; `cancel()` settles both `TaskHandler.background_task` and the `TaskHandler` future itself, since the latter never resolves on its own) and `build_agent_card()` (plain function returning an `a2a.types.AgentCard`, no composite wrapper class); `a2a/__init__.py` re-exports both alongside the existing client-side names (#787)
 - feat(ch10): `A2AAgentSpec.timeout` (default 60.0) — configurable per-peer dispatch timeout for `UseA2AAgentTool`, passed through to `httpx.AsyncClient`; overridable via `from_agent_card()`/`from_url()` (#807)
 - feat(ch10): `UseA2AAgentTool` — dispatch schema `name` + `task` + optional `task_id` to resume a peer task parked in `TASK_STATE_INPUT_REQUIRED`; creates an SDK client fresh per dispatch and always closes it; `TaskHandler._use_a2a_agent_tool`/`_a2a_agents_catalog` wired into `run_step` (#800)

--- a/src/llm_agents_from_scratch/a2a/__init__.py
+++ b/src/llm_agents_from_scratch/a2a/__init__.py
@@ -1,11 +1,18 @@
 """A2A module."""
 
 from .client import A2AAgentSpec, UseA2AAgentTool
-from .server import LLMAgentA2AExecutor, build_agent_card
+from .server import (
+    LLMAgentA2AExecutor,
+    StreamingLLMAgentA2AExecutor,
+    build_agent_card,
+    build_streaming_agent_card,
+)
 
 __all__ = [
     "A2AAgentSpec",
     "LLMAgentA2AExecutor",
+    "StreamingLLMAgentA2AExecutor",
     "UseA2AAgentTool",
     "build_agent_card",
+    "build_streaming_agent_card",
 ]

--- a/src/llm_agents_from_scratch/a2a/server/__init__.py
+++ b/src/llm_agents_from_scratch/a2a/server/__init__.py
@@ -1,8 +1,14 @@
 """A2A server-side module — serving an LLMAgent as an A2A peer."""
 
 from .executor import LLMAgentA2AExecutor, build_agent_card
+from .streaming_executor import (
+    StreamingLLMAgentA2AExecutor,
+    build_streaming_agent_card,
+)
 
 __all__ = [
     "LLMAgentA2AExecutor",
+    "StreamingLLMAgentA2AExecutor",
     "build_agent_card",
+    "build_streaming_agent_card",
 ]

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -1,0 +1,260 @@
+"""StreamingLLMAgentA2AExecutor — streaming variant of LLMAgentA2AExecutor."""
+
+from a2a.helpers import new_task_from_user_message, new_text_part
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentCardSignature,
+    AgentInterface,
+    AgentProvider,
+    AgentSkill,
+    SecurityRequirement,
+    SecurityScheme,
+    TaskState,
+)
+from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol
+from a2a.utils.errors import TaskNotFoundError
+
+from llm_agents_from_scratch.agent.llm_agent import LLMAgent
+from llm_agents_from_scratch.data_structures import Task, TaskResult, TaskStep
+
+
+class StreamingLLMAgentA2AExecutor(AgentExecutor):
+    """Bridges inbound A2A tasks to an ``LLMAgent``, streaming updates.
+
+    Drives ``LLMAgent.run_supervised()`` directly instead of ``run()``:
+    ``SupervisedTaskHandler`` has no background task at all — execution
+    is entirely caller-driven via ``get_next_step()``/``run_step()``
+    (built for Ch8's HITL use case, structurally identical to what
+    streaming needs). This executor calls that loop itself, publishing
+    a ``TaskStatusUpdateEvent`` after each step instead of prompting a
+    human — the same substitution ``LLMAgentA2AExecutor`` makes for the
+    non-streaming case, just at per-step instead of whole-run
+    granularity.
+
+    Two updates are published per step, not one: ``get_next_step()``
+    makes its own LLM call to decide routing (except on the very first
+    step) — real, awaitable work in its own right, not just
+    bookkeeping — so its result (the planned instruction) is published
+    before ``run_step()`` executes it, and that step's result is
+    published after.
+
+    Because there's no separate background task, cancellation here is
+    simpler than ``LLMAgentA2AExecutor``'s: the SDK's own producer loop
+    already runs *this* executor's ``execute()`` as its own task, so
+    cancelling that task interrupts whatever step is currently
+    in-flight directly — there's no orphaned worker left running
+    underneath, unlike ``LLMAgentA2AExecutor.cancel()``'s need to
+    separately cancel ``TaskHandler.background_task``.
+
+    Attributes:
+        agent (LLMAgent): The agent this executor serves.
+        _task_handlers (dict[str, LLMAgent.SupervisedTaskHandler]):
+            In-flight runs, keyed by task_id. ``execute()`` and
+            ``cancel()`` are separate calls with no shared local state
+            connecting them — this registry is what lets ``cancel()``
+            find the specific ``SupervisedTaskHandler`` a concurrent
+            ``execute()`` call (for a different task_id) is driving.
+    """
+
+    def __init__(self, agent: LLMAgent) -> None:
+        """Initialise with the agent to serve.
+
+        Args:
+            agent (LLMAgent): The agent to bridge inbound A2A tasks to.
+        """
+        self.agent = agent
+        self._task_handlers: dict[str, LLMAgent.SupervisedTaskHandler] = {}
+
+    async def execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        """Runs the agent step by step, publishing an update per step.
+
+        Args:
+            context (RequestContext): The request context containing
+                the task instruction.
+            event_queue (EventQueue): The queue to publish task
+                status/artifact events to.
+        """
+        if context.current_task:
+            task = context.current_task
+        else:
+            if context.message is None:
+                raise ValueError(
+                    "RequestContext is missing the user's Message.",
+                )
+            task = new_task_from_user_message(context.message)
+            await event_queue.enqueue_event(task)
+
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.submit()
+        await updater.start_work()
+
+        instruction = context.get_user_input()
+        task_handler = await self.agent.run_supervised(
+            Task(instruction=instruction),
+        )
+        self._task_handlers[task.id] = task_handler
+        try:
+            step_result = None
+            while not task_handler.done():
+                next_step = await task_handler.get_next_step(step_result)
+                match next_step:
+                    case TaskStep():
+                        await updater.update_status(
+                            TaskState.TASK_STATE_WORKING,
+                            message=updater.new_agent_message(
+                                [new_text_part(next_step.instruction)],
+                            ),
+                        )
+                        step_result = await task_handler.run_step(next_step)
+                        await updater.update_status(
+                            TaskState.TASK_STATE_WORKING,
+                            message=updater.new_agent_message(
+                                [new_text_part(step_result.content)],
+                            ),
+                        )
+                    case TaskResult():
+                        await task_handler.complete(next_step)
+        except Exception as e:
+            await updater.update_status(
+                TaskState.TASK_STATE_FAILED,
+                message=updater.new_agent_message([new_text_part(str(e))]),
+            )
+            return
+        finally:
+            self._task_handlers.pop(task.id, None)
+
+        result = task_handler.result()
+        await updater.add_artifact(
+            parts=[new_text_part(result.content)],
+            name="task_result",
+        )
+        await updater.complete()
+
+    async def cancel(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        """Cancels the agent run backing an in-flight task.
+
+        Args:
+            context (RequestContext): The request context naming the
+                task to cancel.
+            event_queue (EventQueue): The queue to publish the
+                cancellation status update to.
+
+        Raises:
+            TaskNotFoundError: If ``context.task_id`` names no
+                in-flight task on this executor.
+        """
+        if context.task_id is None or context.context_id is None:
+            raise ValueError(
+                "RequestContext is missing a task_id or context_id.",
+            )
+        task_handler = self._task_handlers.get(context.task_id)
+        if task_handler is None:
+            raise TaskNotFoundError(
+                f"No in-flight task found for id '{context.task_id}'.",
+            )
+
+        # No background_task to worry about here (SupervisedTaskHandler
+        # has none) -- the SDK already cancels the producer task
+        # running our own execute() before calling cancel(), which
+        # interrupts whatever step is currently in-flight directly.
+        # Publish CANCELED first regardless, for the same reason as
+        # LLMAgentA2AExecutor.cancel(): avoid racing the SDK's own
+        # producer-loop cleanup over this event_queue.
+        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+        await updater.cancel()
+
+        if not task_handler.done():
+            task_handler.cancel()
+
+
+def build_streaming_agent_card(  # noqa: PLR0913, PLR0917
+    name: str,
+    description: str,
+    url: str,
+    version: str = "0.1.0",
+    skills: list[AgentSkill] | None = None,
+    provider: AgentProvider | None = None,
+    documentation_url: str | None = None,
+    security_schemes: dict[str, SecurityScheme] | None = None,
+    security_requirements: list[SecurityRequirement] | None = None,
+    signatures: list[AgentCardSignature] | None = None,
+    icon_url: str | None = None,
+) -> AgentCard:
+    """Builds an ``AgentCard`` for serving a ``StreamingLLMAgentA2AExecutor``.
+
+    Mirrors ``executor.build_agent_card()`` exactly, except
+    ``capabilities`` is ``AgentCapabilities(streaming=True)`` — this
+    executor genuinely publishes incremental status updates per step,
+    unlike the non-streaming ``LLMAgentA2AExecutor``. As with
+    ``build_agent_card()``, every field describing executor *behavior*
+    is fixed rather than exposed as a parameter (``supported_interfaces``,
+    the default I/O modes, ``capabilities``); pure descriptive metadata
+    that claims nothing about behavior stays overridable.
+
+    Args:
+        name (str): The agent's name, shown to peers.
+        description (str): The agent's description, shown to peers.
+        url (str): The deployment URL this agent will be served at.
+            Must be supplied by the caller — nothing in this framework
+            can infer where a ``StreamingLLMAgentA2AExecutor`` will
+            actually be deployed.
+        version (str): The agent's version string. Defaults to
+            ``"0.1.0"``.
+        skills (list[AgentSkill] | None): The agent's declared skills.
+            Defaults to an empty list.
+        provider (AgentProvider | None): The agent's provider
+            organisation. Defaults to unset.
+        documentation_url (str | None): URL to the agent's
+            documentation. Defaults to unset.
+        security_schemes (dict[str, SecurityScheme] | None): Named
+            security schemes the agent supports. Defaults to none.
+        security_requirements (list[SecurityRequirement] | None):
+            Security requirements callers must satisfy. Defaults to
+            none.
+        signatures (list[AgentCardSignature] | None): Cryptographic
+            signatures over the card. Defaults to none.
+        icon_url (str | None): URL to an icon representing the agent.
+            Defaults to unset.
+
+    Returns:
+        AgentCard: The constructed card, with a single
+            ``supported_interfaces`` entry advertising the JSON-RPC
+            transport at ``url``, and streaming enabled.
+    """
+    return AgentCard(
+        # fixed: describes StreamingLLMAgentA2AExecutor's actual
+        # behavior, not passed through as a parameter
+        supported_interfaces=[
+            AgentInterface(
+                url=url,
+                protocol_binding=TransportProtocol.JSONRPC,
+                protocol_version=PROTOCOL_VERSION_1_0,
+            ),
+        ],
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        capabilities=AgentCapabilities(streaming=True),
+        # descriptive metadata only -- mirrors AgentCard directly
+        name=name,
+        description=description,
+        version=version,
+        skills=skills or [],
+        provider=provider,
+        documentation_url=documentation_url,
+        security_schemes=security_schemes,
+        security_requirements=security_requirements,
+        signatures=signatures,
+        icon_url=icon_url,
+    )

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -1,5 +1,7 @@
 """StreamingLLMAgentA2AExecutor — streaming variant of LLMAgentA2AExecutor."""
 
+import asyncio
+
 from a2a.helpers import new_task_from_user_message, new_text_part
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -122,6 +124,16 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
                         )
                     case TaskResult():
                         await task_handler.complete(next_step)
+        except asyncio.CancelledError:
+            # Not caught by except Exception below (CancelledError is a
+            # BaseException, not an Exception) -- this clause is purely
+            # explicit documentation of that fact, not a behavior
+            # change: it must propagate uncaught so the SDK's own
+            # producer-loop cleanup (which closes event_queue and lets
+            # the producer task actually terminate) still runs. The
+            # finally block below still settles _task_handlers either
+            # way.
+            raise
         except Exception as e:
             await updater.update_status(
                 TaskState.TASK_STATE_FAILED,

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -1,7 +1,5 @@
 """StreamingLLMAgentA2AExecutor — streaming variant of LLMAgentA2AExecutor."""
 
-import asyncio
-
 from a2a.helpers import new_task_from_user_message, new_text_part
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -78,6 +76,17 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
     ) -> None:
         """Runs the agent step by step, publishing an update per step.
 
+        Only ``Exception`` is caught below, deliberately not
+        ``BaseException``: ``asyncio.CancelledError`` (raised here when
+        the SDK cancels the producer task running this coroutine, per
+        ``cancel()`` below) must propagate uncaught. The SDK's own
+        producer loop wrapping this call has its own
+        ``except CancelledError`` that closes the event queue and lets
+        the producer task actually terminate. Catching and returning
+        normally here instead would make ``execute()`` look like it
+        finished successfully, leaving that producer task running —
+        parked awaiting a request that will never come.
+
         Args:
             context (RequestContext): The request context containing
                 the task instruction.
@@ -124,16 +133,6 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
                         )
                     case TaskResult():
                         await task_handler.complete(next_step)
-        except asyncio.CancelledError:
-            # Not caught by except Exception below (CancelledError is a
-            # BaseException, not an Exception) -- this clause is purely
-            # explicit documentation of that fact, not a behavior
-            # change: it must propagate uncaught so the SDK's own
-            # producer-loop cleanup (which closes event_queue and lets
-            # the producer task actually terminate) still runs. The
-            # finally block below still settles _task_handlers either
-            # way.
-            raise
         except Exception as e:
             await updater.update_status(
                 TaskState.TASK_STATE_FAILED,

--- a/tests/a2a/server/test_streaming_card.py
+++ b/tests/a2a/server/test_streaming_card.py
@@ -1,0 +1,111 @@
+"""Unit tests for build_streaming_agent_card."""
+
+import inspect
+
+from a2a.types import (
+    AgentCardSignature,
+    AgentProvider,
+    AgentSkill,
+    HTTPAuthSecurityScheme,
+    SecurityRequirement,
+    SecurityScheme,
+)
+from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol
+
+from llm_agents_from_scratch.a2a.server.streaming_executor import (
+    build_streaming_agent_card,
+)
+
+
+def test_build_streaming_agent_card_defaults() -> None:
+    """Tests defaults: version, empty skills, streaming enabled."""
+    card = build_streaming_agent_card(
+        name="my-agent",
+        description="Does things.",
+        url="http://localhost:9999",
+    )
+
+    assert card.name == "my-agent"
+    assert card.description == "Does things."
+    assert card.version == "0.1.0"
+    assert list(card.skills) == []
+    assert card.capabilities.streaming is True
+    assert list(card.default_input_modes) == ["text/plain"]
+    assert list(card.default_output_modes) == ["text/plain"]
+
+
+def test_build_streaming_agent_card_supported_interface() -> None:
+    """Tests the single supported_interfaces entry matches url/JSONRPC/1.0."""
+    card = build_streaming_agent_card(
+        name="my-agent",
+        description="Does things.",
+        url="http://localhost:9999",
+    )
+
+    assert len(card.supported_interfaces) == 1
+    interface = card.supported_interfaces[0]
+    assert interface.url == "http://localhost:9999"
+    assert interface.protocol_binding == TransportProtocol.JSONRPC
+    assert interface.protocol_version == PROTOCOL_VERSION_1_0
+
+
+def test_build_streaming_agent_card_version_and_skills() -> None:
+    """Tests explicit version and skills pass through."""
+    skill = AgentSkill(
+        id="hailstone",
+        name="hailstone",
+        description="Computes hailstone steps.",
+        tags=["math"],
+    )
+
+    card = build_streaming_agent_card(
+        name="my-agent",
+        description="Does things.",
+        url="http://localhost:9999",
+        version="1.2.3",
+        skills=[skill],
+    )
+
+    assert card.version == "1.2.3"
+    assert list(card.skills) == [skill]
+
+
+def test_build_streaming_agent_card_capabilities_not_a_parameter() -> None:
+    """Tests capabilities can't be overridden -- it describes real behavior.
+
+    Same reasoning as build_agent_card(): capabilities.streaming
+    describes what StreamingLLMAgentA2AExecutor actually does. Letting
+    a caller override it to streaming=False would produce a card that
+    lies about the executor it's paired with.
+    """
+    params = inspect.signature(build_streaming_agent_card).parameters
+    assert "capabilities" not in params
+
+
+def test_build_streaming_agent_card_metadata_fields_pass_through() -> None:
+    """Tests provider/documentation_url/security/signatures/icon_url."""
+    provider = AgentProvider(url="https://example.com", organization="Acme")
+    scheme = SecurityScheme(
+        http_auth_security_scheme=HTTPAuthSecurityScheme(scheme="bearer"),
+    )
+    requirement = SecurityRequirement(schemes={})
+    signature = AgentCardSignature(protected="hdr", signature="sig")
+
+    card = build_streaming_agent_card(
+        name="my-agent",
+        description="Does things.",
+        url="http://localhost:9999",
+        provider=provider,
+        documentation_url="https://example.com/docs",
+        security_schemes={"bearer": scheme},
+        security_requirements=[requirement],
+        signatures=[signature],
+        icon_url="https://example.com/icon.png",
+    )
+
+    assert card.provider == provider
+    assert card.documentation_url == "https://example.com/docs"
+    assert dict(card.security_schemes) == {"bearer": scheme}
+    assert list(card.security_requirements) == [requirement]
+    assert list(card.signatures) == [signature]
+    assert card.icon_url == "https://example.com/icon.png"

--- a/tests/a2a/server/test_streaming_executor.py
+++ b/tests/a2a/server/test_streaming_executor.py
@@ -1,0 +1,245 @@
+"""Unit tests for StreamingLLMAgentA2AExecutor."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from a2a.server.events import EventQueueLegacy
+from a2a.types import Message, Part, TaskState, TaskStatus
+from a2a.types import Role as A2ARole
+from a2a.types import Task as A2ATask
+from a2a.utils.errors import TaskNotFoundError
+
+from llm_agents_from_scratch import LLMAgent
+from llm_agents_from_scratch.a2a.server.streaming_executor import (
+    StreamingLLMAgentA2AExecutor,
+)
+from llm_agents_from_scratch.base.llm import BaseLLM
+from llm_agents_from_scratch.data_structures import Task, TaskResult, TaskStep
+
+
+def _context(
+    task_id: str = "t1",
+    context_id: str = "c1",
+    instruction: str = "do the thing",
+    current_task: object | None = None,
+) -> MagicMock:
+    context = MagicMock()
+    context.task_id = task_id
+    context.context_id = context_id
+    context.current_task = current_task
+    context.message = Message(
+        role=A2ARole.ROLE_USER,
+        parts=[Part(text=instruction)],
+        task_id=task_id,
+        context_id=context_id,
+    )
+    context.get_user_input.return_value = instruction
+    return context
+
+
+async def _drain(queue: EventQueueLegacy, timeout: float = 0.5) -> list:
+    events = []
+    try:
+        while True:
+            events.append(
+                await asyncio.wait_for(queue.dequeue_event(), timeout=timeout),
+            )
+    except asyncio.TimeoutError:
+        pass
+    return events
+
+
+@pytest.mark.asyncio
+async def test_execute_completes_task(mock_llm: BaseLLM) -> None:
+    """Tests a successful run publishes COMPLETED with the result artifact."""
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+    context = _context()
+
+    with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
+        mock_next_step.side_effect = [
+            TaskStep(task_id="x", instruction="step 1"),
+            TaskStep(task_id="x", instruction="step 2"),
+            TaskResult(task_id="x", content="the answer"),
+        ]
+        await executor.execute(context, queue)
+
+    events = await _drain(queue)
+
+    statuses = [e.status.state for e in events if hasattr(e, "status")]
+    assert TaskState.TASK_STATE_COMPLETED in statuses
+    working_count = sum(
+        1 for s in statuses if s == TaskState.TASK_STATE_WORKING
+    )
+    num_steps = 2
+    updates_per_step = 2  # planned instruction + step result
+    # +1 for start_work()'s own WORKING update.
+    assert working_count == 1 + num_steps * updates_per_step
+    artifacts = [e for e in events if hasattr(e, "artifact")]
+    assert len(artifacts) == 1
+    assert artifacts[0].artifact.parts[0].text == "the answer"
+    assert context.task_id not in executor._task_handlers
+
+
+@pytest.mark.asyncio
+async def test_execute_enqueues_new_task_when_no_current_task(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests a Task event is enqueued when context.current_task is None."""
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+    context = _context(current_task=None)
+
+    with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
+        mock_next_step.side_effect = [
+            TaskStep(task_id="x", instruction="do the thing"),
+            TaskResult(task_id="x", content="the answer"),
+        ]
+        await executor.execute(context, queue)
+
+    events = await _drain(queue)
+
+    task_events = [e for e in events if type(e).__name__ == "Task"]
+    assert len(task_events) == 1
+    assert task_events[0].id == "t1"
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_new_task_when_current_task_set(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests no Task event is enqueued when context.current_task is set."""
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+    existing_task = A2ATask(
+        id="t1",
+        context_id="c1",
+        status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
+    )
+    context = _context(current_task=existing_task)
+
+    with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
+        mock_next_step.side_effect = [
+            TaskStep(task_id="x", instruction="do the thing"),
+            TaskResult(task_id="x", content="the answer"),
+        ]
+        await executor.execute(context, queue)
+
+    events = await _drain(queue)
+
+    task_events = [e for e in events if type(e).__name__ == "Task"]
+    assert len(task_events) == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_on_missing_message_when_no_current_task(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests a missing Message raises when there's no current_task to resume."""
+    executor = StreamingLLMAgentA2AExecutor(agent=LLMAgent(llm=mock_llm))
+    context = _context()
+    context.message = None
+
+    with pytest.raises(ValueError, match="user's Message"):
+        await executor.execute(context, EventQueueLegacy())
+
+
+@pytest.mark.asyncio
+async def test_execute_maps_exception_to_failed(mock_llm: BaseLLM) -> None:
+    """Tests an exception during the run publishes FAILED, doesn't raise."""
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+    context = _context()
+
+    with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
+        mock_next_step.side_effect = RuntimeError("boom")
+        await executor.execute(context, queue)
+
+    events = await _drain(queue)
+
+    statuses = [e.status.state for e in events if hasattr(e, "status")]
+    assert TaskState.TASK_STATE_FAILED in statuses
+    assert context.task_id not in executor._task_handlers
+
+
+@pytest.mark.asyncio
+async def test_cancel_raises_task_not_found_for_unknown_id(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests cancelling an untracked task_id raises TaskNotFoundError."""
+    executor = StreamingLLMAgentA2AExecutor(agent=LLMAgent(llm=mock_llm))
+    context = _context(task_id="unknown")
+
+    with pytest.raises(TaskNotFoundError):
+        await executor.cancel(context, EventQueueLegacy())
+
+
+@pytest.mark.asyncio
+async def test_cancel_raises_on_missing_task_id(mock_llm: BaseLLM) -> None:
+    """Tests a missing task_id raises before any lookup."""
+    executor = StreamingLLMAgentA2AExecutor(agent=LLMAgent(llm=mock_llm))
+    context = _context(task_id=None)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="task_id or context_id"):
+        await executor.cancel(context, EventQueueLegacy())
+
+
+@pytest.mark.asyncio
+async def test_execute_propagates_cancellation_mid_run(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests execute() propagates cancellation of its own producer task.
+
+    Unlike LLMAgentA2AExecutor, execute()'s step loop awaits
+    get_next_step()/run_step() directly rather than a background-task-
+    driven task_handler, so there's nothing for cancel() itself to
+    interrupt -- the interruption comes from the SDK cancelling the
+    producer task running execute() (here, execute_task) before it
+    ever calls cancel(). This mirrors that ordering directly.
+    """
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+    context = _context()
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await asyncio.sleep(300)
+
+    with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
+        mock_next_step.side_effect = _hang
+        execute_task = asyncio.create_task(executor.execute(context, queue))
+        await asyncio.sleep(0.1)
+
+        execute_task.cancel()
+        await executor.cancel(context, EventQueueLegacy())
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execute_task, timeout=1)
+
+    assert execute_task.cancelled()
+    assert "t1" not in executor._task_handlers
+
+
+@pytest.mark.asyncio
+async def test_cancel_cancels_in_flight_task(mock_llm: BaseLLM) -> None:
+    """Tests cancel() settles the tracked task_handler, publishes CANCELED."""
+    agent = LLMAgent(llm=mock_llm)
+    executor = StreamingLLMAgentA2AExecutor(agent=agent)
+    queue = EventQueueLegacy()
+
+    task_handler = await agent.run_supervised(Task(instruction="hang forever"))
+    executor._task_handlers["t1"] = task_handler
+
+    context = _context()
+    await executor.cancel(context, queue)
+
+    assert task_handler.done()
+    assert task_handler.cancelled()
+
+    events = await _drain(queue)
+    statuses = [e.status.state for e in events if hasattr(e, "status")]
+    assert TaskState.TASK_STATE_CANCELED in statuses

--- a/tests/a2a/server/test_streaming_executor.py
+++ b/tests/a2a/server/test_streaming_executor.py
@@ -1,6 +1,7 @@
 """Unit tests for StreamingLLMAgentA2AExecutor."""
 
 import asyncio
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,6 +49,11 @@ async def _drain(queue: EventQueueLegacy, timeout: float = 0.5) -> list:
     except asyncio.TimeoutError:
         pass
     return events
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    while not predicate():
+        await asyncio.sleep(0.01)
 
 
 @pytest.mark.asyncio
@@ -213,15 +219,22 @@ async def test_execute_propagates_cancellation_mid_run(
     with patch.object(LLMAgent.TaskHandler, "get_next_step") as mock_next_step:
         mock_next_step.side_effect = _hang
         execute_task = asyncio.create_task(executor.execute(context, queue))
-        await asyncio.sleep(0.1)
+        await asyncio.wait_for(
+            _wait_until(lambda: "t1" in executor._task_handlers),
+            timeout=1,
+        )
 
         execute_task.cancel()
-        await executor.cancel(context, EventQueueLegacy())
+        await executor.cancel(context, queue)
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(execute_task, timeout=1)
 
     assert execute_task.cancelled()
     assert "t1" not in executor._task_handlers
+
+    events = await _drain(queue)
+    statuses = [e.status.state for e in events if hasattr(e, "status")]
+    assert TaskState.TASK_STATE_CANCELED in statuses
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- New `a2a/server/streaming_executor.py`: `StreamingLLMAgentA2AExecutor`, a streaming-capable sibling to `LLMAgentA2AExecutor`, fully self-contained (no shared code with `executor.py`, including its own `build_streaming_agent_card()`) per the file-per-executor-variant convention established in #813.
- Drives `LLMAgent.run_supervised()`'s caller-controlled `get_next_step()`/`run_step()` loop directly instead of `run()`, publishing two `TASK_STATE_WORKING` updates per step (planned instruction, then step result) instead of only the final terminal state. `get_next_step()` makes its own LLM routing call (except on the first step) — real work worth surfacing, not just bookkeeping.
- `cancel()` is simpler than `LLMAgentA2AExecutor`'s: `SupervisedTaskHandler` has no `background_task`, so there's no second `Task` to settle — the SDK's own producer loop already cancels the `Task` running `execute()` before invoking `cancel()`, interrupting whatever step is in-flight directly.
- `build_streaming_agent_card()` mirrors `build_agent_card()`'s "opinionated, not neutral" design — `supported_interfaces`/I-O-modes stay fixed the same as the non-streaming card, differing only in `capabilities=AgentCapabilities(streaming=True)`.
- `a2a/server/__init__.py` and `a2a/__init__.py` re-export both new names.

Closes #814

## Test plan
- [x] `uv run pytest tests -q` — 529 passed
- [x] `make coverage` / `make coverage-report` — `streaming_executor.py` at 100%, project total 100%
- [x] `pre-commit run` (ruff check, ruff format, mypy) — all passed
- [x] Live-verified against a real FastAPI/uvicorn server + `a2a-sdk` streaming client (scripted `BaseLLM` driving a fixed multi-step routing sequence): confirmed multiple intermediate `TaskStatusUpdateEvent`s land (planned instruction + step result per step), not just one final event
- [x] Live-verified mid-stream cancellation against the same real server (slow/hanging `BaseLLM.chat`): confirmed clean `TASK_STATE_CANCELED` with no dropped events and no server-side crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)