### PR TITLE
chore: change spelling to subagent without hyphen

### DIFF
--- a/src/llm_agents_from_scratch/a2a/server/executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/executor.py
@@ -34,7 +34,7 @@ class LLMAgentA2AExecutor(AgentExecutor):
 
     Every dispatch runs to completion or failure in one shot; there is
     no ``input_required`` support on this (server) side. §8.5's channel
-    problem was already answered in Ch9 by dissolution (sub-agents run
+    problem was already answered in Ch9 by dissolution (subagents run
     in-process, same terminal), so implementing a non-terminal
     ``SendMessage`` return here would mostly pay off a forward
     reference already paid — a named skip, alongside streaming,

--- a/src/llm_agents_from_scratch/agent/builder.py
+++ b/src/llm_agents_from_scratch/agent/builder.py
@@ -34,7 +34,7 @@ class LLMAgentBuilder:
         mcp_providers (list[MCPToolProvider]): MCP providers for tool
             discovery.
         memories (list[Memory]): Memory backends for the agent.
-        subagents (list[SubAgentSpec]): Sub-agent specs for the agent.
+        subagents (list[SubAgentSpec]): subagent specs for the agent.
             Added in Chapter 9.
         a2a_agents (list[A2AAgentSpec]): A2A peer specs for the agent.
             Added in Chapter 10.
@@ -96,7 +96,7 @@ class LLMAgentBuilder:
             memories (list[Memory] | None, optional): Memory backends
                 for the agent. No default implementation is provided — the
                 caller must supply a concrete subclass. Defaults to None.
-            subagents (list[SubAgentSpec] | None, optional): Sub-agent specs
+            subagents (list[SubAgentSpec] | None, optional): subagent specs
                 to register on the agent. Defaults to None. Added in
                 Chapter 9.
             a2a_agents (list[A2AAgentSpec] | None, optional): A2A peer
@@ -155,19 +155,19 @@ class LLMAgentBuilder:
         return self
 
     def with_subagent(self, spec: "SubAgentSpec") -> Self:
-        """Add a sub-agent spec to builder. Added in Chapter 9.
+        """Add a subagent spec to builder. Added in Chapter 9.
 
         Args:
-            spec (SubAgentSpec): The sub-agent spec to add.
+            spec (SubAgentSpec): The subagent spec to add.
         """
         self.subagents.append(spec)
         return self
 
     def with_subagents(self, specs: "list[SubAgentSpec]") -> Self:
-        """Add sub-agent specs to builder. Added in Chapter 9.
+        """Add subagent specs to builder. Added in Chapter 9.
 
         Args:
-            specs (list[SubAgentSpec]): The sub-agent specs to add.
+            specs (list[SubAgentSpec]): The subagent specs to add.
         """
         self.subagents.extend(specs)
         return self

--- a/src/llm_agents_from_scratch/agent/builder.py
+++ b/src/llm_agents_from_scratch/agent/builder.py
@@ -34,7 +34,7 @@ class LLMAgentBuilder:
         mcp_providers (list[MCPToolProvider]): MCP providers for tool
             discovery.
         memories (list[Memory]): Memory backends for the agent.
-        subagents (list[SubAgentSpec]): subagent specs for the agent.
+        subagents (list[SubAgentSpec]): Subagent specs for the agent.
             Added in Chapter 9.
         a2a_agents (list[A2AAgentSpec]): A2A peer specs for the agent.
             Added in Chapter 10.
@@ -96,7 +96,7 @@ class LLMAgentBuilder:
             memories (list[Memory] | None, optional): Memory backends
                 for the agent. No default implementation is provided — the
                 caller must supply a concrete subclass. Defaults to None.
-            subagents (list[SubAgentSpec] | None, optional): subagent specs
+            subagents (list[SubAgentSpec] | None, optional): Subagent specs
                 to register on the agent. Defaults to None. Added in
                 Chapter 9.
             a2a_agents (list[A2AAgentSpec] | None, optional): A2A peer

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -60,7 +60,7 @@ class LLMAgent:
             the LLM with, represented as a dict.
         templates (LLMAgentTemplates): Prompt templates for LLM Agent.
         logger (logging.Logger): LLMAgent logger.
-        subagents_registry (dict[str, SubAgentSpec]): Sub-agent registry,
+        subagents_registry (dict[str, SubAgentSpec]): subagent registry,
             keyed by name. Built from the constructor list. Added in
             Chapter 9.
         a2a_agents_registry (dict[str, A2AAgentSpec]): A2A peer registry,
@@ -95,9 +95,9 @@ class LLMAgent:
             memories (list[Memory] | None): Episodic memory backends
                 to consult at task start and update at task end. Defaults
                 to None (no memory). Added in Chapter 7.
-            subagents (list[SubAgentSpec] | None): Sub-agents this
+            subagents (list[SubAgentSpec] | None): subagents this
                 coordinator can delegate to. Defaults to None (no
-                sub-agents). Added in Chapter 9.
+                subagents). Added in Chapter 9.
             a2a_agents (list[A2AAgentSpec] | None): A2A peer agents this
                 coordinator can dispatch to. Defaults to None (no A2A
                 peers). Added in Chapter 10.
