### PR TITLE
fix(agent): settle the task handler when memory recall fails

### DIFF
--- a/src/llm_agents_from_scratch/agent/llm_agent.py
+++ b/src/llm_agents_from_scratch/agent/llm_agent.py
@@ -966,7 +966,11 @@ class LLMAgent:
             step_result = None
 
             # added in ch07
-            await task_handler.load_memories()
+            try:
+                await task_handler.load_memories()
+            except Exception as e:
+                task_handler.set_exception(e)
+                return
 
             while not task_handler.done():
                 try:

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -325,6 +325,21 @@ async def test_run_records_episode_for_each_memory(
 
 
 @pytest.mark.asyncio
+async def test_run_sets_exception_when_recall_fails(
+    mock_llm: BaseLLM,
+) -> None:
+    """Tests a failing memory.recall settles the handler with the error."""
+    mock_memory = AsyncMock(spec=Memory)
+    mock_memory.recall.side_effect = RuntimeError("recall down")
+    task = Task(instruction="mock instruction")
+    agent = LLMAgent(llm=mock_llm, memories=[mock_memory])
+
+    handler = agent.run(task)
+    with pytest.raises(RuntimeError, match="recall down"):
+        await asyncio.wait_for(handler, timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_record_memory_raises_when_called_with_no_args(
     mock_llm: BaseLLM,
 ) -> None:


### PR DESCRIPTION
`await task_handler.load_memories()` sits above the `while` loop and
outside the `try` whose `except Exception` is the only place
`set_exception()` is ever called. Anything raised by `memory.recall()`
escapes `_process_loop` before either settle path runs, so the handler
stays pending forever and `await agent.run(task)` hangs.

No custom store needed to hit it: `JSONMemoryStore._search` raises
`NotImplementedError` unconditionally, and `recall_mode` is a public
constructor argument, so `JSONMemoryStore(dir=d, recall_mode=RecallMode.SEARCH)`
hangs the first `run()`. It also strands `await task_handler` in the A2A
executor, which then leaks the registry entry.

`run_supervised()` awaits the same call in a coroutine the caller awaits
directly, where the exception propagates — this brings `run()` in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)