### PR TITLE
fix(mcp): pass streamable HTTP headers on a configured client

### DIFF
--- a/src/llm_agents_from_scratch/tools/mcp/provider.py
+++ b/src/llm_agents_from_scratch/tools/mcp/provider.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamable_http_client
+from mcp.client.streamable_http import (
+    create_mcp_http_client,
+    streamable_http_client,
+)
 
 from llm_agents_from_scratch.errors import (
     MCPWarning,
@@ -94,21 +97,23 @@ class MCPToolProvider:
                     # Wait for shutdown signal
                     await self._shutdown_event.wait()
         else:
-            async with streamable_http_client(  # noqa: SIM117
-                self.streamable_http_url,
-                self.streamable_http_headers,
-            ) as (
-                read_stream,
-                write_stream,
-                _,
+            # headers can only be supplied through a pre-configured client
+            async with (
+                create_mcp_http_client(
+                    headers=self.streamable_http_headers,
+                ) as http_client,
+                streamable_http_client(
+                    self.streamable_http_url,
+                    http_client=http_client,
+                ) as (read_stream, write_stream),
+                ClientSession(read_stream, write_stream) as session,
             ):
-                async with ClientSession(read_stream, write_stream) as session:
-                    await session.initialize()
-                    self._session = session
-                    self._session_ready.set()
+                await session.initialize()
+                self._session = session
+                self._session_ready.set()
 
-                    # Wait for shutdown signal
-                    await self._shutdown_event.wait()
+                # Wait for shutdown signal
+                await self._shutdown_event.wait()
 
     async def session(self) -> ClientSession:
         """Get the persistent session.

--- a/tests/tools/mcp/conftest.py
+++ b/tests/tools/mcp/conftest.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 from typing import Any, AsyncContextManager, Callable
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,7 +29,6 @@ def mock_streamable_http_client_transport() -> Callable[
     async def async_context_manager(*args, **kwargs):
         mock_read = AsyncMock()
         mock_write = AsyncMock()
-        mock_id_callback = MagicMock()
-        yield (mock_read, mock_write, mock_id_callback)
+        yield (mock_read, mock_write)
 
     return async_context_manager

--- a/tests/tools/mcp/test_mcp_tool_provider.py
+++ b/tests/tools/mcp/test_mcp_tool_provider.py
@@ -142,11 +142,18 @@ async def test_session_creation_streamable_http(
     streamablehttp_provider = MCPToolProvider(
         name="mock provider",
         streamable_http_url="http://mock-url.io",
+        streamable_http_headers={"Authorization": "Bearer mock-token"},
     )
 
     await streamablehttp_provider.session()
 
+    # headers travel on the http client, not as a positional argument
     mock_streamable_http_client.assert_called_once()
+    args, kwargs = mock_streamable_http_client.call_args
+    assert args == ("http://mock-url.io",)
+    assert kwargs["http_client"].headers["Authorization"] == (
+        "Bearer mock-token"
+    )
     mock_client_session_cls.assert_called_once()
     assert streamablehttp_provider._session_ready.is_set()
 


### PR DESCRIPTION
Every non-stdio MCP session raised before any network I/O:

```
>>> inspect.signature(streamable_http_client)
(url: 'str', *, http_client: 'httpx2.AsyncClient | None' = None, terminate_on_close: 'bool' = True)
```

The provider called it as `streamable_http_client(url, headers)` — there is
no `headers` parameter and everything after the URL is keyword-only, so the
call raised `TypeError` whether or not headers were set. The transport also
yields two streams, not three, so the tuple unpack raised too. (mypy already
flags both on `main`.)

Headers now go through `create_mcp_http_client(headers=...)`, whose client is
handed to the transport — this is the supported route and keeps the MCP
default timeouts.

Tests were passing because the transport was patched with a
`(*args, **kwargs)` fake and only `assert_called_once()` checked; the test now
asserts the call shape and that the header lands on the client.

Note, not fixed here: `pyproject.toml` still allows `mcp>=1.9.4`, where the
symbol is named `streamablehttp_client` and the module import fails outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)