### PR TITLE
docs: A2A executor terminology + "Initialise" -> "Initialize" repo-wide

### DIFF
--- a/src/llm_agents_from_scratch/a2a/client/tools.py
+++ b/src/llm_agents_from_scratch/a2a/client/tools.py
@@ -66,7 +66,7 @@ class UseA2AAgentTool(AsyncBaseTool):
     """
 
     def __init__(self, a2a_agents_registry: dict[str, A2AAgentSpec]) -> None:
-        """Initialise with a registry of A2A peer agents.
+        """Initialize with a registry of A2A peer agents.
 
         Args:
             a2a_agents_registry (dict[str, A2AAgentSpec]): A2A peers to

--- a/src/llm_agents_from_scratch/a2a/server/executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/executor.py
@@ -1,4 +1,4 @@
-"""LLMAgentA2AExecutor — wraps inbound A2A tasks to an LLMAgent."""
+"""LLMAgentA2AExecutor — wraps inbound A2A tasks for an LLMAgent."""
 
 import asyncio
 
@@ -25,7 +25,7 @@ from llm_agents_from_scratch.data_structures import Task
 
 
 class LLMAgentA2AExecutor(AgentExecutor):
-    """Wraps inbound A2A tasks to an ``LLMAgent``.
+    """Wraps inbound A2A tasks for an ``LLMAgent``.
 
     Per request: ``RequestContext`` -> ``Task(instruction=...)`` ->
     ``await agent.run()`` -> ``Artifact``. Results live in
@@ -71,7 +71,7 @@ class LLMAgentA2AExecutor(AgentExecutor):
         """Initialize with the agent to serve.
 
         Args:
-            agent (LLMAgent): The agent to wrap inbound A2A tasks to.
+            agent (LLMAgent): The agent to wrap inbound A2A tasks for.
         """
         self.agent = agent
         self._task_handlers: dict[str, LLMAgent.TaskHandler] = {}

--- a/src/llm_agents_from_scratch/a2a/server/executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/executor.py
@@ -68,7 +68,7 @@ class LLMAgentA2AExecutor(AgentExecutor):
     """
 
     def __init__(self, agent: LLMAgent) -> None:
-        """Initialise with the agent to serve.
+        """Initialize with the agent to serve.
 
         Args:
             agent (LLMAgent): The agent to wrap inbound A2A tasks to.

--- a/src/llm_agents_from_scratch/a2a/server/executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/executor.py
@@ -1,4 +1,4 @@
-"""LLMAgentA2AExecutor — bridges inbound A2A tasks to an LLMAgent."""
+"""LLMAgentA2AExecutor — wraps inbound A2A tasks to an LLMAgent."""
 
 import asyncio
 
@@ -25,7 +25,7 @@ from llm_agents_from_scratch.data_structures import Task
 
 
 class LLMAgentA2AExecutor(AgentExecutor):
-    """Bridges inbound A2A tasks to an ``LLMAgent``.
+    """Wraps inbound A2A tasks to an ``LLMAgent``.
 
     Per request: ``RequestContext`` -> ``Task(instruction=...)`` ->
     ``await agent.run()`` -> ``Artifact``. Results live in
@@ -71,7 +71,7 @@ class LLMAgentA2AExecutor(AgentExecutor):
         """Initialise with the agent to serve.
 
         Args:
-            agent (LLMAgent): The agent to bridge inbound A2A tasks to.
+            agent (LLMAgent): The agent to wrap inbound A2A tasks to.
         """
         self.agent = agent
         self._task_handlers: dict[str, LLMAgent.TaskHandler] = {}

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -23,7 +23,7 @@ from llm_agents_from_scratch.data_structures import Task, TaskResult, TaskStep
 
 
 class StreamingLLMAgentA2AExecutor(AgentExecutor):
-    """Wraps inbound A2A tasks to an ``LLMAgent``, streaming updates.
+    """Wraps inbound A2A tasks for an ``LLMAgent``, streaming updates.
 
     Drives ``LLMAgent.run_supervised()`` directly instead of ``run()``:
     ``SupervisedTaskHandler`` has no background task at all — execution
@@ -64,7 +64,7 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
         """Initialize with the agent to serve.
 
         Args:
-            agent (LLMAgent): The agent to wrap inbound A2A tasks to.
+            agent (LLMAgent): The agent to wrap inbound A2A tasks for.
         """
         self.agent = agent
         self._task_handlers: dict[str, LLMAgent.SupervisedTaskHandler] = {}

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -23,7 +23,7 @@ from llm_agents_from_scratch.data_structures import Task, TaskResult, TaskStep
 
 
 class StreamingLLMAgentA2AExecutor(AgentExecutor):
