### PR TITLE
docs(ch10): disambiguate task variable and namespace a2a helper calls

### DIFF
--- a/src/llm_agents_from_scratch/a2a/server/executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/executor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from a2a.helpers import new_task_from_user_message, new_text_part
+import a2a.helpers as a2a_helpers
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
@@ -100,35 +100,37 @@ class LLMAgentA2AExecutor(AgentExecutor):
                 status/artifact events to.
         """
         if context.current_task:
-            task = context.current_task
+            a2a_task = context.current_task
         else:
             if context.message is None:
                 raise ValueError(
                     "RequestContext is missing the user's Message.",
                 )
-            task = new_task_from_user_message(context.message)
-            await event_queue.enqueue_event(task)
+            a2a_task = a2a_helpers.new_task_from_user_message(context.message)
+            await event_queue.enqueue_event(a2a_task)
 
-        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        updater = TaskUpdater(event_queue, a2a_task.id, a2a_task.context_id)
         await updater.submit()
         await updater.start_work()
 
         instruction = context.get_user_input()
         task_handler = self.agent.run(Task(instruction=instruction))
-        self._task_handlers[task.id] = task_handler
+        self._task_handlers[a2a_task.id] = task_handler
         try:
             result = await task_handler
         except Exception as e:
             await updater.update_status(
                 TaskState.TASK_STATE_FAILED,
-                message=updater.new_agent_message([new_text_part(str(e))]),
+                message=updater.new_agent_message(
+                    [a2a_helpers.new_text_part(str(e))],
+                ),
             )
             return
         finally:
-            self._task_handlers.pop(task.id, None)
+            self._task_handlers.pop(a2a_task.id, None)
 
         await updater.add_artifact(
-            parts=[new_text_part(result.content)],
+            parts=[a2a_helpers.new_text_part(result.content)],
             name="task_result",
         )
         await updater.complete()

--- a/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
+++ b/src/llm_agents_from_scratch/a2a/server/streaming_executor.py
@@ -1,6 +1,6 @@
 """StreamingLLMAgentA2AExecutor — streaming variant of LLMAgentA2AExecutor."""
 
-from a2a.helpers import new_task_from_user_message, new_text_part
+import a2a.helpers as a2a_helpers
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
@@ -94,16 +94,16 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
                 status/artifact events to.
         """
         if context.current_task:
-            task = context.current_task
+            a2a_task = context.current_task
         else:
             if context.message is None:
                 raise ValueError(
                     "RequestContext is missing the user's Message.",
                 )
-            task = new_task_from_user_message(context.message)
-            await event_queue.enqueue_event(task)
+            a2a_task = a2a_helpers.new_task_from_user_message(context.message)
+            await event_queue.enqueue_event(a2a_task)
 
-        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        updater = TaskUpdater(event_queue, a2a_task.id, a2a_task.context_id)
         await updater.submit()
         await updater.start_work()
 
@@ -111,7 +111,7 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
         task_handler = await self.agent.run_supervised(
             Task(instruction=instruction),
         )
-        self._task_handlers[task.id] = task_handler
+        self._task_handlers[a2a_task.id] = task_handler
         try:
             step_result = None
             while not task_handler.done():
@@ -121,14 +121,22 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
                         await updater.update_status(
                             TaskState.TASK_STATE_WORKING,
                             message=updater.new_agent_message(
-                                [new_text_part(next_step.instruction)],
+                                [
+                                    a2a_helpers.new_text_part(
+                                        next_step.instruction,
+                                    ),
+                                ],
                             ),
                         )
                         step_result = await task_handler.run_step(next_step)
                         await updater.update_status(
                             TaskState.TASK_STATE_WORKING,
                             message=updater.new_agent_message(
-                                [new_text_part(step_result.content)],
+                                [
+                                    a2a_helpers.new_text_part(
+                                        step_result.content,
+                                    ),
+                                ],
                             ),
                         )
                     case TaskResult():
@@ -136,15 +144,17 @@ class StreamingLLMAgentA2AExecutor(AgentExecutor):
         except Exception as e:
             await updater.update_status(
                 TaskState.TASK_STATE_FAILED,
-                message=updater.new_agent_message([new_text_part(str(e))]),
+                message=updater.new_agent_message(
+                    [a2a_helpers.new_text_part(str(e))],
+                ),
             )
             return
         finally:
-            self._task_handlers.pop(task.id, None)
+            self._task_handlers.pop(a2a_task.id, None)
 
         result = task_handler.result()
         await updater.add_artifact(
-            parts=[new_text_part(result.content)],
+            parts=[a2a_helpers.new_text_part(result.content)],
             name="task_result",
         )
         await updater.complete()


### PR DESCRIPTION
## Summary

Two readability changes for book readers, in both `LLMAgentA2AExecutor.execute()` (`a2a/server/executor.py`) and `StreamingLLMAgentA2AExecutor.execute()` (`a2a/server/streaming_executor.py`):

- local `task` -> `a2a_task`: disambiguates the a2a SDK's `Task` object from this framework's own `Task` (`data_structures.Task`), constructed a few lines later in the same function — both are conceptually "a task" but different types.
- `from a2a.helpers import new_task_from_user_message, new_text_part` -> `import a2a.helpers as a2a_helpers`, with call sites updated to `a2a_helpers.new_task_from_user_message(...)` / `a2a_helpers.new_text_part(...)`: makes it visually unambiguous at every call site that these are third-party SDK helpers, not something defined in this repo.

`executor.py`'s changes were made directly by the author; this PR extends the same two fixes to `streaming_executor.py`, which had the identical pattern.

## Test plan
- [x] `make test` — 535 passed
- [x] `make lint` passes