### PR TITLE
feat(ch09): rewrite Example 2 as automatic dispatch via the coordinator

### DIFF
--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -256,11 +256,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0009-0000-0000-000000000009",
    "metadata": {},
-   "source": [
-    "### Example 2: Automatic Dispatch via the Coordinator\n",
-    "\n",
-    "We've completed the necessary updates to `LLMAgent` and `TaskHandler`, and now subagents can be dispatched to perform work during task execution. Let's quickly revisit our previous example, but this time have an `LLMAgent` dispatch the `hailstone` subagent to determine the Hailstone sequence for the number 5 -- no manual `ToolCall` needed, the coordinator decides to dispatch on its own."
-   ]
+   "source": "### Example 2: Automatic Dispatch via the Coordinator"
   },
   {
    "cell_type": "code",

--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -257,12 +257,14 @@
    "id": "a1b2c3d4-0009-0000-0000-000000000009",
    "metadata": {},
    "source": [
-    "### Example 2: Building the Coordinator"
+    "### Example 2: Automatic Dispatch via the Coordinator\n",
+    "\n",
+    "We've completed the necessary updates to `LLMAgent` and `TaskHandler`, and now subagents can be dispatched to perform work during task execution. Let's quickly revisit our previous example, but this time have an `LLMAgent` dispatch the `hailstone` subagent to determine the Hailstone sequence for the number 5 -- no manual `ToolCall` needed, the coordinator decides to dispatch on its own."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "a1b2c3d4-0009-0000-0000-000000000010",
    "metadata": {},
    "outputs": [
@@ -270,12 +272,1859 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'general': SubAgentSpec(name='general', description='General-purpose subagent for open-ended research, multi-step tasks, or work that benefits from an isolated context. Equipped with file reading and Python execution.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7a7ebc57a350>, max_steps=20, skills_scopes=None, explicit_only_skills=None), 'explore': SubAgentSpec(name='explore', description='Read-only subagent for quickly finding and reading files. Use for lookups and fact-finding, not multi-step work.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7a7ebc57a5d0>, max_steps=10, skills_scopes=None, explicit_only_skills=None)}\n"
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "# Stop At One\n",
+      "\n",
+      "Compute a full sequence from a starting number down to 1\n",
+      "using the `next_num...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 5 is 16. I will now continue the process to generate the full Hailstone sequence for the number 5...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the next_number tool with the current number 16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the next_number tool with the current number 16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 16 is 8. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 8 is 4. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"e57e3a6f-815d-4a6f-8a6d-51f35c6b5d0f\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"a...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 4 is 2. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      "\n",
+      "5 → 16 → 8 → 4...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      "\n",
+      "5 → 16 → 8 ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      "\n",
+      "5 → 1...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      "\n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Starting number:** 5  \n",
+      "**Total steps taken:** 5  \n",
+      "**Maximum value reached:** 16  \n",
+      "\n",
+      "Let me know if you'd like to explore further!"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
    "source": [
-    "from llm_agents_from_scratch import LLMAgentBuilder\n",
+    "from llm_agents_from_scratch.data_structures import Task\n",
+    "\n",
+    "# reuses `spec` from Example 1 -- the same hailstone SubAgentSpec, no\n",
+    "# changes needed. SubAgentSpec.builder builds a fresh LLMAgent per\n",
+    "# dispatch, so it's safe to reuse across coordinators.\n",
+    "hailstone_coordinator = await (\n",
+    "    LLMAgentBuilder().with_llm(llm).with_subagents([spec]).build()\n",
+    ")\n",
+    "\n",
+    "task_hailstone = Task(\n",
+    "    instruction=\"Determine the Hailstone sequence for the number 5.\",\n",
+    ")\n",
+    "result_hailstone = await hailstone_coordinator.run(task_hailstone)\n",
+    "print(result_hailstone.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0009-0000-0000-000000000011",
+   "metadata": {},
+   "source": [
+    "### Example 3: Router/Triage\n",
+    "\n",
+    "Build a coordinator with two subagents -- `general` (open-ended, equipped with file reading and Python execution) and `explore` (read-only, for quick lookups) -- and let the LLM route each task to the appropriate one automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a1b2c3d4-0009-0000-0000-000000000012",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'general': SubAgentSpec(name='general', description='General-purpose subagent for open-ended research, multi-step tasks, or work that benefits from an isolated context. Equipped with file reading and Python execution.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7073fe482780>, max_steps=20, skills_scopes=None, explicit_only_skills=None), 'explore': SubAgentSpec(name='explore', description='Read-only subagent for quickly finding and reading files. Use for lookups and fact-finding, not multi-step work.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7073fe482b10>, max_steps=10, skills_scopes=None, explicit_only_skills=None)}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences....[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
+      "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
+      "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assis...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further as...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assistance!"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.data_structures import Task\n",
     "from llm_agents_from_scratch.subagents.recipes import explore_subagent, general_subagent\n",
     "\n",
     "# explore only does lookups, so a small local model is plenty; general\n",
@@ -289,64 +2138,7 @@
     "    .build()\n",
     ")\n",
     "\n",
-    "print(coordinator.subagents_registry)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4-0009-0000-0000-000000000011",
-   "metadata": {},
-   "source": [
-    "### Example 3: Router/Triage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "a1b2c3d4-0009-0000-0000-000000000012",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Find and read the file hailstone_known_sequences.json, then report the Hailstone sequence for the number 6.\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Find and read the file hailstone_known_sequences.json, then report the Hailstone sequence for the number 6.\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
-      "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
-      "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the number 6 is:  \n",
-      "**[6, 3, 10, 5, 16, 8, 4, 2, 1]**  \n",
-      "\n",
-      "It takes **8 steps** to reach the number 1.\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the number 6 is:  \n",
-      "**[6, 3, 10, 5, 16, 8, 4, 2, 1]**  \n",
-      "\n",
-      "It takes **8 steps** to reach the number 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for the number 6 is:  \n",
-      "**[6, 3, 10, 5, 16, 8, 4, 2, 1]**  \n",
-      "\n",
-      "It takes **8 steps** to reach the number 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
-      "\n",
-      "It takes 8 steps to reach the number 1.\n",
-      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
-      "\n",
-      "It takes 8 steps to reach the number 1.\n",
-      "The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
-      "\n",
-      "It takes 8 steps to reach the number 1.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from llm_agents_from_scratch.data_structures import Task\n",
+    "print(coordinator.subagents_registry)\n",
     "\n",
     "# a lookup task — should route to explore (reads hailstone_known_sequences.json)\n",
     "task_lookup = Task(\n",

--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -1698,11 +1698,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0009-0000-0000-000000000011",
    "metadata": {},
-   "source": [
-    "### Example 3: Router/Triage\n",
-    "\n",
-    "Build a coordinator with two subagents -- `general` (open-ended, equipped with file reading and Python execution) and `explore` (read-only, for quick lookups) -- and let the LLM route each task to the appropriate one automatically."
-   ]
+   "source": "### Example 3: Router/Triage"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- "Example 2: Building the Coordinator" → "Example 2: Automatic Dispatch via the Coordinator", matching the book text: revisits Example 1's hailstone task, but has an `LLMAgent` coordinator dispatch it automatically via `run()` instead of a manual `ToolCall` — reuses Example 1's `hailstone` `SubAgentSpec` directly.
- The old Example 2 content (building a coordinator with `general`/`explore` subagents) is folded into the top of Example 3 (Router/Triage), which already depended on that coordinator existing — no renumbering, Examples 3–5 otherwise unchanged.
- Re-executed Examples 1–3 locally (`qwen3:14b`/`qwen3:8b` via Ollama) to regenerate fresh, verified outputs for the new/changed cells.

## Test plan
- [x] Ran the new Example 2 end-to-end — coordinator dispatches `hailstone`, correct sequence (5 → 16 → 8 → 4 → 2 → 1, 5 steps), matches Example 1's manual result
- [x] Ran the restructured Example 3 end-to-end — coordinator builds correctly, routes to `explore`, correct lookup result
- [x] `make lint` passes