### PR TITLE
chore: rename scripts/ to _scripts/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ diagrams:	## Generate SVG diagrams (for web)
 	@mkdir -p uml/rendered
 	@find uml -name "*.puml" -not -path "uml/common/*" -exec dirname {} \; | sed 's|^uml|uml/rendered|' | sort -u | xargs mkdir -p
 	@find uml -name "*.puml" -not -path "uml/common/*" -exec sh -c '$(PLANTUML) -tsvg -o "$$(dirname "{}" | sed "s|^uml|$(PWD)/uml/rendered|")" "{}"' \;
-	@uv run python scripts/fix_svg_background.py --rendered_dir uml/rendered
-	@uv run python scripts/add_svg_legend.py --rendered_dir uml/rendered
-	@uv run python scripts/set_svg_print_size.py --rendered_dir uml/rendered
+	@uv run python _scripts/fix_svg_background.py --rendered_dir uml/rendered
+	@uv run python _scripts/add_svg_legend.py --rendered_dir uml/rendered
+	@uv run python _scripts/set_svg_print_size.py --rendered_dir uml/rendered
 	@echo "SVG diagrams generated in uml/rendered/ directory with chapter structure!"
 
 diagrams-png:	## Also render a PNG next to every diagram SVG (needs `playwright install chromium`)
-	@uv run scripts/render_diagram_pngs.py --rendered_dir uml/rendered
+	@uv run _scripts/render_diagram_pngs.py --rendered_dir uml/rendered

--- a/_scripts/add_svg_legend.py
+++ b/_scripts/add_svg_legend.py
@@ -112,7 +112,7 @@ def main(rendered_dir: Path | str, uml_dir: Path | str = "uml") -> None:
             their `*.legend.yaml` sidecar files.
 
     Examples:
-        >>> uv run python scripts/add_svg_legend.py \
+        >>> uv run python _scripts/add_svg_legend.py \
         ...     --rendered_dir uml/rendered
     """
     rendered_dir = Path(rendered_dir)

--- a/_scripts/capture_inspector_screenshots.py
+++ b/_scripts/capture_inspector_screenshots.py
@@ -18,12 +18,12 @@ suite (`frontend/e2e/helpers.ts`), which proved this UI has no
 to this repo's `pyproject.toml` -- it's a one-off capture-tooling need,
 not a real project dependency. First run:
 
-    uv run scripts/capture_inspector_screenshots.py --help
+    uv run _scripts/capture_inspector_screenshots.py --help
     playwright install chromium   # once, if not already installed
 
 Then, with `ollama serve` running and `qwen3:14b` pulled:
 
-    uv run scripts/capture_inspector_screenshots.py
+    uv run _scripts/capture_inspector_screenshots.py
 
 This launches `examples/inspector_demo.py` via the Agent Inspector CLI itself
 (installed on demand via `uvx`, kept out of this repo's dependency
@@ -58,7 +58,7 @@ DEFAULT_INSPECTOR_SOURCE = (
     "@fde25ef025a034fd50ddf0d719e6902d6020c10e"
 )
 # Manuscript figures live in each user's own local `figures_path` (see
-# `scripts/prepare_book_figures.py` / `book_figures.yml`), never
+# `_scripts/prepare_book_figures.py` / `book_figures.yml`), never
 # tracked in this repo -- so the default here is a untracked scratch
 # directory, not a docs/assets path. Point --output-dir at your real
 # figures_path/ch08 when capturing for real.
@@ -228,7 +228,7 @@ def run(
     subprocess.run(  # noqa: S603
         [
             sys.executable,
-            str(REPO_ROOT / "scripts" / "wrap_png_as_svg.py"),
+            str(REPO_ROOT / "_scripts" / "wrap_png_as_svg.py"),
             "--png_dir",
             str(output_dir),
         ],

--- a/_scripts/fix_svg_background.py
+++ b/_scripts/fix_svg_background.py
@@ -46,7 +46,7 @@ def main(rendered_dir: Path | str) -> None:
             (recursively).
 
     Examples:
-        >>> uv run python scripts/fix_svg_background.py \
+        >>> uv run python _scripts/fix_svg_background.py \
         ...     --rendered_dir uml/rendered
     """
     rendered_dir = Path(rendered_dir)

