### PR TITLE
fix: bump extra/mcp-hailstone's mcp lower bound to >=2.0.0

### DIFF
--- a/extra/mcp-hailstone/pyproject.toml
+++ b/extra/mcp-hailstone/pyproject.toml
@@ -5,7 +5,7 @@ description = "A simple MCP server for the Hailstone tool."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "mcp[cli]>=1.25.0"
+  "mcp[cli]>=2.0.0"
 ]
 authors = [
   {name = "Andrei Fajardo", email = "andrei@nerdai.io"}

--- a/extra/mcp-hailstone/uv.lock
+++ b/extra/mcp-hailstone/uv.lock
@@ -336,7 +336,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=1.25.0" }]
+requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=2.0.0" }]
 
 [[package]]
 name = "mcp-types"


### PR DESCRIPTION
## Summary
- `extra/mcp-hailstone/pyproject.toml`: `mcp[cli]>=1.25.0` → `mcp[cli]>=2.0.0`.
- Follow-up from a code-review finding on #866: the code now requires `mcp.server.MCPServer` (added in mcp 2.0.0), but the dependency pin still said `>=1.25.0`. A fresh resolve without the committed `uv.lock` could land on a pre-2.0.0 mcp — where `MCPServer` doesn't exist in `mcp.server` — and reintroduce the exact `ImportError` #866 just fixed.
- Mirrors the identical fix already applied to the main package's own `mcp` pin (#863/#864).

## Test plan
- [x] `uv lock` (within `extra/mcp-hailstone/`) — minimal diff, only the `requires-dist` specifier changed
- [x] Re-ran Ch05 notebook Examples 1–6 end-to-end against the Hailstone server — all pass
- [x] `make lint` passes