### PR TITLE
feat(ch10): Example 5 — a relay hailstone task across two A2A peers

### DIFF
--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -30,10 +30,10 @@
    "id": "791a535b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:26.172301Z",
-     "iopub.status.busy": "2026-08-07T23:59:26.172210Z",
-     "iopub.status.idle": "2026-08-07T23:59:26.173853Z",
-     "shell.execute_reply": "2026-08-07T23:59:26.173620Z"
+     "iopub.execute_input": "2026-08-08T00:16:19.008096Z",
+     "iopub.status.busy": "2026-08-08T00:16:19.007592Z",
+     "iopub.status.idle": "2026-08-08T00:16:19.013368Z",
+     "shell.execute_reply": "2026-08-08T00:16:19.012066Z"
     }
    },
    "outputs": [],
@@ -58,10 +58,10 @@
    "id": "4a235a38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:26.175227Z",
-     "iopub.status.busy": "2026-08-07T23:59:26.175153Z",
-     "iopub.status.idle": "2026-08-07T23:59:26.180511Z",
-     "shell.execute_reply": "2026-08-07T23:59:26.180254Z"
+     "iopub.execute_input": "2026-08-08T00:16:19.018301Z",
+     "iopub.status.busy": "2026-08-08T00:16:19.018212Z",
+     "iopub.status.idle": "2026-08-08T00:16:19.030534Z",
+     "shell.execute_reply": "2026-08-08T00:16:19.029176Z"
     }
    },
    "outputs": [
@@ -149,10 +149,10 @@
    "id": "2bef5aed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:26.181583Z",
-     "iopub.status.busy": "2026-08-07T23:59:26.181505Z",
-     "iopub.status.idle": "2026-08-07T23:59:27.708663Z",
-     "shell.execute_reply": "2026-08-07T23:59:27.708177Z"
+     "iopub.execute_input": "2026-08-08T00:16:19.033821Z",
+     "iopub.status.busy": "2026-08-08T00:16:19.033550Z",
+     "iopub.status.idle": "2026-08-08T00:16:20.563759Z",
+     "shell.execute_reply": "2026-08-08T00:16:20.561919Z"
     }
    },
    "outputs": [
@@ -241,10 +241,10 @@
    "id": "69150cb3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:27.710108Z",
-     "iopub.status.busy": "2026-08-07T23:59:27.710005Z",
-     "iopub.status.idle": "2026-08-07T23:59:29.217136Z",
-     "shell.execute_reply": "2026-08-07T23:59:29.216793Z"
+     "iopub.execute_input": "2026-08-08T00:16:20.569571Z",
+     "iopub.status.busy": "2026-08-08T00:16:20.569065Z",
+     "iopub.status.idle": "2026-08-08T00:16:22.093754Z",
+     "shell.execute_reply": "2026-08-08T00:16:22.091712Z"
     }
    },
    "outputs": [
@@ -385,10 +385,10 @@
    "id": "1dda9c5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:29.218323Z",
-     "iopub.status.busy": "2026-08-07T23:59:29.218228Z",
-     "iopub.status.idle": "2026-08-07T23:59:30.187985Z",
-     "shell.execute_reply": "2026-08-07T23:59:30.187687Z"
+     "iopub.execute_input": "2026-08-08T00:16:22.099075Z",
+     "iopub.status.busy": "2026-08-08T00:16:22.098616Z",
+     "iopub.status.idle": "2026-08-08T00:16:23.061660Z",
+     "shell.execute_reply": "2026-08-08T00:16:23.061354Z"
     }
    },
    "outputs": [
@@ -500,10 +500,10 @@
    "id": "b76afc3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:30.189164Z",
-     "iopub.status.busy": "2026-08-07T23:59:30.188980Z",
-     "iopub.status.idle": "2026-08-07T23:59:30.192435Z",
-     "shell.execute_reply": "2026-08-07T23:59:30.192176Z"
+     "iopub.execute_input": "2026-08-08T00:16:23.062734Z",
+     "iopub.status.busy": "2026-08-08T00:16:23.062625Z",
+     "iopub.status.idle": "2026-08-08T00:16:23.065758Z",
+     "shell.execute_reply": "2026-08-08T00:16:23.065501Z"
     }
    },
    "outputs": [
@@ -607,10 +607,10 @@
    "id": "8e5a08db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:30.193382Z",
-     "iopub.status.busy": "2026-08-07T23:59:30.193291Z",
-     "iopub.status.idle": "2026-08-07T23:59:57.028058Z",
-     "shell.execute_reply": "2026-08-07T23:59:57.027706Z"
+     "iopub.execute_input": "2026-08-08T00:16:23.066469Z",
+     "iopub.status.busy": "2026-08-08T00:16:23.066381Z",
+     "iopub.status.idle": "2026-08-08T00:16:32.096984Z",
+     "shell.execute_reply": "2026-08-08T00:16:32.096657Z"
     }
    },
    "outputs": [
@@ -618,7 +618,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4, 2, 1"
+      "4,2,1"
      ]
     },
     {
@@ -676,10 +676,10 @@
    "id": "3416d475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:57.029124Z",
-     "iopub.status.busy": "2026-08-07T23:59:57.029022Z",
-     "iopub.status.idle": "2026-08-07T23:59:57.046549Z",
-     "shell.execute_reply": "2026-08-07T23:59:57.046199Z"
+     "iopub.execute_input": "2026-08-08T00:16:32.098228Z",
+     "iopub.status.busy": "2026-08-08T00:16:32.098129Z",
+     "iopub.status.idle": "2026-08-08T00:16:32.114670Z",
+     "shell.execute_reply": "2026-08-08T00:16:32.114447Z"
     }
    },
    "outputs": [
@@ -691,7 +691,7 @@
       "\n",
       "Which positive integer should I start the hailstone sequence from?\n",
       "\n",
-      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='5e3f6ae3-3f8e-469b-861e-3c77ed4927c1', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
+      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='b6562cab-54b5-4934-b386-634c07e02370', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
      ]
     },
     {
@@ -741,10 +741,10 @@
    "id": "742693b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:59:57.047670Z",
-     "iopub.status.busy": "2026-08-07T23:59:57.047501Z",
-     "iopub.status.idle": "2026-08-08T00:03:01.192085Z",
-     "shell.execute_reply": "2026-08-08T00:03:01.191704Z"
+     "iopub.execute_input": "2026-08-08T00:16:32.115997Z",
+     "iopub.status.busy": "2026-08-08T00:16:32.115910Z",
+     "iopub.status.idle": "2026-08-08T00:17:52.532003Z",
+     "shell.execute_reply": "2026-08-08T00:17:52.531578Z"
     }
    },
    "outputs": [
@@ -810,10 +810,10 @@
    "id": "1e7e8b06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:03:01.193362Z",
-     "iopub.status.busy": "2026-08-08T00:03:01.193171Z",
-     "iopub.status.idle": "2026-08-08T00:03:01.195471Z",
-     "shell.execute_reply": "2026-08-08T00:03:01.195209Z"
+     "iopub.execute_input": "2026-08-08T00:17:52.533199Z",
+     "iopub.status.busy": "2026-08-08T00:17:52.533093Z",
+     "iopub.status.idle": "2026-08-08T00:17:52.535172Z",
+     "shell.execute_reply": "2026-08-08T00:17:52.534854Z"
     }
    },
    "outputs": [
@@ -828,7 +828,7 @@
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"4701e4eb-f8c8-4218-bf79-7d2a1a2be8a4\",\n",
+      "    \"id_\": \"92ea669f-43c2-4863-8241-a443c543b4da\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"crewai-hailstone\",\n",
@@ -837,31 +837,31 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"4701e4eb-f8c8-4218-bf79-7d2a1a2be8a4\",\n",
-      "    \"content\": \"The A2A agent 'crewai-hailstone' needs more information before it can continue:\\n\\nWhich positive integer should I start the hailstone sequence from?\\n\\nTo continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='a8c2e9ab-4797-4c45-a80a-d35a682aadd7', and `task` set to the requested information. This resumes the same remote task rather than starting a new one.\",\n",
+      "    \"tool_call_id\": \"92ea669f-43c2-4863-8241-a443c543b4da\",\n",
+      "    \"content\": \"The A2A agent 'crewai-hailstone' needs more information before it can continue:\\n\\nWhich positive integer should I start the hailstone sequence from?\\n\\nTo continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='09967e28-722d-4c11-b8a1-379b18d3816d', and `task` set to the requested information. This resumes the same remote task rather than starting a new one.\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "💬 assistant: {\"name\": \"from_scratch__use_a2a_agent\", \"arguments\": {\"name\":\"crewai-hailstone\",\"task_id\":\"a8c2e9ab-4797-4c45-a80a-d35a682aadd7\",\"task\":\"4\"}}\n",
+      "💬 assistant: {\"name\": \"from_scratch__use_a2a_agent\", \"arguments\": {\"name\":\"crewai-hailstone\",\"task_id\":\"09967e28-722d-4c11-b8a1-379b18d3816d\",\"task\":\"4\"}}\n",
       "\n",
       "=== Task Step End ===\n",
       "\n",
       "=== Task Step Start ===\n",
       "\n",
-      "💬 assistant: My current instruction is 'The assistant should continue by providing the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence.'\n",
+      "💬 assistant: My current instruction is 'The assistant should continue by providing the number '4' as the starting point for the hailstone sequence to the 'crewai-hailstone' agent.'\n",
       "\n",
-      "💬 assistant: I need to provide the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence. The number to start the sequence from is 4.\n",
+      "💬 assistant: I need to call the `from_scratch__use_a2a_agent` tool with the name 'crewai-hailstone' and the task set to '4' to provide the starting point for the hailstone sequence.\n",
       "\n",
       "=== Task Step End ===\n",
       "\n",
       "=== Task Step Start ===\n",
       "\n",
-      "💬 assistant: My current instruction is 'Provide the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence. The number to start the sequence from is 4.'\n",
+      "💬 assistant: My current instruction is 'I need to call the `from_scratch__use_a2a_agent` tool with the name 'crewai-hailstone' and the task set to '4' to provide the starting point for the hailstone sequence.'\n",
       "\n",
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"7c3fa94c-ae1b-4f7c-9904-115e9b918deb\",\n",
+      "    \"id_\": \"92a53230-8653-41eb-bdc9-01dd7e38db82\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"crewai-hailstone\",\n",
@@ -870,7 +870,7 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"7c3fa94c-ae1b-4f7c-9904-115e9b918deb\",\n",
+      "    \"tool_call_id\": \"92a53230-8653-41eb-bdc9-01dd7e38db82\",\n",
       "    \"content\": \"4,2,1\",\n",
       "    \"error\": false\n",
       "}\n",
@@ -922,10 +922,10 @@
    "id": "9c05ab67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:03:01.196440Z",
-     "iopub.status.busy": "2026-08-08T00:03:01.196352Z",
-     "iopub.status.idle": "2026-08-08T00:03:01.209976Z",
-     "shell.execute_reply": "2026-08-08T00:03:01.209744Z"
+     "iopub.execute_input": "2026-08-08T00:17:52.536183Z",
+     "iopub.status.busy": "2026-08-08T00:17:52.536096Z",
+     "iopub.status.idle": "2026-08-08T00:17:52.549332Z",
+     "shell.execute_reply": "2026-08-08T00:17:52.549053Z"
     }
    },
    "outputs": [
@@ -997,10 +997,10 @@
    "id": "687ceacb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:03:01.211109Z",
-     "iopub.status.busy": "2026-08-08T00:03:01.211025Z",
-     "iopub.status.idle": "2026-08-08T00:03:01.225294Z",
-     "shell.execute_reply": "2026-08-08T00:03:01.225022Z"
+     "iopub.execute_input": "2026-08-08T00:17:52.550381Z",
+     "iopub.status.busy": "2026-08-08T00:17:52.550295Z",
+     "iopub.status.idle": "2026-08-08T00:17:52.563742Z",
+     "shell.execute_reply": "2026-08-08T00:17:52.563448Z"
     }
    },
    "outputs": [],
