### PR TITLE
docs(ch08): rename approval-gate sequence diagram title

### DIFF
--- a/uml/ch08/approval_gate_sequence.puml
+++ b/uml/ch08/approval_gate_sequence.puml
@@ -1,6 +1,6 @@
 @startuml uml_ch08_approval_gate_sequence
 !include ../common/book-clean.puml
-title Result Approval Gate — Sequence
+title Result-Approval HITL — Sequence
 
 actor "human" as human
 participant "agent: LLMAgent" as agent


### PR DESCRIPTION
## Summary
- `uml/ch08/approval_gate_sequence.puml`: title changed from "Result Approval Gate — Sequence" to "Result-Approval HITL — Sequence".
- Re-rendered via `make diagrams` to confirm the new title renders correctly (rendered SVGs/PNGs are gitignored, so only the `.puml` source is committed).

## Test plan
- [x] Verified rendered SVG title text updated correctly
- [x] `make lint` passes