@@ -170,7 +170,7 @@ class LLMAgent:
                 activation tool. Set when skills are discovered; ``None``
                 otherwise. Added in Chapter 6.
             _use_subagent_tool (UseSubAgentTool | None): Task-scoped
-                sub-agent dispatch tool. Set when sub-agents are registered
+                subagent dispatch tool. Set when subagents are registered
                 on the agent; ``None`` otherwise. Added in Chapter 9.
             _use_a2a_agent_tool (UseA2AAgentTool | None): Task-scoped A2A
                 peer dispatch tool. Set when A2A peers are registered on
@@ -291,13 +291,13 @@ class LLMAgent:
 
         @property
         def _subagents_catalog(self) -> str:
-            """Return formatted sub-agents catalog, or empty string.
+            """Return formatted subagents catalog, or empty string.
 
             Added in Chapter 9.
 
-            Builds the ``<available_subagents>`` XML block from sub-agents
+            Builds the ``<available_subagents>`` XML block from subagents
             registered on the coordinator. Returns an empty string when no
-            sub-agents are configured so callers can append it
+            subagents are configured so callers can append it
             unconditionally without adding noise.
             """
             specs = self.llm_agent.subagents_registry.values()
@@ -513,7 +513,7 @@ class LLMAgent:
                     content=f"{system_message.content}\n\n{catalog}",
                 )
 
-            # added in ch09: bolt on sub-agents catalog when registered
+            # added in ch09: bolt on subagents catalog when registered
             if catalog := self._subagents_catalog:
                 system_message = ChatMessage(
                     role=ChatRole.SYSTEM,

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -60,7 +60,7 @@ class LLMAgent:
             the LLM with, represented as a dict.
         templates (LLMAgentTemplates): Prompt templates for LLM Agent.
         logger (logging.Logger): LLMAgent logger.
-        subagents_registry (dict[str, SubAgentSpec]): subagent registry,
+        subagents_registry (dict[str, SubAgentSpec]): Subagent registry,
             keyed by name. Built from the constructor list. Added in
             Chapter 9.
         a2a_agents_registry (dict[str, A2AAgentSpec]): A2A peer registry,
@@ -95,7 +95,7 @@ class LLMAgent:
             memories (list[Memory] | None): Episodic memory backends
                 to consult at task start and update at task end. Defaults
                 to None (no memory). Added in Chapter 7.
-            subagents (list[SubAgentSpec] | None): subagents this
+            subagents (list[SubAgentSpec] | None): Subagents this
                 coordinator can delegate to. Defaults to None (no
                 subagents). Added in Chapter 9.
             a2a_agents (list[A2AAgentSpec] | None): A2A peer agents this

--- a/src/llm_agents_from_scratch/agent/templates/defaults.py
+++ b/src/llm_agents_from_scratch/agent/templates/defaults.py
@@ -99,9 +99,9 @@ result directly unless instructed otherwise.
 {memories}
 </memories>""".strip()
 
-DEFAULT_SUBAGENTS_CATALOG = """The following sub-agents are available. To \
+DEFAULT_SUBAGENTS_CATALOG = """The following subagents are available. To \
 dispatch a task to one, call the `from_scratch__use_subagent` tool with the \