@@ -1035,10 +1035,10 @@
    "id": "64dd7124",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:03:01.226276Z",
-     "iopub.status.busy": "2026-08-08T00:03:01.226194Z",
-     "iopub.status.idle": "2026-08-08T00:04:54.744649Z",
-     "shell.execute_reply": "2026-08-08T00:04:54.744333Z"
+     "iopub.execute_input": "2026-08-08T00:17:52.564898Z",
+     "iopub.status.busy": "2026-08-08T00:17:52.564810Z",
+     "iopub.status.idle": "2026-08-08T00:19:14.143955Z",
+     "shell.execute_reply": "2026-08-08T00:19:14.143580Z"
     }
    },
    "outputs": [
@@ -1095,9 +1095,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
-      "\n",
-      "1. **Step 1**: 8 is even, so the next...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the computation is complete. ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1111,7 +1109,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence starting at 8 is: 8, 4, 2, 1. The computation is complete as it has reached 1.\n"
      ]
     },
     {
@@ -1139,14 +1137,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**.\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence starting at 8 is: 8, 4, 2, 1. The computation is complete as it has reached 1.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**."
+      "The hailstone sequence starting at 8 is: 8, 4, 2, 1. The computation is complete as it has reached 1."
      ]
     },
     {
@@ -1200,10 +1198,10 @@
    "id": "ec16f077",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:04:54.746053Z",
-     "iopub.status.busy": "2026-08-08T00:04:54.745924Z",
-     "iopub.status.idle": "2026-08-08T00:04:54.748471Z",
-     "shell.execute_reply": "2026-08-08T00:04:54.748214Z"
+     "iopub.execute_input": "2026-08-08T00:19:14.145162Z",
+     "iopub.status.busy": "2026-08-08T00:19:14.145069Z",
+     "iopub.status.idle": "2026-08-08T00:19:14.148951Z",
+     "shell.execute_reply": "2026-08-08T00:19:14.148693Z"
     }
    },
    "outputs": [
@@ -1239,23 +1237,110 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uninstalled "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 package"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "in 0.26ms"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Installed "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 package"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "in 0.95ms"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "INFO:     Started server process [336815]\n",
+      "INFO:     Started server process [338576]\n",
       "INFO:     Waiting for application startup.\n",
       "INFO:     Application startup complete.\n",
       "INFO:     Uvicorn running on http://0.0.0.0:9300 (Press CTRL+C to quit)\n",
-      "INFO:     127.0.0.1:49944 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
-      "INFO:     127.0.0.1:37658 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:38922 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:38750 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the hailstone sequence starting at 8, until it reaches 1.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the hailstone sequence starting at 8, until it reaches 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
-      "\n",
-      "1. **Step 1**: 8 is even, so the next number i...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x=8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=8.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 8 is 4. I will now compute the subsequent numbers in the sequence until it reache...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the hailstone sequence starting at 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the hailstone sequence starting at 4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=4.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 4 is 2. I will now compute the subsequent numbers in the sequence until it reache...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the hailstone sequence starting at 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the hailstone sequence starting at 2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x=2.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the computation is complete. The full ...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
-      "\n",
-      "1. **Step 1**: 8 is even, so the next numbe...[TRUNCATED]\n",
-      "INFO:     127.0.0.1:41372 - \"POST / HTTP/1.1\" 200 OK\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the computation is complete. The fu...[TRUNCATED]\n",
+      "INFO:     127.0.0.1:60898 - \"POST / HTTP/1.1\" 200 OK\n"
      ]
     },
     {
@@ -1284,10 +1369,10 @@
    "id": "e52422f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:04:54.749464Z",
-     "iopub.status.busy": "2026-08-08T00:04:54.749356Z",
-     "iopub.status.idle": "2026-08-08T00:06:12.766715Z",
-     "shell.execute_reply": "2026-08-08T00:06:12.766410Z"
+     "iopub.execute_input": "2026-08-08T00:19:14.150563Z",
+     "iopub.status.busy": "2026-08-08T00:19:14.150412Z",
+     "iopub.status.idle": "2026-08-08T00:20:41.755959Z",
+     "shell.execute_reply": "2026-08-08T00:20:41.755699Z"
     }
    },
    "outputs": [
@@ -1416,7 +1501,7 @@
      "text": [
       " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Starting with 16, I will continue the hailstone sequence step by step until it reaches 1. \n",
       "\n",
-      "1. The first step is to apply the ...[TRUNCATED]\n"
+      "1. 16 is even, so the next number ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1430,9 +1515,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
-      "\n",
-      "Combining this with the earlier sequence from 20 to 16, the ...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The full hailstone sequence from 20 to 1 is: 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1.\n"
      ]
     },
     {
@@ -1460,20 +1543,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
-      "\n",
-      "Combining this with the earlier sequence from 20 to 16, t...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The full hailstone sequence from 20 to 1 is: 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
-      "\n",
-      "Combining this with the earlier sequence from 20 to 16, the full sequence from 20 to 1 is **20, 10, 5, 16, 8, 4, 2, 1**. \n",
-      "\n",
-      "The task is complete."
+      "The full hailstone sequence from 20 to 1 is: 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1."
      ]
     },
     {
@@ -1505,10 +1582,10 @@
    "id": "6306e73a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:06:12.767966Z",
-     "iopub.status.busy": "2026-08-08T00:06:12.767872Z",
-     "iopub.status.idle": "2026-08-08T00:06:12.769762Z",
-     "shell.execute_reply": "2026-08-08T00:06:12.769495Z"
+     "iopub.execute_input": "2026-08-08T00:20:41.756989Z",
+     "iopub.status.busy": "2026-08-08T00:20:41.756904Z",
+     "iopub.status.idle": "2026-08-08T00:20:41.758822Z",
+     "shell.execute_reply": "2026-08-08T00:20:41.758575Z"
     }
    },
    "outputs": [
@@ -1523,7 +1600,7 @@
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"636dc717-cb96-477d-b152-e06299662cae\",\n",
+      "    \"id_\": \"f5fea94c-ab0e-4534-9307-758395519367\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"crewai-hailstone\",\n",
@@ -1532,7 +1609,7 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"636dc717-cb96-477d-b152-e06299662cae\",\n",
+      "    \"tool_call_id\": \"f5fea94c-ab0e-4534-9307-758395519367\",\n",
       "    \"content\": \"20,10,5,16\",\n",
       "    \"error\": false\n",
       "}\n",
@@ -1548,7 +1625,7 @@
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"1a755d2c-0d2a-4b18-b47e-7c306273c8e2\",\n",
+      "    \"id_\": \"b60e378e-5ba1-4828-bafa-57dccda17c0a\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"from-scratch-hailstone\",\n",
@@ -1557,16 +1634,12 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"1a755d2c-0d2a-4b18-b47e-7c306273c8e2\",\n",
-      "    \"content\": \"Starting with 16, I will continue the hailstone sequence step by step until it reaches 1. \\n\\n1. The first step is to apply the hailstone sequence rule to 16. Since 16 is even, the next number is 16 / 2 = 8.\\n2. Now, applying the rule to 8, which is also even, the next number is 8 / 2 = 4.\\n3. Applying the rule to 4, which is even, the next number is 4 / 2 = 2.\\n4. Applying the rule to 2, which is even, the next number is 2 / 2 = 1.\\n\\nThe hailstone sequence from 16 until it reaches 1 is 16, 8, 4, 2, 1.\",\n",
+      "    \"tool_call_id\": \"b60e378e-5ba1-4828-bafa-57dccda17c0a\",\n",
+      "    \"content\": \"Starting with 16, I will continue the hailstone sequence step by step until it reaches 1. \\n\\n1. 16 is even, so the next number is $16 / 2 = 8$.\\n2. 8 is even, so the next number is $8 / 2 = 4$.\\n3. 4 is even, so the next number is $4 / 2 = 2$.\\n4. 2 is even, so the next number is $2 / 2 = 1$.\\n\\nThe sequence from 16 until it reaches 1 is: 16 → 8 → 4 → 2 → 1.\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "💬 assistant: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
-      "\n",
-      "Combining this with the earlier sequence from 20 to 16, the full sequence from 20 to 1 is **20, 10, 5, 16, 8, 4, 2, 1**. \n",
-      "\n",
-      "The task is complete.\n",
+      "💬 assistant: The full hailstone sequence from 20 to 1 is: 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1.\n",
       "\n",
       "=== Task Step End ==="
      ]
