### PR TITLE
fix(memory): serialize Episode.error so failed episodes can persist

### DIFF
--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -51,12 +51,17 @@ class Episode(BaseModel):
     metadata: dict[str, str] = Field(default_factory=dict)
     completed_at: datetime = Field(default_factory=datetime.now)
 
-    @field_serializer("error")
-    def _serialize_error(self, error: Exception | str | None) -> str | None:
+    @staticmethod
+    def _error_as_text(error: Exception | str | None) -> str | None:
         """Render ``error`` as text; Pydantic cannot serialize Exceptions."""
         if error is None or isinstance(error, str):
             return error
         return f"{type(error).__name__}: {error}"
+
+    @field_serializer("error")
+    def _serialize_error(self, error: Exception | str | None) -> str | None:
+        """Serialize ``error`` with the same text used by ``format()``."""
+        return self._error_as_text(error)
 
     def format(
         self,
@@ -93,6 +98,8 @@ class Episode(BaseModel):
                 elif f == "completed_at":
                     ts = val.strftime("%Y-%m-%d %H:%M:%S")
                     parts.append(f"completed_at: {ts}")
+                elif f == "error":
+                    parts.append(f"error: {self._error_as_text(val)}")
                 else:
                     parts.append(f"{f}: {val}")
         return "\n".join(parts)
@@ -109,6 +116,9 @@ class Episode(BaseModel):
                 elif f == "completed_at":
                     ts = val.strftime("%Y-%m-%d %H:%M:%S")
                     lines.append(f"    <completed_at>{ts}</completed_at>")
+                elif f == "error":
+                    text = self._error_as_text(val)
+                    lines.append(f"    <error>{text}</error>")
                 else:
                     lines.append(f"    <{f}>{val}</{f}>")
         lines.append("  </episode>")

--- a/src/llm_agents_from_scratch/data_structures/memory.py
+++ b/src/llm_agents_from_scratch/data_structures/memory.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 from .agent import Task, TaskResult
 
@@ -32,8 +32,9 @@ class Episode(BaseModel):
         rollout (str): The full agent trajectory for the task.
         result (TaskResult | None): The final result of the task, or
             ``None`` if the task ended with an error.
-        error (Exception | None): The exception raised if the task
-            failed, or ``None`` on success.
+        error (Exception | str | None): The exception raised if the
+            task failed, or ``None`` on success. Persisted — and so read
+            back — as a ``"{type}: {message}"`` string.
         metadata (dict[str, str]): Key-value annotations written at
             record time (e.g. ``{"reflection": "..."}``). Surfaced
             automatically in ``format()`` output.
@@ -46,9 +47,16 @@ class Episode(BaseModel):
     task: Task
     rollout: str
     result: TaskResult | None = Field(default=None)
-    error: Exception | None = Field(default=None)
+    error: Exception | str | None = Field(default=None)
     metadata: dict[str, str] = Field(default_factory=dict)
     completed_at: datetime = Field(default_factory=datetime.now)
+
+    @field_serializer("error")
+    def _serialize_error(self, error: Exception | str | None) -> str | None:
+        """Render ``error`` as text; Pydantic cannot serialize Exceptions."""
+        if error is None or isinstance(error, str):
+            return error
+        return f"{type(error).__name__}: {error}"
 
     def format(
         self,

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -173,3 +173,24 @@ def test_episode_init() -> None:
     assert episode.task == mock_task
     assert episode.result == mock_task_result
     assert episode.rollout == mock_rollout
+
+
+def test_episode_with_error_round_trips_through_json() -> None:
+    """Tests a failed Episode can be serialized and read back."""
+    task = Task(instruction="mock instruction")
+    ep = Episode(task=task, rollout="", error=ValueError("boom"))
+
+    restored = Episode.model_validate_json(ep.model_dump_json())
+
+    assert restored.error == "ValueError: boom"
+    assert Episode.model_validate_json(restored.model_dump_json()).error == (
+        "ValueError: boom"
+    )
+
+
+def test_episode_without_error_serializes_none() -> None:
+    """Tests a successful Episode serializes ``error`` as null."""
+    task = Task(instruction="mock instruction")
+    ep = Episode(task=task, rollout="")
+
+    assert Episode.model_validate_json(ep.model_dump_json()).error is None

--- a/tests/data_structures/test_memory.py
+++ b/tests/data_structures/test_memory.py
@@ -113,7 +113,7 @@ def test_format_xml_error() -> None:
         mode=EpisodeFormatMode.XML,
         exclude=_ALL_FIELDS - {"error"},
     )
-    assert "<error>something went wrong" in text
+    assert "<error>RuntimeError: something went wrong</error>" in text
 
 
 def test_format_xml_error_omitted_when_none() -> None:


### PR DESCRIPTION
`Episode.error: Exception | None` is declared under
`arbitrary_types_allowed=True`. Pydantic validates it but has no serializer
for an arbitrary `Exception`, so any failed episode blows up on write:

```
>>> Episode(task=Task(instruction="x"), rollout="", error=ValueError("boom")).model_dump_json()
PydanticSerializationError: Unable to serialize unknown type: <class 'ValueError'>
```

Both shipped stores serialize the whole model (`JSONMemoryStore.write` and
the Qdrant payload builder), so the error half of `Episode` was unusable
for both backends.

Adds a `field_serializer` rendering the exception as `"{type}: {message}"`,
and widens the field to `Exception | str | None` so what the stores write
re-validates on read (both call `model_validate_json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)