### PR TITLE
docs(diagrams): true-uniform font size for all class diagrams (5.0pt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ diagrams:	## Generate SVG diagrams (for web)
 	@uv run python _scripts/fix_svg_background.py --rendered_dir uml/rendered
 	@uv run python _scripts/add_svg_legend.py --rendered_dir uml/rendered
 	@uv run python _scripts/set_svg_print_size.py --rendered_dir uml/rendered
+	@uv run python _scripts/frame_svg_width.py --rendered_dir uml/rendered
 	@echo "SVG diagrams generated in uml/rendered/ directory with chapter structure!"
 
 diagrams-png:	## Also render a PNG next to every diagram SVG (needs `playwright install chromium`)

--- a/_scripts/frame_svg_width.py
+++ b/_scripts/frame_svg_width.py
@@ -1,0 +1,167 @@
+"""Center every rendered diagram SVG in a fixed-width frame.
+
+`set_svg_print_size.py` gives each diagram its own correct physical
+size, but that size still varies diagram to diagram (a small class
+diagram might land at 2.6in wide, a dense one at 5.5in) -- placed in
+the manuscript, that reads as inconsistent column alignment even
+though the *font size* is now uniform. This widens every diagram's
+canvas to a fixed frame (default 5.5in) and centers the actual
+diagram horizontally within it, so every image is exactly the same
+width on the page. Height is left alone -- only width is normalized.
+
+Diagrams narrower than the frame are padded (whitespace added, content
+re-centered) -- font size is untouched. A diagram wider than the frame
+(shouldn't normally happen if `set_svg_print_size.py`'s own max width
+is <= the frame width, but handled defensively) is scaled down to fit
+exactly, which does shrink its font size slightly.
+
+Padding is done by widening the SVG's `viewBox` and translating the
+existing content group by half the added width -- not by drawing a
+second white rectangle over it, so it composes cleanly with
+`fix_svg_background.py`'s full-canvas background rect (already
+percentage-sized, so it automatically covers the widened canvas too).
+"""
+
+import re
+from pathlib import Path
+
+import fire
+
+DEFAULT_FRAME_WIDTH_IN = 5.5
+
+VIEWBOX = re.compile(r'viewBox="0 0 ([\d.]+) ([\d.]+)"')
+WIDTH_ATTR = re.compile(r'width="([\d.]+)in"')
+HEIGHT_ATTR = re.compile(r'height="([\d.]+)in"')
+STYLE_SIZE = re.compile(r"width:[\d.]+in;height:[\d.]+in;")
+CONTENT_GROUP = re.compile(r"(<\?plantuml[^>]*\?><defs/>)<g>")
+
+
+def _frame_one(
+    svg_path: Path,
+    frame_width_in: float,
+) -> dict[str, float | str] | None:
+    content = svg_path.read_text()
+    viewbox_match = VIEWBOX.search(content)
+    width_match = WIDTH_ATTR.search(content)
+    height_match = HEIGHT_ATTR.search(content)
+    if not (viewbox_match and width_match and height_match):
+        return None
+
+    view_w, view_h = (
+        float(viewbox_match.group(1)),
+        float(viewbox_match.group(2)),
+    )
+    width_in = float(width_match.group(1))
+    height_in = float(height_match.group(1))
+
+    if width_in > frame_width_in:
+        # Defensive: shouldn't happen if set_svg_print_size.py's own
+        # max width is already <= frame_width_in, but shrink to fit
+        # rather than silently overflow the frame.
+        scale = frame_width_in / width_in
+        new_width_in = frame_width_in
+        new_height_in = height_in * scale
+        content = WIDTH_ATTR.sub(
+            f'width="{new_width_in:.4f}in"',
+            content,
+            count=1,
+        )
+        content = HEIGHT_ATTR.sub(
+            f'height="{new_height_in:.4f}in"',
+            content,
+            count=1,
+        )
+        content = STYLE_SIZE.sub(
+            f"width:{new_width_in:.4f}in;height:{new_height_in:.4f}in;",
+            content,
+            count=1,
+        )
+        svg_path.write_text(content)
+        return {
+            "name": svg_path.name,
+            "width_in": new_width_in,
+            "height_in": new_height_in,
+            "padded_in": 0.0,
+            "shrunk": True,
+        }
+
+    pad_in = frame_width_in - width_in
+    new_view_w = view_w * (frame_width_in / width_in)
+    dx = (new_view_w - view_w) / 2
+
+    content = VIEWBOX.sub(
+        f'viewBox="0 0 {new_view_w:.4f} {view_h:.4f}"',
+        content,
+        count=1,
+    )
+    content, n = CONTENT_GROUP.subn(
+        rf'\1<g transform="translate({dx:.4f},0)">',
+        content,
+        count=1,
+    )
+    if not n:
+        return None
+    content = WIDTH_ATTR.sub(
+        f'width="{frame_width_in:.4f}in"',
+        content,
+        count=1,
+    )
+    content = STYLE_SIZE.sub(
+        f"width:{frame_width_in:.4f}in;height:{height_in:.4f}in;",
+        content,
+        count=1,
+    )
+    svg_path.write_text(content)
+
+    return {
+        "name": svg_path.name,
+        "width_in": frame_width_in,
+        "height_in": height_in,
+        "padded_in": pad_in,
+        "shrunk": False,
+    }
+
+
+def main(
+    rendered_dir: Path | str,
+    frame_width_in: float = DEFAULT_FRAME_WIDTH_IN,
+) -> None:
+    """Center every SVG under rendered_dir in a fixed-width frame.
+
+    Args:
+        rendered_dir (Path | str): Directory containing rendered SVGs
+            (must already have physical width/height set, e.g. by
+            set_svg_print_size.py).
+        frame_width_in (float): Fixed frame width every diagram gets
+            centered in, in inches.
+
+    Examples:
+        >>> uv run python _scripts/frame_svg_width.py \
+        ...     --rendered_dir uml/rendered
+    """
+    rendered_dir = Path(rendered_dir)
+    results = []
+    for svg_path in sorted(rendered_dir.rglob("*.svg")):
+        result = _frame_one(svg_path, frame_width_in)
+        if result:
+            results.append(result)
+
+    shrunk = [r for r in results if r["shrunk"]]
+    print(
+        f"Framed {len(results)} SVG file(s) to a "
+        f"{frame_width_in}in wide frame.",
+    )
+    if shrunk:
+        print(
+            f"{len(shrunk)} diagram(s) were wider than the frame and had to "
+            "be shrunk to fit (check max_width_in in set_svg_print_size.py):",
+        )
+        for r in shrunk:
+            print(
+                f"  {r['name']}: {r['width_in']:.2f}in x "
+                f"{r['height_in']:.2f}in",
+            )
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/_scripts/render_diagram_pngs.py
+++ b/_scripts/render_diagram_pngs.py
@@ -19,17 +19,58 @@ in this repo (`_scripts/capture_inspector_screenshots.py`) for
 faithful SVG/UI rendering, so this reuses the same engine instead of
 a second, less-correct one.
 
+Also injects a PNG `pHYs` chunk declaring the render DPI. Playwright's
+screenshot doesn't write one, so the file's *pixel count* is the only
+size information a PNG-consuming tool (Word, etc.) has -- diagrams
+with different pixel counts (different natural size/complexity) then
+get auto-fit to a page differently, defeating the whole point of
+set_svg_print_size.py's uniform physical sizing: a diagram rendered at
+fewer total pixels looks *larger* once placed, not smaller, because
+it needs less shrinking to fit the same page width. Confirmed via a
+minimal repro (no `pHYs` chunk in the raw Playwright output). The
+`pHYs` chunk lets DPI-aware tools place the image at its true physical
+size instead of guessing from pixel count.
+
     uv run _scripts/render_diagram_pngs.py --rendered_dir uml/rendered
     playwright install chromium   # once, if not already installed
 """
 
 import argparse
+import struct
+import zlib
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
 DEFAULT_DPI = 300
 CSS_PX_PER_INCH = 96  # browsers treat "in" units as fixed 96 CSS px/in
+METERS_PER_INCH = 0.0254
+PNG_SIGNATURE_LEN = 8
+IHDR_CHUNK_LEN = 25  # 4 (length) + 4 (type) + 13 (data) + 4 (CRC)
+
+
+def _phys_chunk(dpi: float) -> bytes:
+    pixels_per_meter = round(dpi / METERS_PER_INCH)
+    # unit=1 -> pixels-per-meter (the only PNG spec option for a real
+    # physical unit; 0 means "unspecified aspect ratio only").
+    data = struct.pack(">IIB", pixels_per_meter, pixels_per_meter, 1)
+    chunk_type = b"pHYs"
+    crc = zlib.crc32(chunk_type + data)
+    return (
+        struct.pack(">I", len(data))
+        + chunk_type
+        + data
+        + struct.pack(">I", crc)
+    )
+
+
+def _add_dpi_metadata(png_path: Path, dpi: float) -> None:
+    png_bytes = png_path.read_bytes()
+    # pHYs must appear before the first IDAT chunk; right after IHDR
+    # (always the first chunk) is the conventional, always-valid spot.
+    insert_at = PNG_SIGNATURE_LEN + IHDR_CHUNK_LEN
+    fixed = png_bytes[:insert_at] + _phys_chunk(dpi) + png_bytes[insert_at:]
+    png_path.write_bytes(fixed)
 
 
 def main(rendered_dir: Path, dpi: int) -> None:
@@ -64,6 +105,7 @@ def main(rendered_dir: Path, dpi: int) -> None:
             png_path = svg_path.with_suffix(".png")
             page.locator("svg").screenshot(path=str(png_path))
             page.close()
+            _add_dpi_metadata(png_path, dpi)
             print(f"  wrote {png_path}")
             rendered += 1
         browser.close()

--- a/_scripts/set_svg_print_size.py
+++ b/_scripts/set_svg_print_size.py
@@ -45,7 +45,10 @@ THEME_BODY_FONT_PT = 14
 
 DEFAULT_TARGET_PT = 9.0
 CLASS_TARGET_PT = 5.0
-DEFAULT_MAX_WIDTH_IN = 5.6
+# 5.5in, not the book's full 5.6in figure-box width -- matches
+# frame_svg_width.py's default frame, so no diagram needs a second,
+# separate shrink pass once it's centered in that fixed-width frame.
+DEFAULT_MAX_WIDTH_IN = 5.5
 DEFAULT_MAX_HEIGHT_IN = 7.0
 
 VIEWBOX = re.compile(r'viewBox="0 0 ([\d.]+) ([\d.]+)"')

--- a/_scripts/set_svg_print_size.py
+++ b/_scripts/set_svg_print_size.py
@@ -15,6 +15,23 @@ size" (100%, no further resizing) renders body text at a fixed target
 point size everywhere -- unless the diagram is too large to hit that
 target within the book's max figure box (default 5.6in x 7in), in
 which case it is scaled down just enough to fit, and reported as such.
+
+Class diagrams get a lower, uniform target than everything else
+(CLASS_TARGET_PT, default 5.0pt vs DEFAULT_TARGET_PT's 9pt): they vary
+far more in natural size (a two-class diagram next to a ten-method
+one) than sequence diagrams do, so holding them to the shared 9pt
+target left most of them capped anyway (17 of 22 at last count) while
+a handful of simple ones rendered noticeably larger side by side in
+the manuscript -- inconsistent either way. A floor picked as a
+compromise (e.g. 7pt) still leaves a straggling tail of outliers below
+it, which doesn't actually deliver a consistent reader experience,
+just a smaller inconsistency. 5.0pt is calibrated to the single
+worst-case class diagram's own natural ceiling (~4.92pt, a diagram
+nearly 2x the width budget) -- rounded up slightly so effectively
+every class diagram (21 of 22, the last one only ~0.1pt short) renders
+at the exact same size, true uniformity within the existing 5.6in x
+7in box, no diagram redesign required. Revisit upward once the
+worst-offending diagrams are split/simplified (tracked separately).
 """
 
 import re
@@ -27,6 +44,7 @@ THEME_DPI = 500
 THEME_BODY_FONT_PT = 14
 
 DEFAULT_TARGET_PT = 9.0
+CLASS_TARGET_PT = 5.0
 DEFAULT_MAX_WIDTH_IN = 5.6
 DEFAULT_MAX_HEIGHT_IN = 7.0
 
@@ -34,6 +52,7 @@ VIEWBOX = re.compile(r'viewBox="0 0 ([\d.]+) ([\d.]+)"')
 WIDTH_ATTR = re.compile(r'width="[\d.]+px"')
 HEIGHT_ATTR = re.compile(r'height="[\d.]+px"')
 STYLE_SIZE = re.compile(r"width:[\d.]+px;height:[\d.]+px;")
+DIAGRAM_TYPE = re.compile(r'data-diagram-type="([A-Z]+)"')
 
 
 def _inches_per_user_unit(target_pt: float) -> float:
@@ -43,7 +62,8 @@ def _inches_per_user_unit(target_pt: float) -> float:
 
 def _resize_one(
     svg_path: Path,
-    target_pt: float,
+    default_target_pt: float,
+    class_target_pt: float,
     max_width_in: float,
     max_height_in: float,
 ) -> dict[str, float | str] | None:
@@ -52,6 +72,12 @@ def _resize_one(
     if not match:
         return None
     view_w, view_h = float(match.group(1)), float(match.group(2))
+
+    type_match = DIAGRAM_TYPE.search(content)
+    diagram_type = type_match.group(1) if type_match else None
+    target_pt = (
+        class_target_pt if diagram_type == "CLASS" else default_target_pt
+    )
 
     in_per_unit = _inches_per_user_unit(target_pt)
     natural_w_in = view_w * in_per_unit
@@ -77,6 +103,8 @@ def _resize_one(
 
     return {
         "name": svg_path.name,
+        "diagram_type": diagram_type or "?",
+        "target_pt": target_pt,
         "width_in": final_w_in,
         "height_in": final_h_in,
         "effective_pt": effective_pt,
@@ -87,6 +115,7 @@ def _resize_one(
 def main(
     rendered_dir: Path | str,
     target_pt: float = DEFAULT_TARGET_PT,
+    class_target_pt: float = CLASS_TARGET_PT,
     max_width_in: float = DEFAULT_MAX_WIDTH_IN,
     max_height_in: float = DEFAULT_MAX_HEIGHT_IN,
 ) -> None:
@@ -94,7 +123,11 @@ def main(
 
     Args:
         rendered_dir (Path | str): Directory containing rendered SVGs.
-        target_pt (float): Target body-text point size at print size.
+        target_pt (float): Target body-text point size for non-class
+            diagrams (sequence, mindmap, etc.) at print size.
+        class_target_pt (float): Target body-text point size for class
+            diagrams specifically -- lower and uniform, see module
+            docstring for why class diagrams get their own target.
         max_width_in (float): Max figure width, in inches.
         max_height_in (float): Max figure height, in inches.
 
@@ -105,13 +138,20 @@ def main(
     rendered_dir = Path(rendered_dir)
     results = []
     for svg_path in sorted(rendered_dir.rglob("*.svg")):
-        result = _resize_one(svg_path, target_pt, max_width_in, max_height_in)
+        result = _resize_one(
+            svg_path,
+            target_pt,
+            class_target_pt,
+            max_width_in,
+            max_height_in,
+        )
         if result:
             results.append(result)
 
     capped = [r for r in results if r["capped"]]
     print(
-        f"Set print size on {len(results)} SVG file(s) (target {target_pt}pt).",
+        f"Set print size on {len(results)} SVG file(s) "
+        f"(target {target_pt}pt, class diagrams {class_target_pt}pt).",
     )
     if capped:
         print(


### PR DESCRIPTION
## Summary
- `set_svg_print_size.py` now detects diagram type (`data-diagram-type` in the rendered SVG) and applies a separate, lower `CLASS_TARGET_PT` (5.0) to class diagrams specifically, instead of sharing the 9pt target used for sequence/mindmap diagrams.
- Calibrated to the single worst-case class diagram's own natural ceiling (`llm_agent_uml_class_pt2.svg`, ~4.92pt at a 5.6in width cap, nearly 2x over budget), rounded up slightly to 5.0.
- Result: capped-diagram count drops from 19/27 to 3/27 overall; among the 22 class diagrams specifically, 21 now render at the exact same size, the last one only ~0.1pt short.
- **Follow-up fix 1**: `render_diagram_pngs.py` now embeds a PNG `pHYs` chunk (DPI metadata) on every rendered PNG. Playwright's screenshot doesn't write one, so a PNG-consuming tool (Word, etc.) only has raw pixel count to place the image by — diagrams with different pixel counts got auto-fit to a page differently, silently undoing the uniform sizing above once inserted into the manuscript.
- **Follow-up fix 2**: new `frame_svg_width.py` centers every diagram SVG in a fixed 5.5in-wide frame (padding narrower diagrams, font size untouched). Font-size uniformity alone still left different diagrams at different physical widths (2.6in next to 5.5in), which reads as inconsistent column alignment in the manuscript regardless of DPI metadata support. `set_svg_print_size.py`'s max width is now 5.5in too (was 5.6), matching the frame exactly — 0 of 27 diagrams need the defensive shrink-to-fit path. Every diagram's PNG now renders at identical pixel width (1650px @ 300 DPI).

## Why not a higher "compromise" floor (e.g. 7pt) for class diagrams?
Checked the actual distribution first: at 7pt, 8 of 22 class diagrams would still be outliers (ranging 4.9–6.7pt) — that's not real uniformity, just a smaller inconsistency. True uniformity at a legible size would require redesigning ~6 of the worst-offending diagrams, which is real content work, not a sizing-script change. This ships a script-only fix now (true uniform at 5.0pt, no diagram redesign needed) and leaves raising the target as a follow-up once the worst diagrams are split/simplified.

## Test plan
- [x] `make diagrams && make diagrams-png` runs end-to-end
- [x] Verified mathematically: identical `font-size` in SVG user units + identical `target_pt` for any uncapped diagram guarantees identical effective pt, regardless of the diagram's own natural size
- [x] Verified visually: matched-scale pixel crop comparison of two very differently-sized class diagrams — class-name header text renders at identical size in both
- [x] `pHYs` chunk verified structurally (correct 300 DPI) and via Pillow (`img.info["dpi"] == (300, 300)`)
- [x] Frame centering verified via pixel analysis (content bounding box vs. canvas width, ~0.8% asymmetry — negligible, from the diagram's own arrow/label layout, not a centering bug)
- [x] All 27 diagrams confirmed at identical 1650px PNG width (5.5in @ 300 DPI)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)