-    """Bridges inbound A2A tasks to an ``LLMAgent``, streaming updates.
+    """Wraps inbound A2A tasks to an ``LLMAgent``, streaming updates.
 
     Drives ``LLMAgent.run_supervised()`` directly instead of ``run()``:
     ``SupervisedTaskHandler`` has no background task at all — execution
@@ -64,7 +64,7 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
         """Initialise with the agent to serve.
 
         Args:
-            agent (LLMAgent): The agent to bridge inbound A2A tasks to.
+            agent (LLMAgent): The agent to wrap inbound A2A tasks to.
         """
         self.agent = agent
         self._task_handlers: dict[str, LLMAgent.SupervisedTaskHandler] = {}

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -61,7 +61,7 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
     """
 
     def __init__(self, agent: LLMAgent) -> None:
-        """Initialise with the agent to serve.
+        """Initialize with the agent to serve.
 
         Args:
             agent (LLMAgent): The agent to wrap inbound A2A tasks to.

--- a/src/llm_agents_from_scratch/base/memory_store.py
+++ b/src/llm_agents_from_scratch/base/memory_store.py
@@ -37,7 +37,7 @@ class BaseMemoryStore(ABC):
         max_results: int = 5,
         recall_mode: RecallMode = RecallMode.SEARCH,
     ) -> None:
-        """Initialise shared store state.
+        """Initialize shared store state.
 
         Args:
             max_results (int): Default maximum number of episodes

--- a/src/llm_agents_from_scratch/subagents/tools.py
+++ b/src/llm_agents_from_scratch/subagents/tools.py
@@ -34,7 +34,7 @@ class UseSubAgentTool(AsyncBaseTool):
     """
 
     def __init__(self, subagents_registry: dict[str, SubAgentSpec]) -> None:
-        """Initialise with a registry of subagents.
+        """Initialize with a registry of subagents.
 
         Args:
             subagents_registry (dict[str, SubAgentSpec]): Subagents to

--- a/src/llm_agents_from_scratch/tools/default/human_input.py
+++ b/src/llm_agents_from_scratch/tools/default/human_input.py
@@ -193,7 +193,7 @@ class SharedConsoleHumanInputTool(AsyncBaseTool):
     _console_lock: asyncio.Lock = asyncio.Lock()
 
     def __init__(self, agent_name: str | None = None) -> None:
-        """Initialise with an optional agent-name label.
+        """Initialize with an optional agent-name label.
 
         Args:
             agent_name (str | None): Name of the coordinator or

--- a/tests/agent/test_task_handler.py
+++ b/tests/agent/test_task_handler.py
@@ -950,7 +950,7 @@ async def test_llm_agent_init_no_memories_defaults_to_empty_list(
 
 @pytest.mark.asyncio
 async def test_task_handler_recalled_memories_init(mock_llm: BaseLLM) -> None:
-    """Tests _recalled_memories initialises as empty string."""
+    """Tests _recalled_memories initializes as empty string."""
     handler = LLMAgent.TaskHandler(
         llm_agent=LLMAgent(llm=mock_llm),
         task=Task(instruction="mock instruction"),

--- a/tests/subagents/test_spec.py
+++ b/tests/subagents/test_spec.py
@@ -11,7 +11,7 @@ MAX_STEPS = 10
 
 
 def test_subagentspec_init(mock_llm: BaseLLM) -> None:
-    """Tests SubAgentSpec initialises with required and optional fields."""
+    """Tests SubAgentSpec initializes with required and optional fields."""
     builder = LLMAgentBuilder(llm=mock_llm)
     spec = SubAgentSpec(
         name="researcher",


### PR DESCRIPTION
## Summary

**"bridges"/"bridge" -> "wraps"/"wrap"** (A2A executor docstrings):
- All 5 code occurrences describing the `LLMAgent`/executor relationship, for consistency across `executor.py` and `streaming_executor.py` (module docstring, class docstring, `__init__`'s `Args` entry — x2 files).
- `streaming_executor.py`'s "the same substitution `LLMAgentA2AExecutor` makes" line references the wrap/bridge choice implicitly without naming it, so unchanged.
- The Notion design doc's one informal "the inbound bridge" mention (Decision 14) is left alone — it describes what the executor does, not the relationship's defined term the way these docstrings use it.

**"Initialise"/"initialises" -> "Initialize"/"initializes"** (repo-wide sweep):
- One instance per file, each a `__init__` docstring's first line or a test docstring describing init behavior: `a2a/client/tools.py`, `a2a/server/executor.py`, `a2a/server/streaming_executor.py`, `base/memory_store.py`, `subagents/tools.py`, `tools/default/human_input.py`, `tests/agent/test_task_handler.py`, `tests/subagents/test_spec.py`.
- Standardizes on American spelling throughout — confirmed no remaining British-spelling occurrences anywhere in the codebase.

## Test plan
- [x] `make test` — 535 passed
- [x] `make lint` passes