### PR TITLE
docs(ch10): remove Example 3's manual-inspection part

### DIFF
--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -525,58 +525,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05a63356",
-   "metadata": {},
-   "source": [
-    "`CrewAIHailstoneExecutor`'s ambiguity check is a plain regex for a digit -- a spelled-out number like *\"four\"* triggers `TASK_STATE_INPUT_REQUIRED` organically, not as a CrewAI judgment call.\n",
-    "\n",
-    "Before letting an `LLMAgent` handle this automatically (next), here's what that wrapped response looks like when inspecting it manually:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "a9d11b42",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The A2A agent 'crewai-hailstone' needs more information before it can continue:\n",
-      "\n",
-      "Which positive integer should I start the hailstone sequence from?\n",
-      "\n",
-      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='1beaa620-afe8-492d-b0cd-3caa875913c5', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from llm_agents_from_scratch.a2a import UseA2AAgentTool\n",
-    "from llm_agents_from_scratch.data_structures import ToolCall\n",
-    "\n",
-    "tool = UseA2AAgentTool(a2a_agents_registry={spec.name: spec})\n",
-    "\n",
-    "ambiguous_call = ToolCall(\n",
-    "    tool_name=\"from_scratch__use_a2a_agent\",\n",
-    "    arguments={\n",
-    "        \"name\": spec.name,\n",
-    "        \"task\": \"Compute the hailstone sequence starting at the number four.\",\n",
-    "    },\n",
-    ")\n",
-    "input_required_result = await tool(tool_call=ambiguous_call)\n",
-    "print(input_required_result.content)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "0d0db273",
    "metadata": {},
    "source": [

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -367,7 +367,9 @@
    "cell_type": "markdown",
    "id": "b6085363",
    "metadata": {},
-   "source": "### Example 1: Constructing an A2AAgentSpec from a URL"
+   "source": [
+    "### Example 1: Constructing an A2AAgentSpec from a URL"
+   ]
   },
   {
    "cell_type": "code",
@@ -523,40 +525,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d0db273",
+   "id": "05a63356",
    "metadata": {},
    "source": [
-    "### Example 3: Resuming a Peer Task Parked in input_required"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0d463e9c",
-   "metadata": {},
-   "source": [
-    "`CrewAIHailstoneExecutor`'s ambiguity check is a plain regex for a digit -- a spelled-out number like *\"four\"* triggers `TASK_STATE_INPUT_REQUIRED` organically, not as a CrewAI judgment call."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bf7db2b0",
-   "metadata": {},
-   "source": [
-    "#### 3a. Manually Inspecting the Wrapped Response"
+    "`CrewAIHailstoneExecutor`'s ambiguity check is a plain regex for a digit -- a spelled-out number like *\"four\"* triggers `TASK_STATE_INPUT_REQUIRED` organically, not as a CrewAI judgment call.\n",
+    "\n",
+    "Before letting an `LLMAgent` handle this automatically (next), here's what that wrapped response looks like when inspecting it manually:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "3416d475",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-08T00:16:32.098228Z",
-     "iopub.status.busy": "2026-08-08T00:16:32.098129Z",
-     "iopub.status.idle": "2026-08-08T00:16:32.114670Z",
-     "shell.execute_reply": "2026-08-08T00:16:32.114447Z"
-    }
-   },
+   "execution_count": 7,
+   "id": "a9d11b42",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -566,7 +547,7 @@
       "\n",
       "Which positive integer should I start the hailstone sequence from?\n",
       "\n",
-      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='b6562cab-54b5-4934-b386-634c07e02370', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
+      "To continue, call `from_scratch__use_a2a_agent` again with name='crewai-hailstone', task_id='1beaa620-afe8-492d-b0cd-3caa875913c5', and `task` set to the requested information. This resumes the same remote task rather than starting a new one."
      ]
     },
     {
@@ -596,10 +577,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87c05e53",
+   "id": "0d0db273",
    "metadata": {},
    "source": [
-    "#### 3b. Letting an LLMAgent Resume the Task"
+    "### Example 3: Letting an LLMAgent Resume a Peer Task Parked in input_required"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- "3a. Manually Inspecting the Wrapped Response" is removed entirely (initially demoted to an unnumbered preamble, then dropped on reflection).
- Example 3's header absorbs 3b's title, since it's now a single-part example: "### Example 3: Letting an LLMAgent Resume a Peer Task Parked in input_required".
- No downstream dependency issue: 3b's code was already independent of 3a's variables (`tool`/`ambiguous_call`/`input_required_result`) — confirmed clean, nothing references them anymore.

## Test plan
- [x] Confirmed no orphaned references to the removed cell's variables
- [x] `make lint` passes