### PR TITLE
docs(ch10): swap order of Example 1's Agent Card / URL constructors

### DIFF
--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -376,7 +376,7 @@
    "id": "8e3345e6",
    "metadata": {},
    "source": [
-    "#### 1a. From a URL"
+    "#### 1a. From an Agent Card"
    ]
   },
   {
@@ -393,13 +393,113 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/nerdai/Projects/llm-agents-from-scratch/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
+      "spec name: crewai-hailstone"
      ]
     },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spec url: http://localhost:9200"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spec catalog:\n",
+      "<a2a_agent>\n",
+      "    <name>crewai-hailstone</name>\n",
+      "    <description>Computes the full Hailstone (Collatz) sequence.</description>\n",
+      "    <a2a_skills>\n",
+      "      <a2a_skill>hailstone_sequence</a2a_skill>\n",
+      "    </a2a_skills>\n",
+      "  </a2a_agent>"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill\n",
+    "from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol\n",
+    "from llm_agents_from_scratch.a2a import A2AAgentSpec\n",
+    "\n",
+    "# hand-built, no network call -- useful for tests, fixtures, or a peer\n",
+    "# whose card details you already know ahead of time\n",
+    "hand_built_card = AgentCard(\n",
+    "    name=\"crewai-hailstone\",\n",
+    "    description=\"Computes the full Hailstone (Collatz) sequence.\",\n",
+    "    supported_interfaces=[\n",
+    "        AgentInterface(\n",
+    "            url=\"http://localhost:9200\",\n",
+    "            protocol_binding=TransportProtocol.JSONRPC,\n",
+    "            protocol_version=PROTOCOL_VERSION_1_0,\n",
+    "        ),\n",
+    "    ],\n",
+    "    version=\"0.1.0\",\n",
+    "    capabilities=AgentCapabilities(streaming=False),\n",
+    "    default_input_modes=[\"text/plain\"],\n",
+    "    default_output_modes=[\"text/plain\"],\n",
+    "    skills=[\n",
+    "        AgentSkill(\n",
+    "            id=\"hailstone_sequence\",\n",
+    "            name=\"hailstone_sequence\",\n",
+    "            description=\"Compute the full hailstone sequence for x.\",\n",
+    "            tags=[\"math\"],\n",
+    "        ),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "spec_hand_built = A2AAgentSpec.from_agent_card(agent_card=hand_built_card)\n",
+    "print(f\"spec name: {spec_hand_built.name}\")\n",
+    "print(f\"spec url: {spec_hand_built.url}\")\n",
+    "print(f\"spec catalog:\\n{spec_hand_built.catalog()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a5dc6c0",
+   "metadata": {},
+   "source": [
+    "#### 1b. From a URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b76afc3f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-08T00:16:23.062734Z",
+     "iopub.status.busy": "2026-08-08T00:16:23.062625Z",
+     "iopub.status.idle": "2026-08-08T00:16:23.065758Z",
+     "shell.execute_reply": "2026-08-08T00:16:23.065501Z"
+    }
+   },
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
@@ -484,113 +584,6 @@
     "print(f\"url: {spec.url}\")\n",
     "print(f\"timeout: {spec.timeout}\")\n",
     "print(spec.agent_card)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5a5dc6c0",
-   "metadata": {},
-   "source": [
-    "#### 1b. From an Agent Card"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "b76afc3f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-08T00:16:23.062734Z",
-     "iopub.status.busy": "2026-08-08T00:16:23.062625Z",
-     "iopub.status.idle": "2026-08-08T00:16:23.065758Z",
-     "shell.execute_reply": "2026-08-08T00:16:23.065501Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "spec name: crewai-hailstone"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "spec url: http://localhost:9200"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "spec catalog:\n",
-      "<a2a_agent>\n",
-      "    <name>crewai-hailstone</name>\n",
-      "    <description>Computes the full Hailstone (Collatz) sequence.</description>\n",
-      "    <a2a_skills>\n",
-      "      <a2a_skill>hailstone_sequence</a2a_skill>\n",
-      "    </a2a_skills>\n",
-      "  </a2a_agent>"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill\n",
-    "from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol\n",
-    "\n",
-    "# hand-built, no network call -- useful for tests, fixtures, or a peer\n",
-    "# whose card details you already know ahead of time\n",
-    "hand_built_card = AgentCard(\n",
-    "    name=\"crewai-hailstone\",\n",
-    "    description=\"Computes the full Hailstone (Collatz) sequence.\",\n",
-    "    supported_interfaces=[\n",
-    "        AgentInterface(\n",
-    "            url=\"http://localhost:9200\",\n",
-    "            protocol_binding=TransportProtocol.JSONRPC,\n",
-    "            protocol_version=PROTOCOL_VERSION_1_0,\n",
-    "        ),\n",
-    "    ],\n",
-    "    version=\"0.1.0\",\n",
-    "    capabilities=AgentCapabilities(streaming=False),\n",
-    "    default_input_modes=[\"text/plain\"],\n",
-    "    default_output_modes=[\"text/plain\"],\n",
-    "    skills=[\n",
-    "        AgentSkill(\n",
-    "            id=\"hailstone_sequence\",\n",
-    "            name=\"hailstone_sequence\",\n",
-    "            description=\"Compute the full hailstone sequence for x.\",\n",
-    "            tags=[\"math\"],\n",
-    "        ),\n",
-    "    ],\n",
-    ")\n",
-    "\n",
-    "spec_hand_built = A2AAgentSpec.from_agent_card(agent_card=hand_built_card)\n",
-    "print(f\"spec name: {spec_hand_built.name}\")\n",
-    "print(f\"spec url: {spec_hand_built.url}\")\n",
-    "print(f\"spec catalog:\\n{spec_hand_built.catalog()}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Matches the manuscript's listing order: 1a is now "From an Agent Card" (was "From a URL"), 1b is now "From a URL" (was "From an Agent Card").
- Headers and code swapped together; cells not reordered — content-swapped in place, so execution order naturally flips.
- `spec` (used by Examples 2-3) is still produced by `from_url()`, just runs second instead of first now. `spec_hand_built` stays self-contained either way. No other cell references position, only variable names, so nothing else needed touching.

## Test plan
- [x] Re-executed both swapped cells against a live CrewAI Hailstone A2A server — output content is identical to before, just attributed to the swapped positions
- [x] `make lint` passes