### PR TITLE
docs(ch10): fold Example 4's 4a into the preamble, shift 4b-4d down

### DIFF
--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -713,14 +713,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d5f6ee4e",
-   "metadata": {},
-   "source": [
-    "#### 4a. Building LLMAgentA2AExecutor and build_agent_card()"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "9c05ab67",
@@ -791,9 +783,7 @@
    "cell_type": "markdown",
    "id": "add97904",
    "metadata": {},
-   "source": [
-    "#### 4b. Discovering the Server"
-   ]
+   "source": "#### 4a. Discovering the Server"
   },
   {
    "cell_type": "code",
@@ -821,9 +811,7 @@
    "cell_type": "markdown",
    "id": "cb870138",
    "metadata": {},
-   "source": [
-    "#### 4c. Dispatching via the Coordinator"
-   ]
+   "source": "#### 4b. Dispatching via the Coordinator"
   },
   {
    "cell_type": "markdown",
@@ -984,9 +972,7 @@
    "cell_type": "markdown",
    "id": "8ad5e159",
    "metadata": {},
-   "source": [
-    "#### 4d. The Server's Own Log Stream"
-   ]
+   "source": "#### 4c. The Server's Own Log Stream"
   },
   {
    "cell_type": "markdown",

--- a/examples/ch10.ipynb
+++ b/examples/ch10.ipynb
@@ -783,7 +783,9 @@
    "cell_type": "markdown",
    "id": "add97904",
    "metadata": {},
-   "source": "#### 4a. Discovering the Server"
+   "source": [
+    "#### 4a. Discovering the Server"
+   ]
   },
   {
    "cell_type": "code",
@@ -811,7 +813,9 @@
    "cell_type": "markdown",
    "id": "cb870138",
    "metadata": {},
-   "source": "#### 4b. Dispatching via the Coordinator"
+   "source": [
+    "#### 4b. Dispatching via the Coordinator"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -972,7 +976,9 @@
    "cell_type": "markdown",
    "id": "8ad5e159",
    "metadata": {},
-   "source": "#### 4c. The Server's Own Log Stream"
+   "source": [
+    "#### 4c. The Server's Own Log Stream"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- "4a. Building `LLMAgentA2AExecutor` and `build_agent_card()`" no longer stands as its own numbered sub-example. Its code (unchanged) now sits directly under Example 4's intro paragraph, unnumbered — same pattern already used for Example 3's demoted manual-inspection part.
- 4b/4c/4d shift down to 4a/4b/4c accordingly.

## Test plan
- [x] Confirmed the folded code cell is self-contained — no downstream cell references its variables (`demo_llm`, `hailstone_agent`, `demo_executor`, `demo_card`, `next_number`), so no content needed to move, only the heading
- [x] `make lint` passes