### PR TITLE
fix(agent): settle the task handler even when recording memory fails

### DIFF
--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -899,7 +899,7 @@ class LLMAgent:
                     f"complete() requires a TaskResult, "
                     f"got {type(result).__name__}.",
                 )
-            await self.record_memory(result=result)
+            await self.try_record_memory(result=result)
             self.set_result(result)
 
         def reject(
@@ -934,7 +934,7 @@ class LLMAgent:
                     ``TaskHandlerError("Task aborted.")``.
             """
             err = error or TaskHandlerError("Task aborted.")
-            await self.record_memory(error=err)
+            await self.try_record_memory(error=err)
             self.set_exception(err)
 
     def run(

--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -794,6 +794,29 @@ class LLMAgent:
             for memory in self.llm_agent.memories:
                 await memory.record(episode)
 
+        async def try_record_memory(
+            self,
+            result: TaskResult | None = None,
+            error: Exception | None = None,
+        ) -> None:
+            """Record an episode, logging (not raising) on failure.
+
+            Added in Chapter 7.
+
+            Used on the paths that settle the handler afterwards: a failing
+            memory backend must not prevent ``set_result()`` /
+            ``set_exception()`` from running, which would leave the handler
+            — and any ``await`` on it — pending forever.
+
+            Args:
+                result (TaskResult | None): The successful task result.
+                error (Exception | None): The exception from a failed task.
+            """
+            try:
+                await self.record_memory(result=result, error=error)
+            except Exception:
+                self.logger.exception("Failed to record episode to memory.")
+
         async def request_approval(
             self,
             result: TaskResult,
@@ -996,16 +1019,18 @@ class LLMAgent:
                                         "re-entering loop with feedback.",
                                     )
                                     continue
-                            await task_handler.record_memory(
+                            # added in ch07
+                            await task_handler.try_record_memory(
                                 result=next_step,
-                            )  # added in ch07
+                            )
                             task_handler.set_result(next_step)
                             self.logger.info(
                                 f"🏁 Task completed: {next_step.content}",
                             )
 
                 except Exception as e:
-                    await task_handler.record_memory(error=e)  # added in ch07
+                    # added in ch07
+                    await task_handler.try_record_memory(error=e)
                     task_handler.set_exception(e)
 
         task_handler.background_task = asyncio.create_task(_process_loop())

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -325,6 +325,49 @@ async def test_run_records_episode_for_each_memory(
 
 
 @pytest.mark.asyncio
+@patch.object(LLMAgent.TaskHandler, "get_next_step")
+async def test_run_settles_handler_when_recording_success_fails(
+    mock_get_next_step: AsyncMock,
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests a failing memory.record still lets the result be set."""
+    task = Task(instruction="mock instruction")
+    task_result = TaskResult(task_id=task.id_, content="mock result")
+    mock_get_next_step.side_effect = [task_result]
+
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.return_value = ""
+    mock_memory.record.side_effect = RuntimeError("memory down")
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+
+    handler = agent.run(task)
+    result = await asyncio.wait_for(handler, timeout=1)
+
+    assert result == task_result
+
+
+@pytest.mark.asyncio
+@patch.object(LLMAgent.TaskHandler, "get_next_step")
+async def test_run_settles_handler_when_recording_failure_fails(
+    mock_get_next_step: AsyncMock,
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests a failing memory.record still lets the exception be set."""
+    err = RuntimeError("boom")
+    mock_get_next_step.side_effect = err
+
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.return_value = ""
+    mock_memory.record.side_effect = RuntimeError("memory down")
+    task = Task(instruction="mock instruction")
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+
+    handler = agent.run(task)
+    with pytest.raises(RuntimeError, match="boom"):
+        await asyncio.wait_for(handler, timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_record_memory_raises_when_called_with_no_args(
     mock_llm: BaseLLM,
 ) -> None:


### PR DESCRIPTION
In `_process_loop`, `record_memory()` is awaited unguarded *before*
`set_result()` / `set_exception()`. If a memory backend raises, the
exception escapes the loop, the handler is never settled, and
`await agent.run(task)` hangs forever — the real error only visible via
`handler.background_task.exception()`.

This is reachable with the shipped `reflective_memory` recipe: on a failed
task, `_reflect` evaluates `episode.result.content` on `None` and raises.

Both settle paths now go through `TaskHandler.try_record_memory()`, which
logs backend failures instead of propagating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)