@@ -1597,10 +1670,10 @@
    "id": "0b3a7624",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-08T00:06:12.770779Z",
-     "iopub.status.busy": "2026-08-08T00:06:12.770694Z",
-     "iopub.status.idle": "2026-08-08T00:06:13.509468Z",
-     "shell.execute_reply": "2026-08-08T00:06:13.508060Z"
+     "iopub.execute_input": "2026-08-08T00:20:41.759906Z",
+     "iopub.status.busy": "2026-08-08T00:20:41.759826Z",
+     "iopub.status.idle": "2026-08-08T00:20:42.497381Z",
+     "shell.execute_reply": "2026-08-08T00:20:42.495409Z"
     }
    },
    "outputs": [

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -30,10 +30,10 @@
    "id": "791a535b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:53.601900Z",
-     "iopub.status.busy": "2026-08-07T23:03:53.601428Z",
-     "iopub.status.idle": "2026-08-07T23:03:53.607544Z",
-     "shell.execute_reply": "2026-08-07T23:03:53.606283Z"
+     "iopub.execute_input": "2026-08-07T23:59:26.172301Z",
+     "iopub.status.busy": "2026-08-07T23:59:26.172210Z",
+     "iopub.status.idle": "2026-08-07T23:59:26.173853Z",
+     "shell.execute_reply": "2026-08-07T23:59:26.173620Z"
     }
    },
    "outputs": [],
