### PR TITLE
fix: extra/mcp-hailstone broken against mcp 2.0 (FastMCP moved/renamed)

### DIFF
--- a/extra/mcp-hailstone/main.py
+++ b/extra/mcp-hailstone/main.py
@@ -1,9 +1,9 @@
 """Main application."""
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 # Create an MCP server
-mcp = FastMCP("Hailstone")
+mcp = MCPServer("Hailstone")
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- `extra/mcp-hailstone/main.py` used `from mcp.server.fastmcp import FastMCP`, which no longer exists in `mcp==2.0.0` — renamed to `MCPServer`, moved to `mcp.server`. Server-side counterpart to the client-side `streamablehttp_client` → `streamable_http_client` rename (#742, #863).
- Fix: `from mcp.server import MCPServer` / `mcp = MCPServer("Hailstone")`. API-compatible for this usage (same `.tool()` decorator, same `.run(transport=...)` signature).
- `extra/mcp-hailstone`'s own `uv.lock` already resolves `mcp==2.0.0`, so this was already broken on `main` — not something #864 introduced.

Closes #865.

## Test plan
- [x] Re-ran Ch05 notebook Examples 1–6 end-to-end (provider creation, session, tool discovery, close, tool attrs, execution) against the fixed server — all pass
- [x] `make lint` passes