### PR TITLE
docs: add A2A to API Reference

### DIFF
--- a/docs/api_reference/a2a/executor.md
+++ b/docs/api_reference/a2a/executor.md
@@ -1,0 +1,7 @@
+# LLMAgentA2AExecutor
+
+::: llm_agents_from_scratch.a2a.server.executor
+    options:
+      members:
+        - LLMAgentA2AExecutor
+        - build_agent_card

--- a/docs/api_reference/a2a/spec.md
+++ b/docs/api_reference/a2a/spec.md
@@ -1,0 +1,6 @@
+# A2AAgentSpec
+
+::: llm_agents_from_scratch.a2a.client.spec
+    options:
+      members:
+        - A2AAgentSpec

--- a/docs/api_reference/a2a/streaming_executor.md
+++ b/docs/api_reference/a2a/streaming_executor.md
@@ -1,0 +1,7 @@
+# StreamingLLMAgentA2AExecutor
+
+::: llm_agents_from_scratch.a2a.server.streaming_executor
+    options:
+      members:
+        - StreamingLLMAgentA2AExecutor
+        - build_streaming_agent_card

--- a/docs/api_reference/a2a/tools.md
+++ b/docs/api_reference/a2a/tools.md
@@ -1,0 +1,6 @@
+# UseA2AAgentTool
+
+::: llm_agents_from_scratch.a2a.client.tools
+    options:
+      members:
+        - UseA2AAgentTool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,11 @@ nav:
     - Subagents:
       - SubAgentSpec: api_reference/subagents/spec.md
       - UseSubAgentTool: api_reference/subagents/tools.md
+    - A2A:
+      - A2AAgentSpec: api_reference/a2a/spec.md
+      - UseA2AAgentTool: api_reference/a2a/tools.md
+      - LLMAgentA2AExecutor: api_reference/a2a/executor.md
+      - StreamingLLMAgentA2AExecutor: api_reference/a2a/streaming_executor.md
     - Errors: api_reference/errors/index.md
 plugins:
   - search


### PR DESCRIPTION
## Summary
- Adds `docs/api_reference/a2a/{spec,tools,executor,streaming_executor}.md`, mirroring the existing per-module page pattern (e.g. `api_reference/subagents/spec.md`).
- Covers both client-side (`A2AAgentSpec`, `UseA2AAgentTool`) and server-side (`LLMAgentA2AExecutor` + `build_agent_card`, `StreamingLLMAgentA2AExecutor` + `build_streaming_agent_card`) modules — the original issue held off on server-side pages pending #787, which has since merged along with its streaming follow-up (#814).
- Adds corresponding `mkdocs.yml` nav entries under a new **A2A** section.
- A2A error classes (`A2AError`, `A2AAgentNotFoundError`, `A2AAgentCardMissingInterfaceError`) were already picked up by the existing `errors/index.md` (`::: llm_agents_from_scratch.errors`, a top-level package re-export) — no separate errors page needed.

Closes #812

## Test plan
- [x] `uv run --group docs mkdocs build --strict` — the two pre-existing griffe warnings (`return_history` in `llms/ollama/llm.py` / `llms/openai/llm.py`) are unrelated to this change and present on `main` too; no new warnings introduced by the A2A pages
- [x] Verified rendered output for all four new pages contains the expected class/function docs
- [x] `pre-commit run` on changed files — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)