### PR TITLE
refactor(ch09): SubAgentSpec — plain class instead of BaseModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- refactor(ch09): `SubAgentSpec` — plain class instead of a pydantic `BaseModel`, matching `Skill`/`Memory`/`LLMAgentBuilder`'s pattern for objects that wrap a live collaborator (`arbitrary_types_allowed=True` was the only thing pydantic bought here); same constructor signature, `catalog()` unchanged, hand-written `__repr__` (#831)
 - refactor(ch09): `SubAgentSpec.agent: LLMAgent` → `SubAgentSpec.builder: LLMAgentBuilder` — the spec is now pure data holding a build recipe, not a live agent, mirroring `A2AAgentSpec`'s rule; `UseSubAgentTool` builds a fresh `LLMAgent` from the recipe on every dispatch, reusing whatever the builder was given directly (memory stores, MCP providers) across builds (#830)
 
 ## [0.0.23] - 2026-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- refactor(ch09): `SubAgentSpec` — plain class instead of a pydantic `BaseModel`, matching `Skill`/`Memory`/`LLMAgentBuilder`'s pattern for objects that wrap a live collaborator (`arbitrary_types_allowed=True` was the only thing pydantic bought here); same constructor signature, `catalog()` unchanged, hand-written `__repr__` (#831)
+- refactor(ch09): `SubAgentSpec` — plain class instead of a pydantic `BaseModel`, matching `Skill`/`Memory`/`LLMAgentBuilder`'s pattern for objects that wrap a live collaborator (`arbitrary_types_allowed=True` was the only thing pydantic bought here); same constructor signature, `catalog()` unchanged, hand-written `__repr__` (#833)
 - refactor(ch09): `SubAgentSpec.agent: LLMAgent` → `SubAgentSpec.builder: LLMAgentBuilder` — the spec is now pure data holding a build recipe, not a live agent, mirroring `A2AAgentSpec`'s rule; `UseSubAgentTool` builds a fresh `LLMAgent` from the recipe on every dispatch, reusing whatever the builder was given directly (memory stores, MCP providers) across builds (#830)
 
 ## [0.0.23] - 2026-08-07

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -1,14 +1,12 @@
 """SubAgentSpec — specification for a named sub-agent."""
 
-from pydantic import BaseModel, ConfigDict, Field
-
 from llm_agents_from_scratch.agent import LLMAgentBuilder
 from llm_agents_from_scratch.data_structures.skill import SkillScope
 
 from .constants import CATALOG_SPEC_TEMPLATE
 
 
-class SubAgentSpec(BaseModel):
+class SubAgentSpec:
     """Specification for a named sub-agent in a multi-agent system.
 
     Each ``SubAgentSpec`` entry registers a build recipe for a sub-agent
@@ -24,6 +22,28 @@ class SubAgentSpec(BaseModel):
     each time, mirroring the existing fresh-``TaskHandler``-per-``run()``
     pattern.
 
+    Not in ``data_structures/``: that package is the zero-dependency
+    bottom layer (stdlib/pydantic imports only, no framework
+    cross-references), reserved for passive records like
+    ``SkillFrontmatter``. ``builder`` holds a live ``LLMAgentBuilder``
+    and ``catalog()`` is real behavior — this spec matches ``Skill``'s
+    shape, not ``SkillFrontmatter``'s. Moving it would also create a
+    real import cycle: ``LLMAgent`` only imports ``SubAgentSpec`` under
+    ``TYPE_CHECKING`` today precisely to avoid
+    ``agent.llm_agent`` → ``subagents.spec`` → ``agent.builder`` →
+    ``agent.llm_agent``; ``data_structures/`` is imported eagerly
+    everywhere, so that guard would stop working. See
+    ``A2AAgentSpec`` for the same reasoning, spelled out in full.
+
+    A plain class, not a pydantic ``BaseModel``, for the same reason
+    ``Skill``/``Memory``/``LLMAgentBuilder`` are plain classes: those
+    are reserved for behavior-bearing objects that wrap a live
+    collaborator, not passive serializable data. ``BaseModel`` would
+    only have bought required-field validation (a plain ``__init__``
+    already raises ``TypeError`` on missing required args) at the cost
+    of needing ``arbitrary_types_allowed=True`` for ``builder``, a
+    non-pydantic type.
+
     Attributes:
         name: Unique registry key for this sub-agent. Appears as an enum
             value in ``UseSubAgentTool``'s dispatch schema — must be
@@ -32,8 +52,7 @@ class SubAgentSpec(BaseModel):
             the ``<available_subagents>`` catalog. Should describe capability,
             not implementation.
         builder: The recipe used to build this sub-agent fresh on every
-            dispatch. Held as a live object; Pydantic's
-            ``arbitrary_types_allowed`` is required for this field.
+            dispatch.
         max_steps: Optional cap on the number of steps the sub-agent may
             take per dispatch. Passed to ``agent.run()`` to bound runaway
             executions. ``None`` uses the agent's own default.
@@ -46,44 +65,50 @@ class SubAgentSpec(BaseModel):
             exclusions).
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    def __init__(  # noqa: PLR0913, PLR0917
+        self,
+        name: str,
+        description: str,
+        builder: LLMAgentBuilder,
+        max_steps: int | None = None,
+        skills_scopes: list[SkillScope] | None = None,
+        explicit_only_skills: set[str] | None = None,
+    ) -> None:
+        """Initialise a SubAgentSpec.
 