-sub-agent name and a task instruction.
+subagent name and a task instruction.
 
 <available_subagents>
 {subagents}

--- a/src/llm_agents_from_scratch/errors/subagents.py
+++ b/src/llm_agents_from_scratch/errors/subagents.py
@@ -10,6 +10,6 @@ class SubAgentsError(LLMAgentsFromScratchError):
 
 
 class SubAgentNotFoundError(SubAgentsError):
-    """Raised when a named sub-agent is not in the registry."""
+    """Raised when a named subagent is not in the registry."""
 
     pass

--- a/src/llm_agents_from_scratch/logger.py
+++ b/src/llm_agents_from_scratch/logger.py
@@ -14,8 +14,8 @@ ROOT_LOGGER_NAME = "llm_agents_fs"
 DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_MSG_MAX_LENGTH = 150
 
-# Set by UseSubAgentTool around a dispatched sub-agent's run() so every log
-# line emitted from within that run — coordinator and sub-agent share the
+# Set by UseSubAgentTool around a dispatched subagent's run() so every log
+# line emitted from within that run — coordinator and subagent share the
 # same logger names — can be tagged with which agent it came from.
 current_subagent_name: ContextVar[str | None] = ContextVar(
     "current_subagent_name",

--- a/src/llm_agents_from_scratch/subagents/spec.py
+++ b/src/llm_agents_from_scratch/subagents/spec.py
@@ -1,4 +1,4 @@
-"""SubAgentSpec — specification for a named sub-agent."""
+"""SubAgentSpec — specification for a named subagent."""
 
 from llm_agents_from_scratch.agent import LLMAgentBuilder
 from llm_agents_from_scratch.data_structures.skill import SkillScope
@@ -7,9 +7,9 @@ from .constants import CATALOG_SPEC_TEMPLATE
 
 
 class SubAgentSpec:
-    """Specification for a named sub-agent in a multi-agent system.
+    """Specification for a named subagent in a multi-agent system.
 
-    Each ``SubAgentSpec`` entry registers a build recipe for a sub-agent
+    Each ``SubAgentSpec`` entry registers a build recipe for a subagent
     under a human-readable name. The name serves as the registry key on
     the parent coordinator and as the enum value the coordinator's
     ``UseSubAgentTool`` presents to the LLM for dispatch.
@@ -32,22 +32,22 @@ class SubAgentSpec:
     non-pydantic type.
 
     Attributes:
-        name: Unique registry key for this sub-agent. Appears as an enum
+        name: Unique registry key for this subagent. Appears as an enum
             value in ``UseSubAgentTool``'s dispatch schema — must be
             human-readable and stable.
         description: Short routing signal shown to the coordinator LLM in
             the ``<available_subagents>`` catalog. Should describe capability,
             not implementation.
-        builder: The recipe used to build this sub-agent fresh on every
+        builder: The recipe used to build this subagent fresh on every
             dispatch.
-        max_steps: Optional cap on the number of steps the sub-agent may
+        max_steps: Optional cap on the number of steps the subagent may
             take per dispatch. Passed to ``agent.run()`` to bound runaway
             executions. ``None`` uses the agent's own default.
         skills_scopes: Optional scopes to scan for skills on this
-            sub-agent's dispatches. Passed to ``agent.run()``. ``None``
+            subagent's dispatches. Passed to ``agent.run()``. ``None``
             uses the agent's own default (``[USER, PROJECT]``).
         explicit_only_skills: Optional skill names to exclude from this
-            sub-agent's model catalog on dispatch. Passed to
+            subagent's model catalog on dispatch. Passed to
             ``agent.run()``. ``None`` uses the agent's own default (no
             exclusions).
     """
@@ -61,21 +61,21 @@ class SubAgentSpec:
         skills_scopes: list[SkillScope] | None = None,
         explicit_only_skills: set[str] | None = None,
     ) -> None:
-        """Initialise a SubAgentSpec.
+        """Initialize a SubAgentSpec.
 
         Args:
-            name: Unique registry key for this sub-agent.
+            name: Unique registry key for this subagent.
             description: Routing signal shown to the coordinator LLM in
                 the ``<available_subagents>`` catalog.
-            builder: The recipe used to build this sub-agent per
+            builder: The recipe used to build this subagent per
                 dispatch.
-            max_steps: Optional cap on sub-agent steps per dispatch.
+            max_steps: Optional cap on subagent steps per dispatch.
                 Defaults to ``None`` (agent's own default).
             skills_scopes: Optional scopes to scan for skills on this
-                sub-agent's dispatches. Defaults to ``None`` (agent's
+                subagent's dispatches. Defaults to ``None`` (agent's
                 own default).
             explicit_only_skills: Optional skill names to exclude from
-                this sub-agent's model catalog on dispatch. Defaults to
+                this subagent's model catalog on dispatch. Defaults to
                 ``None`` (agent's own default).
         """
         self.name = name