@@ -58,10 +58,10 @@
    "id": "4a235a38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:53.612644Z",
-     "iopub.status.busy": "2026-08-07T23:03:53.612198Z",
-     "iopub.status.idle": "2026-08-07T23:03:53.629169Z",
-     "shell.execute_reply": "2026-08-07T23:03:53.628521Z"
+     "iopub.execute_input": "2026-08-07T23:59:26.175227Z",
+     "iopub.status.busy": "2026-08-07T23:59:26.175153Z",
+     "iopub.status.idle": "2026-08-07T23:59:26.180511Z",
+     "shell.execute_reply": "2026-08-07T23:59:26.180254Z"
     }
    },
    "outputs": [
@@ -149,10 +149,10 @@
    "id": "2bef5aed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:53.631602Z",
-     "iopub.status.busy": "2026-08-07T23:03:53.631366Z",
-     "iopub.status.idle": "2026-08-07T23:03:55.159702Z",
-     "shell.execute_reply": "2026-08-07T23:03:55.157082Z"
+     "iopub.execute_input": "2026-08-07T23:59:26.181583Z",
+     "iopub.status.busy": "2026-08-07T23:59:26.181505Z",
+     "iopub.status.idle": "2026-08-07T23:59:27.708663Z",
+     "shell.execute_reply": "2026-08-07T23:59:27.708177Z"
     }
    },
    "outputs": [
@@ -241,10 +241,10 @@
    "id": "69150cb3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:55.164477Z",
-     "iopub.status.busy": "2026-08-07T23:03:55.163992Z",
-     "iopub.status.idle": "2026-08-07T23:03:56.679502Z",
-     "shell.execute_reply": "2026-08-07T23:03:56.677957Z"
+     "iopub.execute_input": "2026-08-07T23:59:27.710108Z",
+     "iopub.status.busy": "2026-08-07T23:59:27.710005Z",
+     "iopub.status.idle": "2026-08-07T23:59:29.217136Z",
+     "shell.execute_reply": "2026-08-07T23:59:29.216793Z"
     }
    },
    "outputs": [
@@ -385,13 +385,21 @@
    "id": "1dda9c5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:56.685530Z",
-     "iopub.status.busy": "2026-08-07T23:03:56.685098Z",
-     "iopub.status.idle": "2026-08-07T23:03:58.176336Z",
-     "shell.execute_reply": "2026-08-07T23:03:58.176074Z"
+     "iopub.execute_input": "2026-08-07T23:59:29.218323Z",
+     "iopub.status.busy": "2026-08-07T23:59:29.218228Z",
+     "iopub.status.idle": "2026-08-07T23:59:30.187985Z",
+     "shell.execute_reply": "2026-08-07T23:59:30.187687Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/nerdai/Projects/llm-agents-from-scratch/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -492,10 +500,10 @@
    "id": "b76afc3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:58.177590Z",
-     "iopub.status.busy": "2026-08-07T23:03:58.177488Z",
-     "iopub.status.idle": "2026-08-07T23:03:58.180714Z",
-     "shell.execute_reply": "2026-08-07T23:03:58.180408Z"
+     "iopub.execute_input": "2026-08-07T23:59:30.189164Z",
+     "iopub.status.busy": "2026-08-07T23:59:30.188980Z",
+     "iopub.status.idle": "2026-08-07T23:59:30.192435Z",
+     "shell.execute_reply": "2026-08-07T23:59:30.192176Z"
     }
    },
    "outputs": [
@@ -599,10 +607,10 @@
    "id": "8e5a08db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:03:58.181723Z",
-     "iopub.status.busy": "2026-08-07T23:03:58.181643Z",
-     "iopub.status.idle": "2026-08-07T23:04:12.921805Z",
-     "shell.execute_reply": "2026-08-07T23:04:12.921450Z"
+     "iopub.execute_input": "2026-08-07T23:59:30.193382Z",
+     "iopub.status.busy": "2026-08-07T23:59:30.193291Z",
+     "iopub.status.idle": "2026-08-07T23:59:57.028058Z",
+     "shell.execute_reply": "2026-08-07T23:59:57.027706Z"
     }
    },
    "outputs": [
@@ -610,7 +618,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4,2,1"
+      "4, 2, 1"
      ]
     },
     {
@@ -668,10 +676,10 @@
    "id": "3416d475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:04:12.922952Z",
-     "iopub.status.busy": "2026-08-07T23:04:12.922829Z",
-     "iopub.status.idle": "2026-08-07T23:04:12.944430Z",
-     "shell.execute_reply": "2026-08-07T23:04:12.944155Z"
+     "iopub.execute_input": "2026-08-07T23:59:57.029124Z",
+     "iopub.status.busy": "2026-08-07T23:59:57.029022Z",
+     "iopub.status.idle": "2026-08-07T23:59:57.046549Z",
+     "shell.execute_reply": "2026-08-07T23:59:57.046199Z"
     }
    },
    "outputs": [
@@ -683,7 +691,7 @@
       "\n",
       "Which positive integer should I start the hailstone sequence from?\n",
       "\n",
-      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='3e306310-6a72-4f8a-afc6-928ff39232ec', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
+      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='5e3f6ae3-3f8e-469b-861e-3c77ed4927c1', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
      ]
     },
     {
@@ -733,10 +741,10 @@
    "id": "742693b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:04:12.945416Z",
-     "iopub.status.busy": "2026-08-07T23:04:12.945328Z",
-     "iopub.status.idle": "2026-08-07T23:05:28.776710Z",
-     "shell.execute_reply": "2026-08-07T23:05:28.776285Z"
+     "iopub.execute_input": "2026-08-07T23:59:57.047670Z",
+     "iopub.status.busy": "2026-08-07T23:59:57.047501Z",
+     "iopub.status.idle": "2026-08-08T00:03:01.192085Z",
+     "shell.execute_reply": "2026-08-08T00:03:01.191704Z"
     }
    },
    "outputs": [
@@ -744,7 +752,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The hailstone sequence starting at the number four is: 4, 2, 1."
+      "The hailstone sequence starting at the number 4 is: 4, 2, 1."
      ]
     },
     {
@@ -802,10 +810,10 @@
    "id": "1e7e8b06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:05:28.777935Z",
-     "iopub.status.busy": "2026-08-07T23:05:28.777833Z",
-     "iopub.status.idle": "2026-08-07T23:05:28.780212Z",
-     "shell.execute_reply": "2026-08-07T23:05:28.779896Z"
+     "iopub.execute_input": "2026-08-08T00:03:01.193362Z",
+     "iopub.status.busy": "2026-08-08T00:03:01.193171Z",
+     "iopub.status.idle": "2026-08-08T00:03:01.195471Z",
+     "shell.execute_reply": "2026-08-08T00:03:01.195209Z"
     }
    },
    "outputs": [
@@ -820,7 +828,7 @@
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"3373b9d5-2171-4306-8465-0140da2ecbac\",\n",
+      "    \"id_\": \"4701e4eb-f8c8-4218-bf79-7d2a1a2be8a4\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"crewai-hailstone\",\n",
@@ -829,31 +837,31 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"3373b9d5-2171-4306-8465-0140da2ecbac\",\n",
-      "    \"content\": \"The A2A agent 'crewai-hailstone' needs more information before it can continue:\\n\\nWhich positive integer should I start the hailstone sequence from?\\n\\nTo continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='8fb7e481-8408-40ed-9332-d28aed5bb93f', and `task` set to the requested information. This resumes the same remote task rather than starting a new one.\",\n",
+      "    \"tool_call_id\": \"4701e4eb-f8c8-4218-bf79-7d2a1a2be8a4\",\n",
+      "    \"content\": \"The A2A agent 'crewai-hailstone' needs more information before it can continue:\\n\\nWhich positive integer should I start the hailstone sequence from?\\n\\nTo continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='a8c2e9ab-4797-4c45-a80a-d35a682aadd7', and `task` set to the requested information. This resumes the same remote task rather than starting a new one.\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "💬 assistant: {\"name\": \"from_scratch__use_a2a_agent\", \"arguments\": {\"name\":\"crewai-hailstone\",\"task_id\":\"8fb7e481-8408-40ed-9332-d28aed5bb93f\",\"task\":\"4\"}}\n",
+      "💬 assistant: {\"name\": \"from_scratch__use_a2a_agent\", \"arguments\": {\"name\":\"crewai-hailstone\",\"task_id\":\"a8c2e9ab-4797-4c45-a80a-d35a682aadd7\",\"task\":\"4\"}}\n",
       "\n",
       "=== Task Step End ===\n",
       "\n",
       "=== Task Step Start ===\n",
       "\n",
-      "💬 assistant: My current instruction is 'The assistant should continue by providing the necessary input to the 'crewai-hailstone' agent to compute the hailstone sequence starting at the number four.'\n",
+      "💬 assistant: My current instruction is 'The assistant should continue by providing the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence.'\n",
       "\n",
-      "💬 assistant: I need to call the `from_scratch__use_a2a_agent` tool with the name \"crewai-hailstone\" and the task set to \"4\" to provide the necessary input for computing the hailstone sequence starting at the number four.\n",
+      "💬 assistant: I need to provide the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence. The number to start the sequence from is 4.\n",
       "\n",
       "=== Task Step End ===\n",
       "\n",
       "=== Task Step Start ===\n",
       "\n",
-      "💬 assistant: My current instruction is 'Call the `from_scratch__use_a2a_agent` tool with the name 'crewai-hailstone' and the task set to '4' to provide the necessary input for computing the hailstone sequence starting at the number four.'\n",
+      "💬 assistant: My current instruction is 'Provide the required information to the 'crewai-hailstone' agent to proceed with computing the hailstone sequence. The number to start the sequence from is 4.'\n",
       "\n",
       "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
-      "    \"id_\": \"c373ca55-0afd-4fe7-a4a8-156e6b3af1d4\",\n",
+      "    \"id_\": \"7c3fa94c-ae1b-4f7c-9904-115e9b918deb\",\n",
       "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
       "    \"arguments\": {\n",
       "        \"name\": \"crewai-hailstone\",\n",
@@ -862,12 +870,12 @@
       "}.\n",
       "\n",
       "🔧 tool: {\n",
-      "    \"tool_call_id\": \"c373ca55-0afd-4fe7-a4a8-156e6b3af1d4\",\n",
+      "    \"tool_call_id\": \"7c3fa94c-ae1b-4f7c-9904-115e9b918deb\",\n",
       "    \"content\": \"4,2,1\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "💬 assistant: The hailstone sequence starting at the number four is: 4, 2, 1.\n",
+      "💬 assistant: The hailstone sequence starting at the number 4 is: 4, 2, 1.\n",
       "\n",
       "=== Task Step End ==="
      ]
@@ -914,10 +922,10 @@
    "id": "9c05ab67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:05:28.781210Z",
-     "iopub.status.busy": "2026-08-07T23:05:28.781128Z",
-     "iopub.status.idle": "2026-08-07T23:05:28.794753Z",
-     "shell.execute_reply": "2026-08-07T23:05:28.794505Z"
+     "iopub.execute_input": "2026-08-08T00:03:01.196440Z",
+     "iopub.status.busy": "2026-08-08T00:03:01.196352Z",
+     "iopub.status.idle": "2026-08-08T00:03:01.209976Z",
+     "shell.execute_reply": "2026-08-08T00:03:01.209744Z"
     }
    },
    "outputs": [
@@ -989,10 +997,10 @@
    "id": "687ceacb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:05:28.795809Z",
-     "iopub.status.busy": "2026-08-07T23:05:28.795726Z",
-     "iopub.status.idle": "2026-08-07T23:05:28.809743Z",
-     "shell.execute_reply": "2026-08-07T23:05:28.809458Z"
+     "iopub.execute_input": "2026-08-08T00:03:01.211109Z",
+     "iopub.status.busy": "2026-08-08T00:03:01.211025Z",
+     "iopub.status.idle": "2026-08-08T00:03:01.225294Z",
+     "shell.execute_reply": "2026-08-08T00:03:01.225022Z"
     }
    },
    "outputs": [],
