### PR TITLE
test: skip optional-extra tests when the extra is not installed

### DIFF
--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -328,6 +328,7 @@ async def test_continue_chat_with_tool_results(
     mock_async_client_class.assert_called_once()
 
 
+@pytest.mark.skipif(not openai_installed, reason="openai is not installed")
 def test_chat_message_to_openai_response_input_param_raises_error() -> None:
     """Tests chat_message_to_openai_response_input_param raises error.
 

--- a/tests/notebook_utils/test_pandas.py
+++ b/tests/notebook_utils/test_pandas.py
@@ -1,8 +1,21 @@
 """Unit tests for pandas notebook utils."""
 
+from importlib.util import find_spec
 from unittest.mock import MagicMock, patch
 
+import pytest
 
+# the packages `set_dataframe_display_options` requires, as declared by its
+# own `check_extra_was_installed` call
+notebook_utils_installed = all(
+    find_spec(package) for package in ("pandas", "IPython")
+)
+
+
+@pytest.mark.skipif(
+    not notebook_utils_installed,
+    reason="notebook-utils extra is not installed",
+)
 @patch(
     "llm_agents_from_scratch.notebook_utils.pandas.check_extra_was_installed",
 )


### PR DESCRIPTION
## Problem

A fresh checkout installed without the optional extras — i.e. `uv sync --dev` rather than the `uv sync --all-extras --dev` in CONTRIBUTING.md — fails two tests immediately, for reasons unrelated to the code under test:

```
FAILED tests/llms/test_openai.py::test_chat_message_to_openai_response_input_param_raises_error
FAILED tests/notebook_utils/test_pandas.py::test_set_dataframe_display_options
2 failed, 526 passed, 6 skipped
```

Both are `ModuleNotFoundError` for a package that lives behind an optional extra:

- **`test_chat_message_to_openai_response_input_param_raises_error`** is the only test function in `test_openai.py` missing the `@pytest.mark.skipif(not openai_installed, ...)` guard that its six siblings carry. Without the `openai` extra, the `from openai.types.responses...` import *inside* the helper raises `ModuleNotFoundError` before the `DataConversionError` the test asserts on.
- **`test_set_dataframe_display_options`** patches `pandas.set_option`. `mock.patch` resolves its target when the patcher starts, not at decoration time, so the test collects fine and then dies at run time without the `notebook-utils` extra.

## Fix

Guard both with the `find_spec` convention already established in `test_openai.py`. No production code changes.

For the pandas test the guard covers `pandas` **and** `IPython` — the same package list `set_dataframe_display_options` passes to its own `check_extra_was_installed` call — so the test skips correctly regardless of which half is absent. (`IPython` happens to arrive transitively via the `ipykernel` dev dependency today, but that's incidental and shouldn't be relied on.)

## Why skip rather than restructure

CI runs `uv sync --all-extras --dev`, so both tests still execute and assert there — `skipif` is a no-op in CI and coverage is unchanged. Skipping only affects local checkouts that deliberately opted out of the extras. That keeps the promise in both directions: a fresh clone is green out of the box, and nobody has to install `openai` or `pandas` to contribute.

## Verification

Without the extras (the failing case):

```
526 passed, 8 skipped        # was: 2 failed, 526 passed, 6 skipped
```

With the extras present, via an ephemeral overlay (`uv run --with openai --with pandas`), confirming the guards don't mask real coverage:

```
tests/llms/test_openai.py tests/notebook_utils/test_pandas.py  ->  9 passed
```

`ruff check` and `ruff format --check` are clean on both files. (`mypy` runs only against `src/` per `.pre-commit-config.yaml`, so it is unaffected.)

## Unrelated observation, not addressed here

`OpenAILLM.__init__` guards itself with `check_extra_was_installed(extra="openai", packages="openai")`, but the module-level helpers in `llms/openai/utils.py` do not. Calling `chat_message_to_openai_response_input_param` without the extra therefore surfaces a raw `ModuleNotFoundError` instead of the library's `MissingExtraError`. Left alone to keep this PR to the test fix — happy to open a follow-up if that's worth aligning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)