@@ -98,7 +98,7 @@ class SubAgentSpec:
         )
 
     def catalog(self) -> str:
-        """Return XML entry for this spec in the sub-agents catalog."""
+        """Return XML entry for this spec in the subagents catalog."""
         return CATALOG_SPEC_TEMPLATE.format(
             name=self.name,
             description=self.description,

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -37,7 +37,7 @@ class UseSubAgentTool(AsyncBaseTool):
         """Initialise with a registry of subagents.
 
         Args:
-            subagents_registry (dict[str, SubAgentSpec]): subagents to
+            subagents_registry (dict[str, SubAgentSpec]): Subagents to
                 register, keyed by name.
         """
         self._subagents_registry = subagents_registry
@@ -151,7 +151,7 @@ class UseSubAgentTool(AsyncBaseTool):
         try:
             if spec is None:
                 raise SubAgentNotFoundError(
-                    f"subagent '{subagent_name}' not found.",
+                    f"Subagent '{subagent_name}' not found.",
                 )
             agent = await spec.builder.build()
             result = await agent.run(

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -1,4 +1,4 @@
-"""UseSubAgentTool — dispatches a task to a named sub-agent."""
+"""UseSubAgentTool — dispatches a task to a named subagent."""
 
 import json
 from typing import Any
@@ -16,43 +16,43 @@ from .spec import SubAgentSpec
 
 
 class UseSubAgentTool(AsyncBaseTool):
-    """Async tool that dispatches a task to a registered sub-agent.
+    """Async tool that dispatches a task to a registered subagent.
 
-    Each sub-agent registered with the parent coordinator is callable via this
-    single tool. The LLM selects a sub-agent by name (constrained to an enum
+    Each subagent registered with the parent coordinator is callable via this
+    single tool. The LLM selects a subagent by name (constrained to an enum
     of registered names) and provides a free-text task instruction. The tool
-    runs the sub-agent to completion and returns only ``result.content``,
+    runs the subagent to completion and returns only ``result.content``,
     keeping trajectories isolated.
 
-    All sub-agent exceptions — including ``MaxStepsReachedError`` — are caught
+    All subagent exceptions — including ``MaxStepsReachedError`` — are caught
     and returned as ``ToolCallResult(error=True)`` so the coordinator can
     re-plan rather than crash.
 
     Attributes:
-        subagents_registry (dict[str, SubAgentSpec]): Registered sub-agents,
+        subagents_registry (dict[str, SubAgentSpec]): Registered subagents,
             keyed by name.
     """
 
     def __init__(self, subagents_registry: dict[str, SubAgentSpec]) -> None:
-        """Initialise with a registry of sub-agents.
+        """Initialise with a registry of subagents.
 
         Args:
-            subagents_registry (dict[str, SubAgentSpec]): Sub-agents to
+            subagents_registry (dict[str, SubAgentSpec]): subagents to
                 register, keyed by name.
         """
         self._subagents_registry = subagents_registry
 
     @property
     def name(self) -> str:
-        """Name of the sub-agent dispatch tool."""
+        """Name of the subagent dispatch tool."""
         return "from_scratch__use_subagent"
 
     @property
     def description(self) -> str:
-        """Description of the sub-agent dispatch tool."""
+        """Description of the subagent dispatch tool."""
         return (
-            "Dispatch a task to a named sub-agent and return its result. "
-            "Only call this tool with a sub-agent name from the "
+            "Dispatch a task to a named subagent and return its result. "
+            "Only call this tool with a subagent name from the "
             "<available_subagents> catalog."
         )
 
@@ -60,7 +60,7 @@ class UseSubAgentTool(AsyncBaseTool):
     def parameters_json_schema(self) -> dict[str, Any]:
         """JSON schema for tool parameters.
 
-        The ``name`` field is constrained to an enum of registered sub-agent
+        The ``name`` field is constrained to an enum of registered subagent
         names so the LLM can only dispatch to agents that exist.
         """
         return {
@@ -70,12 +70,12 @@ class UseSubAgentTool(AsyncBaseTool):
                     "type": "string",
                     "enum": sorted(self._subagents_registry),
                     "description": (
-                        "Name of the sub-agent to dispatch the task to."
+                        "Name of the subagent to dispatch the task to."
                     ),
                 },
                 "task": {
                     "type": "string",
-                    "description": "The task instruction for the sub-agent.",
+                    "description": "The task instruction for the subagent.",
                 },
             },
             "required": ["name", "task"],
@@ -87,7 +87,7 @@ class UseSubAgentTool(AsyncBaseTool):
         *args: Any,
         **kwargs: Any,
     ) -> ToolCallResult:
-        """Dispatch a task to the named sub-agent and return its result.
+        """Dispatch a task to the named subagent and return its result.
 
         Builds a fresh ``LLMAgent`` from ``spec.builder`` on every call —
         the spec holds a recipe, not a live agent. Whatever the builder
@@ -118,8 +118,8 @@ class UseSubAgentTool(AsyncBaseTool):
             **kwargs (Any): Additional keyword arguments.
 
         Returns:
-            ToolCallResult: The sub-agent's ``result.content`` on success, or
-                an error result if the sub-agent raises for any reason.
+            ToolCallResult: The subagent's ``result.content`` on success, or
+                an error result if the subagent raises for any reason.
         """
         subagent_name = tool_call.arguments.get("name")
         task_instruction = tool_call.arguments.get("task")
@@ -151,7 +151,7 @@ class UseSubAgentTool(AsyncBaseTool):
         try:
             if spec is None:
                 raise SubAgentNotFoundError(
-                    f"Sub-agent '{subagent_name}' not found.",
+                    f"subagent '{subagent_name}' not found.",
                 )
             agent = await spec.builder.build()
             result = await agent.run(

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -23,7 +23,7 @@ def _prompt_human(
         choices (list[str] | None): Optional list of valid responses.
             When provided, the human is re-prompted until they enter
             one of the listed values.
-        agent_name (str | None): Name of the coordinator or sub-agent
+        agent_name (str | None): Name of the coordinator or subagent
             rendered in the panel title. Defaults to None.
 
     Returns:
@@ -148,8 +148,8 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
 
     The optional ``agent_name`` label is rendered in the panel title so
     the operator knows which agent is asking — the coordinator or one
-    of its sub-agents. Typically set to ``SubAgentSpec.name`` for a
-    sub-agent, or left ``None`` for the coordinator.
+    of its subagents. Typically set to ``SubAgentSpec.name`` for a
+    subagent, or left ``None`` for the coordinator.
 
     The class-level ``_console_lock`` is shared by all instances, so
     concurrent agents take turns at a single stdin rather than racing.
@@ -190,7 +190,7 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
 
         Args:
             agent_name (str | None): Name of the coordinator or
-                sub-agent rendered in the panel title. Defaults to
+                subagent rendered in the panel title. Defaults to
                 None.
         """
         self.agent_name = agent_name


### PR DESCRIPTION
## Summary
- Spelling normalization: `sub-agent(s)` → `subagent(s)` across docstrings, comments, and LLM-facing prompt/tool-description text in `src/`.
- Fixed a capitalization slip the rename introduced: a few sentence-start instances (docstring Args entries, and the raised `SubAgentNotFoundError` message) had lowercased to `subagent` instead of `Subagent`.

## Test plan
- [x] `make lint` passes
- [x] `pytest tests -q` — 533 passed, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)