-    name: str = Field(
-        description=(
-            "Unique registry key for this sub-agent. Appears as an enum "
-            "value in UseSubAgentTool's dispatch schema."
-        ),
-    )
-    description: str = Field(
-        description=(
-            "Routing signal shown to the coordinator LLM in the "
-            "<available_subagents> catalog."
-        ),
-    )
-    builder: LLMAgentBuilder = Field(
-        description="The recipe used to build this sub-agent per dispatch.",
-    )
-    max_steps: int | None = Field(
-        default=None,
-        description=(
-            "Optional cap on sub-agent steps per dispatch. "
-            "None uses the agent's own default."
-        ),
-    )
-    skills_scopes: list[SkillScope] | None = Field(
-        default=None,
-        description=(
-            "Optional scopes to scan for skills on this sub-agent's "
-            "dispatches. None uses the agent's own default."
-        ),
-    )
-    explicit_only_skills: set[str] | None = Field(
-        default=None,
-        description=(
-            "Optional skill names to exclude from this sub-agent's model "
-            "catalog on dispatch. None uses the agent's own default."
-        ),
-    )
+        Args:
+            name: Unique registry key for this sub-agent.
+            description: Routing signal shown to the coordinator LLM in
+                the ``<available_subagents>`` catalog.
+            builder: The recipe used to build this sub-agent per
+                dispatch.
+            max_steps: Optional cap on sub-agent steps per dispatch.
+                Defaults to ``None`` (agent's own default).
+            skills_scopes: Optional scopes to scan for skills on this
+                sub-agent's dispatches. Defaults to ``None`` (agent's
+                own default).
+            explicit_only_skills: Optional skill names to exclude from
+                this sub-agent's model catalog on dispatch. Defaults to
+                ``None`` (agent's own default).
+        """
+        self.name = name
+        self.description = description
+        self.builder = builder
+        self.max_steps = max_steps
+        self.skills_scopes = skills_scopes
+        self.explicit_only_skills = explicit_only_skills
+
+    def __repr__(self) -> str:
+        """Readable repr, mirroring the fields pydantic would have shown."""
+        return (
+            f"{type(self).__name__}("
+            f"name={self.name!r}, "
+            f"description={self.description!r}, "
+            f"builder={self.builder!r}, "
+            f"max_steps={self.max_steps!r}, "
+            f"skills_scopes={self.skills_scopes!r}, "
+            f"explicit_only_skills={self.explicit_only_skills!r})"
+        )
 
     def catalog(self) -> str:
         """Return XML entry for this spec in the sub-agents catalog."""

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -86,7 +86,7 @@ class SubAgentSpec:
         self.explicit_only_skills = explicit_only_skills
 
     def __repr__(self) -> str:
-        """Readable repr, mirroring the fields pydantic would have shown."""
+        """Readable repr listing every field."""
         return (
             f"{type(self).__name__}("
             f"name={self.name!r}, "

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -22,19 +22,6 @@ class SubAgentSpec:
     each time, mirroring the existing fresh-``TaskHandler``-per-``run()``
     pattern.
 
-    Not in ``data_structures/``: that package is the zero-dependency
-    bottom layer (stdlib/pydantic imports only, no framework
-    cross-references), reserved for passive records like
-    ``SkillFrontmatter``. ``builder`` holds a live ``LLMAgentBuilder``
-    and ``catalog()`` is real behavior — this spec matches ``Skill``'s
-    shape, not ``SkillFrontmatter``'s. Moving it would also create a
-    real import cycle: ``LLMAgent`` only imports ``SubAgentSpec`` under
-    ``TYPE_CHECKING`` today precisely to avoid
-    ``agent.llm_agent`` → ``subagents.spec`` → ``agent.builder`` →
-    ``agent.llm_agent``; ``data_structures/`` is imported eagerly
-    everywhere, so that guard would stop working. See
-    ``A2AAgentSpec`` for the same reasoning, spelled out in full.
-
     A plain class, not a pydantic ``BaseModel``, for the same reason
     ``Skill``/``Memory``/``LLMAgentBuilder`` are plain classes: those
     are reserved for behavior-bearing objects that wrap a live

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -109,6 +109,7 @@ def test_subagentspec_repr(mock_llm: BaseLLM) -> None:
     assert text.startswith("SubAgentSpec(")
     assert "name='researcher'" in text
     assert "description='Searches the web.'" in text
+    assert "builder=" in text
     assert f"max_steps={MAX_STEPS}" in text
     assert "skills_scopes=None" in text
     assert "explicit_only_skills=None" in text

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -95,9 +95,7 @@ def test_subagentspec_catalog(mock_llm: BaseLLM) -> None:
 
 
 def test_subagentspec_repr(mock_llm: BaseLLM) -> None:
-    """Tests __repr__ surfaces every field, plain-class replacement for
-    pydantic's auto-generated repr.
-    """
+    """Tests __repr__ surfaces every field."""
     spec = SubAgentSpec(
         name="researcher",
         description="Searches the web.",

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -1,7 +1,6 @@
 """Unit tests for SubAgentSpec."""
 
 import pytest
-from pydantic import ValidationError
 
 from llm_agents_from_scratch.agent import LLMAgentBuilder
 from llm_agents_from_scratch.base.llm import BaseLLM
@@ -65,8 +64,8 @@ def test_subagentspec_max_steps(mock_llm: BaseLLM) -> None:
 
 
 def test_subagentspec_requires_name(mock_llm: BaseLLM) -> None:
-    """Tests SubAgentSpec raises ValidationError when name is missing."""
-    with pytest.raises(ValidationError):
+    """Tests SubAgentSpec raises TypeError when name is missing."""
+    with pytest.raises(TypeError):
         SubAgentSpec(  # type: ignore[call-arg]
             description="no name provided",
             builder=LLMAgentBuilder(llm=mock_llm),
@@ -74,8 +73,8 @@ def test_subagentspec_requires_name(mock_llm: BaseLLM) -> None:
 
 
 def test_subagentspec_requires_description(mock_llm: BaseLLM) -> None:
-    """Tests SubAgentSpec raises ValidationError when description is missing."""
-    with pytest.raises(ValidationError):
+    """Tests SubAgentSpec raises TypeError when description is missing."""
+    with pytest.raises(TypeError):
         SubAgentSpec(  # type: ignore[call-arg]
             name="coder",
             builder=LLMAgentBuilder(llm=mock_llm),
@@ -93,3 +92,23 @@ def test_subagentspec_catalog(mock_llm: BaseLLM) -> None:
 
     assert "<name>researcher</name>" in entry
     assert "<description>Searches the web.</description>" in entry
+
+
+def test_subagentspec_repr(mock_llm: BaseLLM) -> None:
+    """Tests __repr__ surfaces every field, plain-class replacement for
+    pydantic's auto-generated repr.
+    """
+    spec = SubAgentSpec(
+        name="researcher",
+        description="Searches the web.",
+        builder=LLMAgentBuilder(llm=mock_llm),
+        max_steps=MAX_STEPS,
+    )
+    text = repr(spec)
+
+    assert text.startswith("SubAgentSpec(")
+    assert "name='researcher'" in text
+    assert "description='Searches the web.'" in text
+    assert f"max_steps={MAX_STEPS}" in text
+    assert "skills_scopes=None" in text
+    assert "explicit_only_skills=None" in text


### PR DESCRIPTION
## Summary
- `SubAgentSpec` is now a plain class instead of a pydantic `BaseModel`. It was the outlier: every other class wrapping a live, behavior-bearing collaborator (`Skill`, `Memory`, `MCPToolProvider`, `LLMAgent`, `LLMAgentBuilder`, `TaskHandler`) is already a plain class in this codebase — `BaseModel` is reserved for passive, serializable data (`data_structures/`, `SkillFrontmatter`).
- `arbitrary_types_allowed=True` — needed only because `builder: LLMAgentBuilder` isn't a pydantic type — is gone entirely.
- Same constructor signature (`name`, `description`, `builder`, `max_steps`, `skills_scopes`, `explicit_only_skills`), same `catalog()` method.
- Missing required args now raise `TypeError` (plain `__init__`) instead of pydantic's `ValidationError` — same guarantee, different exception type.
- Hand-written `__repr__` reproduces pydantic's exact field-by-field format, so `examples/ch09.ipynb`'s cached output cell needed no changes.

## Test plan
- [x] `make lint` passes
- [x] `pytest tests -q` — 533 passed (1 new: `test_subagentspec_repr`)
- [x] Verified no other code relies on pydantic-specific behavior (`.model_dump()`, `__eq__`) — duplicate-name checks in `LLMAgent.__init__` key off `.name` strings, not spec identity/equality

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)