@@ -1027,10 +1035,10 @@
    "id": "64dd7124",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:05:28.810866Z",
-     "iopub.status.busy": "2026-08-07T23:05:28.810783Z",
-     "iopub.status.idle": "2026-08-07T23:06:50.974421Z",
-     "shell.execute_reply": "2026-08-07T23:06:50.974133Z"
+     "iopub.execute_input": "2026-08-08T00:03:01.226276Z",
+     "iopub.status.busy": "2026-08-08T00:03:01.226194Z",
+     "iopub.status.idle": "2026-08-08T00:04:54.744649Z",
+     "shell.execute_reply": "2026-08-08T00:04:54.744333Z"
     }
    },
    "outputs": [
@@ -1087,7 +1095,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the process is complete. The ...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
+      "\n",
+      "1. **Step 1**: 8 is even, so the next...[TRUNCATED]\n"
      ]
     },
     {
@@ -1101,7 +1111,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence starting at 8 is: 8, 4, 2, 1. The process is now complete as it has reached 1.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**.\n"
      ]
     },
     {
@@ -1129,14 +1139,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence starting at 8 is: 8, 4, 2, 1. The process is now complete as it has reached 1.\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The hailstone sequence starting at 8 is: 8, 4, 2, 1. The process is now complete as it has reached 1."
+      "The hailstone sequence starting at 8 is: **8 → 4 → 2 → 1**."
      ]
     },
     {
@@ -1190,10 +1200,10 @@
    "id": "ec16f077",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:06:50.975440Z",
-     "iopub.status.busy": "2026-08-07T23:06:50.975348Z",
-     "iopub.status.idle": "2026-08-07T23:06:50.977898Z",
-     "shell.execute_reply": "2026-08-07T23:06:50.977617Z"
+     "iopub.execute_input": "2026-08-08T00:04:54.746053Z",
+     "iopub.status.busy": "2026-08-08T00:04:54.745924Z",
+     "iopub.status.idle": "2026-08-08T00:04:54.748471Z",
+     "shell.execute_reply": "2026-08-08T00:04:54.748214Z"
     }
    },
    "outputs": [
@@ -1222,7 +1232,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`VIRTUAL_ENV=/home/nerdai/.cache/uv/builds-v0/.tmpQnfGOT` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead"
+      "`VIRTUAL_ENV=/home/nerdai/Projects/llm-agents-from-scratch/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead"
      ]
     },
     {
@@ -1230,39 +1240,22 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "INFO:     Started server process [323186]\n",
+      "INFO:     Started server process [336815]\n",
       "INFO:     Waiting for application startup.\n",
       "INFO:     Application startup complete.\n",
       "INFO:     Uvicorn running on http://0.0.0.0:9300 (Press CTRL+C to quit)\n",
-      "INFO:     127.0.0.1:55760 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
-      "INFO:     127.0.0.1:50442 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:49944 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:37658 - \"GET /.well-known/agent-card.json HTTP/1.1\" 200 OK\n",
       "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the hailstone sequence starting at 8, until it reaches 1.\n",
       "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the hailstone sequence starting at 8, until it reaches 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x = 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x = 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x = 8.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 8 is 4. I will now compute the subsequent numbers in the sequence until it reache...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the hailstone sequence starting at 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the hailstone sequence starting at 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x = 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x = 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x = 4.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 4 is 2. I will now compute the subsequent numbers in the sequence until it reache...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the next number in the hailstone sequence starting at 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the next number in the hailstone sequence starting at 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with x = 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with x = 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with x = 2.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the process is complete. The full hail...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
+      "\n",
+      "1. **Step 1**: 8 is even, so the next number i...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the hailstone sequence starting at 2 is 1. The sequence has now reached 1, so the process is complete. The full h...[TRUNCATED]\n",
-      "INFO:     127.0.0.1:48856 - \"POST / HTTP/1.1\" 200 OK\n"
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Starting with 8, I will compute the hailstone sequence step by step until it reaches 1.\n",
+      "\n",
+      "1. **Step 1**: 8 is even, so the next numbe...[TRUNCATED]\n",
+      "INFO:     127.0.0.1:41372 - \"POST / HTTP/1.1\" 200 OK\n"
      ]
     },
     {
@@ -1279,6 +1272,319 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3407e0e5",
+   "metadata": {},
+   "source": [
+    "### Example 5: A Relay Hailstone Task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e52422f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T00:04:54.749464Z",
+     "iopub.status.busy": "2026-08-08T00:04:54.749356Z",
+     "iopub.status.idle": "2026-08-08T00:06:12.766715Z",
+     "shell.execute_reply": "2026-08-08T00:06:12.766410Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the crewai-hailstone peer agent to compute the hailstone sequence starting at 20, run 3 steps then stop. Take the last number it ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the crewai-hailstone peer agent to compute the hailstone sequence starting at 20, run 3 steps then stop. Take the last number ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_a2a_agent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 20,10,5,16\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The last number reported by the crewai-hailstone agent is 16. I will now ask the from-scratch-hailstone agent to continue the hailstone...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the from-scratch-hailstone agent with the task: 'Continue the hailstone sequence from 16 until it reaches 1.'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the from-scratch-hailstone agent with the task: 'Continue the hailstone sequence from 16 until it reaches 1.'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_a2a_agent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Starting with 16, I will continue the hailstone sequence step by step until it reaches 1. \n",
+      "\n",
+      "1. The first step is to apply the ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
+      "\n",
+      "Combining this with the earlier sequence from 20 to 16, the ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
+      "\n",
+      "Combining this with the earlier sequence from 20 to 16, t...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
+      "\n",
+      "Combining this with the earlier sequence from 20 to 16, the full sequence from 20 to 1 is **20, 10, 5, 16, 8, 4, 2, 1**. \n",
+      "\n",
+      "The task is complete."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "relay_task = Task(\n",
+    "    instruction=(\n",
+    "        \"Ask the crewai-hailstone peer agent to compute the hailstone \"\n",
+    "        \"sequence starting at 20, run 3 steps then stop. Take the last \"\n",
+    "        \"number it reports, then ask the from-scratch-hailstone peer \"\n",
+    "        \"agent to continue the hailstone sequence from that number \"\n",
+    "        \"until it reaches 1. Report the full sequence from 20 to 1.\"\n",
+    "    ),\n",
+    ")\n",
+    "relay_handler = coordinator.run(relay_task, max_steps=10)\n",
+    "relay_result = await relay_handler\n",
+    "print(relay_result.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6306e73a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T00:06:12.767966Z",
+     "iopub.status.busy": "2026-08-08T00:06:12.767872Z",
+     "iopub.status.idle": "2026-08-08T00:06:12.769762Z",
+     "shell.execute_reply": "2026-08-08T00:06:12.769495Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Task Step Start ===\n",
+      "\n",
+      "💬 assistant: My current instruction is 'Ask the crewai-hailstone peer agent to compute the hailstone sequence starting at 20, run 3 steps then stop. Take the last number it reports, then ask the from-scratch-hailstone peer agent to continue the hailstone sequence from that number until it reaches 1. Report the full sequence from 20 to 1.'\n",
+      "\n",
+      "💬 assistant: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"636dc717-cb96-477d-b152-e06299662cae\",\n",
+      "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
+      "    \"arguments\": {\n",
+      "        \"name\": \"crewai-hailstone\",\n",
+      "        \"task\": \"Compute the hailstone sequence starting at 20, run 3 steps then stop.\"\n",
+      "    }\n",
+      "}.\n",
+      "\n",
+      "🔧 tool: {\n",
+      "    \"tool_call_id\": \"636dc717-cb96-477d-b152-e06299662cae\",\n",
+      "    \"content\": \"20,10,5,16\",\n",
+      "    \"error\": false\n",
+      "}\n",
+      "\n",
+      "💬 assistant: The last number reported by the crewai-hailstone agent is 16. I will now ask the from-scratch-hailstone agent to continue the hailstone sequence from 16 until it reaches 1.\n",
+      "\n",
+      "=== Task Step End ===\n",
+      "\n",
+      "=== Task Step Start ===\n",
+      "\n",
+      "💬 assistant: My current instruction is 'Call the from-scratch-hailstone agent with the task: 'Continue the hailstone sequence from 16 until it reaches 1.''\n",
+      "\n",
+      "💬 assistant: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"1a755d2c-0d2a-4b18-b47e-7c306273c8e2\",\n",
+      "    \"tool_name\": \"from_scratch__use_a2a_agent\",\n",
+      "    \"arguments\": {\n",
+      "        \"name\": \"from-scratch-hailstone\",\n",
+      "        \"task\": \"Continue the hailstone sequence from 16 until it reaches 1.\"\n",
+      "    }\n",
+      "}.\n",
+      "\n",
+      "🔧 tool: {\n",
+      "    \"tool_call_id\": \"1a755d2c-0d2a-4b18-b47e-7c306273c8e2\",\n",
+      "    \"content\": \"Starting with 16, I will continue the hailstone sequence step by step until it reaches 1. \\n\\n1. The first step is to apply the hailstone sequence rule to 16. Since 16 is even, the next number is 16 / 2 = 8.\\n2. Now, applying the rule to 8, which is also even, the next number is 8 / 2 = 4.\\n3. Applying the rule to 4, which is even, the next number is 4 / 2 = 2.\\n4. Applying the rule to 2, which is even, the next number is 2 / 2 = 1.\\n\\nThe hailstone sequence from 16 until it reaches 1 is 16, 8, 4, 2, 1.\",\n",
+      "    \"error\": false\n",
+      "}\n",
+      "\n",
+      "💬 assistant: The hailstone sequence from 16 until it reaches 1 is **16, 8, 4, 2, 1**. \n",
+      "\n",
+      "Combining this with the earlier sequence from 20 to 16, the full sequence from 20 to 1 is **20, 10, 5, 16, 8, 4, 2, 1**. \n",
+      "\n",
+      "The task is complete.\n",
+      "\n",
+      "=== Task Step End ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(relay_handler.rollout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b56ed568",
    "metadata": {},
    "source": [
@@ -1287,14 +1593,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "0b3a7624",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T23:06:50.978787Z",
-     "iopub.status.busy": "2026-08-07T23:06:50.978698Z",
-     "iopub.status.idle": "2026-08-07T23:06:51.715886Z",
-     "shell.execute_reply": "2026-08-07T23:06:51.714067Z"
+     "iopub.execute_input": "2026-08-08T00:06:12.770779Z",
+     "iopub.status.busy": "2026-08-08T00:06:12.770694Z",
+     "iopub.status.idle": "2026-08-08T00:06:13.509468Z",
+     "shell.execute_reply": "2026-08-08T00:06:13.508060Z"
     }
    },
    "outputs": [

--- a/extra/a2a-crewai-hailstone/README.md
+++ b/extra/a2a-crewai-hailstone/README.md
@@ -30,6 +30,12 @@ guessing. Resume by sending another message to the same `task_id` with
 the missing integer — the same client-side pattern
 `UseA2AAgentTool`'s `task_id` parameter supports for any peer.
 
+An instruction can also name a step budget (e.g. "run 3 steps then
+stop"), in which case the crew stops after exactly that many calls to
+`hailstone_step` instead of continuing to 1 — used by Chapter 10's
+Example 5 to hand a partially-computed sequence off to another peer.
+Without a step budget, behavior is unchanged: the crew runs to 1.
+
 ## Installation
 
 ```bash

--- a/extra/a2a-crewai-hailstone/README.md
+++ b/extra/a2a-crewai-hailstone/README.md
@@ -30,11 +30,11 @@ guessing. Resume by sending another message to the same `task_id` with
 the missing integer — the same client-side pattern
 `UseA2AAgentTool`'s `task_id` parameter supports for any peer.
 
-An instruction can also name a step budget (e.g. "run 3 steps then
-stop"), in which case the crew stops after exactly that many calls to
-`hailstone_step` instead of continuing to 1 — used by Chapter 10's
-Example 5 to hand a partially-computed sequence off to another peer.
-Without a step budget, behavior is unchanged: the crew runs to 1.
+An instruction can also name a stopping point other than 1 (e.g. "run
+3 steps then stop") — the crew's own goal tells it to stop there
+instead of continuing to 1, used by Chapter 10's Example 5 to hand a
+partially-computed sequence off to another peer. Without one, behavior
+is unchanged: the crew runs to 1.
 
 ## Installation
 

--- a/extra/a2a-crewai-hailstone/main.py
+++ b/extra/a2a-crewai-hailstone/main.py
@@ -53,6 +53,27 @@ def _extract_starting_integer(instruction: str) -> int | None:
     return int(match.group()) if match else None
 
 
+def _extract_step_budget(instruction: str) -> int | None:
+    r"""Pulls a "run N steps" style step budget out of an instruction.
+
+    Matched separately from ``_extract_starting_integer()`` (a bare
+    ``\d+``) so a phrase like "starting at 8, run 3 steps then stop"
+    doesn't confuse the two integers. Absent, ``execute()`` falls back
+    to the original full-sequence-to-1 behavior, so every prior
+    example's instruction (which never names a step count) is
+    unaffected.
+
+    Args:
+        instruction: The raw task instruction text.
+
+    Returns:
+        The requested step count, or None if the instruction names
+        none.
+    """
+    match = re.search(r"(\d+)\s+steps?", instruction)
+    return int(match.group(1)) if match else None
+
+
 @tool("hailstone_step")
 def hailstone_step_fn(x: int) -> str:
     """Performs a single step of the Hailstone sequence.
@@ -64,40 +85,77 @@ def hailstone_step_fn(x: int) -> str:
     return str(3 * x + 1)
 
 
-def build_crew(instruction: str) -> Crew:
-    """Builds a single-agent Crew that computes a full hailstone sequence.
+def build_crew(starting_value: int, step_budget: int | None = None) -> Crew:
+    """Builds a single-agent Crew that computes a hailstone sequence.
 
     Args:
-        instruction: The raw task instruction from the A2A caller,
-            expected to name the positive integer to start from.
+        starting_value: The positive integer to start the sequence
+            from.
+        step_budget: If given, the crew stops after exactly this many
+            steps rather than continuing to 1 -- used by the relay
+            demo in Chapter 10's Example 5, where this peer only
+            carries the sequence partway before handing off to
+            another agent. Defaults to None (run to completion).
 
     Returns:
-        Crew: A crew ready to be kicked off with this instruction.
+        Crew: A crew ready to be kicked off.
     """
     llm = LLM(model=OLLAMA_MODEL, base_url=OLLAMA_BASE_URL)
-    agent = Agent(
-        role="Hailstone Sequence Calculator",
-        goal=(
+    if step_budget is None:
+        goal = (
             "Compute the full Collatz/Hailstone sequence for the positive "
             "integer named in the task, by repeatedly calling the "
             "hailstone_step tool on each result until it reaches 1."
-        ),
-        backstory=(
+        )
+        backstory = (
             "An expert on the Collatz conjecture who never computes a "
             "step by hand — always calls the hailstone_step tool once "
             "per step, feeding each result back in as the next call's "
             "input, until the sequence reaches 1."
-        ),
+        )
+        description = (
+            f"Compute the hailstone sequence starting at {starting_value}."
+        )
+        expected_output = (
+            "The full hailstone sequence as a comma-separated list of "
+            "integers, starting with the input value and ending at 1, "
+            "and nothing else."
+        )
+    else:
+        goal = (
+            "Compute a partial Collatz/Hailstone sequence for the positive "
+            "integer named in the task, by calling the hailstone_step "
+            "tool exactly the number of times given, then stopping even "
+            "if the sequence hasn't reached 1 yet."
+        )
+        backstory = (
+            "An expert on the Collatz conjecture who never computes a "
+            "step by hand — always calls the hailstone_step tool once "
+            "per step, feeding each result back in as the next call's "
+            "input, and stops as soon as the requested number of calls "
+            "has been made."
+        )
+        description = (
+            f"Starting at {starting_value}, call hailstone_step exactly "
+            f"{step_budget} times, feeding each result into the next "
+            f"call as input. Stop after exactly {step_budget} calls, "
+            "even if the sequence hasn't reached 1 yet."
+        )
+        expected_output = (
+            f"The sequence of {step_budget + 1} integers from "
+            f"{starting_value} through the value after {step_budget} "
+            "steps, as a comma-separated list, and nothing else."
+        )
+    agent = Agent(
+        role="Hailstone Sequence Calculator",
+        goal=goal,
+        backstory=backstory,
         tools=[hailstone_step_fn],
         llm=llm,
     )
     task = Task(
-        description=instruction,
-        expected_output=(
-            "The full hailstone sequence as a comma-separated list of "
-            "integers, starting with the input value and ending at 1, "
-            "and nothing else."
-        ),
+        description=description,
+        expected_output=expected_output,
         agent=agent,
     )
     return Crew(agents=[agent], tasks=[task])
@@ -156,9 +214,8 @@ class CrewAIHailstoneExecutor(AgentExecutor):
             )
             return
 
-        crew = build_crew(
-            f"Compute the hailstone sequence starting at {starting_value}.",
-        )
+        step_budget = _extract_step_budget(instruction)
+        crew = build_crew(starting_value, step_budget)
         result = await asyncio.to_thread(crew.kickoff)
 
         await updater.add_artifact(

--- a/extra/a2a-crewai-hailstone/main.py
+++ b/extra/a2a-crewai-hailstone/main.py
@@ -53,27 +53,6 @@ def _extract_starting_integer(instruction: str) -> int | None:
     return int(match.group()) if match else None
 
 
-def _extract_step_budget(instruction: str) -> int | None:
-    r"""Pulls a "run N steps" style step budget out of an instruction.
-
-    Matched separately from ``_extract_starting_integer()`` (a bare
-    ``\d+``) so a phrase like "starting at 8, run 3 steps then stop"
-    doesn't confuse the two integers. Absent, ``execute()`` falls back
-    to the original full-sequence-to-1 behavior, so every prior
-    example's instruction (which never names a step count) is
-    unaffected.
-
-    Args:
-        instruction: The raw task instruction text.
-
-    Returns:
-        The requested step count, or None if the instruction names
-        none.
-    """
-    match = re.search(r"(\d+)\s+steps?", instruction)
-    return int(match.group(1)) if match else None
-
-
 @tool("hailstone_step")
 def hailstone_step_fn(x: int) -> str:
     """Performs a single step of the Hailstone sequence.
@@ -85,77 +64,46 @@ def hailstone_step_fn(x: int) -> str:
     return str(3 * x + 1)
 
 
-def build_crew(starting_value: int, step_budget: int | None = None) -> Crew:
+def build_crew(instruction: str) -> Crew:
     """Builds a single-agent Crew that computes a hailstone sequence.
 
     Args:
-        starting_value: The positive integer to start the sequence
-            from.
-        step_budget: If given, the crew stops after exactly this many
-            steps rather than continuing to 1 -- used by the relay
-            demo in Chapter 10's Example 5, where this peer only
-            carries the sequence partway before handing off to
-            another agent. Defaults to None (run to completion).
+        instruction: The raw task instruction from the A2A caller,
+            expected to name the positive integer to start from and,
+            optionally, a stopping point other than 1 (e.g. "run 3
+            steps then stop") -- used by the relay demo in Chapter
+            10's Example 5, where this peer only carries the sequence
+            partway before handing off to another agent.
 
     Returns:
-        Crew: A crew ready to be kicked off.
+        Crew: A crew ready to be kicked off with this instruction.
     """
     llm = LLM(model=OLLAMA_MODEL, base_url=OLLAMA_BASE_URL)
-    if step_budget is None:
-        goal = (
-            "Compute the full Collatz/Hailstone sequence for the positive "
-            "integer named in the task, by repeatedly calling the "
-            "hailstone_step tool on each result until it reaches 1."
-        )
-        backstory = (
-            "An expert on the Collatz conjecture who never computes a "
-            "step by hand — always calls the hailstone_step tool once "
-            "per step, feeding each result back in as the next call's "
-            "input, until the sequence reaches 1."
-        )
-        description = (
-            f"Compute the hailstone sequence starting at {starting_value}."
-        )
-        expected_output = (
-            "The full hailstone sequence as a comma-separated list of "
-            "integers, starting with the input value and ending at 1, "
-            "and nothing else."
-        )
-    else:
-        goal = (
-            "Compute a partial Collatz/Hailstone sequence for the positive "
-            "integer named in the task, by calling the hailstone_step "
-            "tool exactly the number of times given, then stopping even "
-            "if the sequence hasn't reached 1 yet."
-        )
-        backstory = (
-            "An expert on the Collatz conjecture who never computes a "
-            "step by hand — always calls the hailstone_step tool once "
-            "per step, feeding each result back in as the next call's "
-            "input, and stops as soon as the requested number of calls "
-            "has been made."
-        )
-        description = (
-            f"Starting at {starting_value}, call hailstone_step exactly "
-            f"{step_budget} times, feeding each result into the next "
-            f"call as input. Stop after exactly {step_budget} calls, "
-            "even if the sequence hasn't reached 1 yet."
-        )
-        expected_output = (
-            f"The sequence of {step_budget + 1} integers from "
-            f"{starting_value} through the value after {step_budget} "
-            "steps, as a comma-separated list, and nothing else."
-        )
     agent = Agent(
         role="Hailstone Sequence Calculator",
-        goal=goal,
-        backstory=backstory,
+        goal=(
+            "Compute the Collatz/Hailstone sequence described in the "
+            "task, by repeatedly calling the hailstone_step tool on "
+            "each result. Continue until the sequence reaches 1, "
+            "unless the task names a different stopping point (e.g. a "
+            "fixed number of steps), in which case stop there instead."
+        ),
+        backstory=(
+            "An expert on the Collatz conjecture who never computes a "
+            "step by hand — always calls the hailstone_step tool once "
+            "per step, feeding each result back in as the next call's "
+            "input, and stops exactly where the task says to."
+        ),
         tools=[hailstone_step_fn],
         llm=llm,
     )
     task = Task(
-        description=description,
-        expected_output=expected_output,
+        description=instruction,
+        expected_output=(
+            "The computed hailstone sequence as a comma-separated list "
+            "of integers, starting with the input value, and nothing "
+            "else."
+        ),
         agent=agent,
     )
     return Crew(agents=[agent], tasks=[task])
@@ -214,8 +162,7 @@ class CrewAIHailstoneExecutor(AgentExecutor):
             )
             return
 
-        step_budget = _extract_step_budget(instruction)
-        crew = build_crew(starting_value, step_budget)
+        crew = build_crew(instruction)
         result = await asyncio.to_thread(crew.kickoff)
 
         await updater.add_artifact(


### PR DESCRIPTION
## Summary
- Adds an optional step budget to `CrewAIHailstoneExecutor` (e.g. "run 3 steps then stop") — previously the executor discarded the caller's instruction beyond the starting integer and always ran the crew to 1.
- `examples/ch10.ipynb` Example 5: the coordinator (already holding both peers from Examples 3/4) asks `crewai-hailstone` to compute 3 steps from 20, then hands the last value it reports to `from-scratch-hailstone` to finish, stitching both legs into one combined trajectory. No explanatory prose in the notebook itself, per convention — the executor-comparison figure this issue originally proposed is instead noted in the Chapter 10 Notion writing plan for the book prose to pick up.
- Full notebook re-executed end-to-end (`jupyter nbconvert --execute --inplace`) against both live A2A servers; verified only the new cells' sources changed, no errors anywhere.

## Test plan
- [x] `make lint` passes
- [x] Live end-to-end run: `crewai-hailstone` (budget=3) returns `20,10,5,16`; `from-scratch-hailstone` continues to `16,8,4,2,1`; coordinator reports the combined `20,10,5,16,8,4,2,1`, confirmed via `handler.rollout` showing both peer dispatches
- [x] Full notebook re-executed top to bottom with zero cell errors

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)