--- a/_scripts/prepare_book_figures.py
+++ b/_scripts/prepare_book_figures.py
@@ -38,7 +38,7 @@ def main(
         include_pdf (bool): Whether or not to include .pdf version of images
 
     Examples:
-        >>> uv run python scripts/prepare_book_figures.py --figures_path "./"
+        >>> uv run python _scripts/prepare_book_figures.py --figures_path "./"
     """
     config_path = config_path or DEFAULT_CONFIG_PATH
 

--- a/_scripts/render_diagram_pngs.py
+++ b/_scripts/render_diagram_pngs.py
@@ -4,7 +4,7 @@
 """Render a PNG alongside every rendered UML diagram SVG.
 
 `make diagrams` produces `uml/rendered/**/*.svg` with a fixed physical
-print size baked in (see `scripts/set_svg_print_size.py`). This adds
+print size baked in (see `_scripts/set_svg_print_size.py`). This adds
 a matching PNG next to each one, at a DPI that reproduces that exact
 physical size crisply in print (default 300 DPI).
 
@@ -15,11 +15,11 @@ of actual font metrics), rendering glyphs at their natural width
 instead and overflowing box boundaries -- confirmed with a minimal
 repro, text spilling out of every class-diagram box. Browsers
 implement this correctly, and Chromium is already relied on elsewhere
-in this repo (`scripts/capture_inspector_screenshots.py`) for
+in this repo (`_scripts/capture_inspector_screenshots.py`) for
 faithful SVG/UI rendering, so this reuses the same engine instead of
 a second, less-correct one.
 
-    uv run scripts/render_diagram_pngs.py --rendered_dir uml/rendered
+    uv run _scripts/render_diagram_pngs.py --rendered_dir uml/rendered
     playwright install chromium   # once, if not already installed
 """
 

--- a/_scripts/set_svg_print_size.py
+++ b/_scripts/set_svg_print_size.py
@@ -99,7 +99,7 @@ def main(
         max_height_in (float): Max figure height, in inches.
 
     Examples:
-        >>> uv run python scripts/set_svg_print_size.py \
+        >>> uv run python _scripts/set_svg_print_size.py \
         ...     --rendered_dir uml/rendered
     """
     rendered_dir = Path(rendered_dir)

--- a/_scripts/wrap_png_as_svg.py
+++ b/_scripts/wrap_png_as_svg.py
@@ -4,7 +4,7 @@ A screenshot can't become genuine vector art -- this doesn't attempt
 that. It solves a narrower, real problem: placing a PNG at "actual
 size" in a layout tool (Canva, InDesign) requires the file to already
 carry a physical size, or every placement is a manual, inconsistent
-resize (the same pain point `scripts/set_svg_print_size.py` fixes for
+resize (the same pain point `_scripts/set_svg_print_size.py` fixes for
 PlantUML diagrams). Wrapping the PNG in an SVG with explicit
 `width`/`height` in inches gives it that fixed physical size directly,
 without needing vector content.
@@ -17,7 +17,7 @@ at print resolution (warns if the fitted size would drop below
 
 Deliberately dependency-free (stdlib only, argparse rather than
 `fire`) so it can run via a bare `sys.executable` from any
-environment -- e.g. `scripts/capture_inspector_screenshots.py`'s own
+environment -- e.g. `_scripts/capture_inspector_screenshots.py`'s own
 isolated PEP 723 env, which has `playwright` but not this project's
 own dev dependencies.
 """
@@ -104,7 +104,7 @@ def main(
         max_height_in (float): Max figure height, in inches.
 
     Examples:
-        >>> python scripts/wrap_png_as_svg.py --png_dir screenshots
+        >>> python _scripts/wrap_png_as_svg.py --png_dir screenshots
     """
     wrapped = 0
     for png_path in sorted(png_dir.rglob("*.png")):


### PR DESCRIPTION
## Summary
- Renames the top-level `scripts/` directory to `_scripts/` and updates every reference (Makefile, docstrings, in-code path construction), including `render_diagram_pngs.py` from #842 (rebased onto `main` now that #842 is merged).
- Deliberately doesn't touch anything under `src/llm_agents_from_scratch/skills/` or `tests/skills/` — those reference the unrelated Skills-framework convention (each *skill's own* `scripts/` subdirectory per `OPTIONAL_SUBDIRS`), not this repo's top-level directory.

## Test plan
- [x] `make lint` passes
- [x] `make diagrams` runs end-to-end from the new `_scripts/` location, same output as before (27 SVGs, same print-size report)
- [x] `make diagrams-png` runs end-to-end from the new `_scripts/` location (27 PNGs)