### PR TITLE
docs(ch09): reorder examples — HITL becomes Example 3

### DIFF
--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -256,7 +256,9 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4-0009-0000-0000-000000000009",
    "metadata": {},
-   "source": "### Example 2: Automatic Dispatch via the Coordinator"
+   "source": [
+    "### Example 2: Automatic Dispatch via the Coordinator"
+   ]
   },
   {
    "cell_type": "code",
@@ -1696,9 +1698,307 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4-0009-0000-0000-000000000016",
+   "metadata": {},
+   "source": [
+    "### Example 3: HITL on the Coordinator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a1b2c3d4-0009-0000-0000-000000000017",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n",
+      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for their name, then return a friendly greeting.\n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for their name, then return a friendly greeting.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭──────────────────────────────────────────── Human Input — hailstone ────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide a starting number for the Hailstone sequence:                                                    <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[33m╭─\u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m Human Input — hailstone \u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m Please provide a starting number for the Hailstone sequence:                                                    \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt; <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[1/2/3/4/5/6/7/8/9/10]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "> \u001b[1;35m[1/2/3/4/5/6/7/8/9/10]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " 4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭───────────────────────────────────────────── Human Input — greeter ─────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[33m╭─\u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m Human Input — greeter \u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m What is your name?                                                                                              \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt;: </pre>\n"
+      ],
+      "text/plain": [
+       ">: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The starting number is 4. Now, I will compute its Hailstone sequence by repeatedly applying the next_number tool until the value 1 is r...[TRUNCATED]\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " Andrei\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Andrei\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 2. I will continue applying the next_number tool to 2 until the sequence reaches 1. Let's proceed.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complete. ...[TRUNCATED]\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complet...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is c...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
+      "\n",
+      "**Hailstone Sub-agent Result:**\n",
+      "- Starting number:...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents have completed their tasks successfully. Let me report the results:                             <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Hailstone Sub-agent Result:**                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Starting number: 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Hailstone sequence: 4, 2, 1                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - The sequence reached 1 and completed successfully.                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Greeter Sub-agent Result:**                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Name obtained: Andrei                                                                                         <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> friendly greeting.                                                                                              <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Both sub-agents have completed their tasks successfully. Let me report the results:                             \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Hailstone Sub-agent Result:**                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m - Starting number: 4                                                                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m - Hailstone sequence: 4, 2, 1                                                                                   \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m - The sequence reached 1 and completed successfully.                                                            \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m **Greeter Sub-agent Result:**                                                                                   \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m - Name obtained: Andrei                                                                                         \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     \u001b[36m│\u001b[0m\n",
+       "\u001b[36m│\u001b[0m friendly greeting.                                                                                              \u001b[36m│\u001b[0m\n",
+       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Approve this result? <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[y/n]</span>: </pre>\n"
+      ],
+      "text/plain": [
+       "Approve this result? \u001b[1;35m[y/n]\u001b[0m: "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
+      "\n",
+      "**Hailstone Sub-agent Result:**\n",
+      "- Starting numb...[TRUNCATED]\n",
+      "Both sub-agents have completed their tasks successfully. Let me report the results:\n",
+      "\n",
+      "**Hailstone Sub-agent Result:**\n",
+      "- Starting number: 4\n",
+      "- Hailstone sequence: 4, 2, 1\n",
+      "- The sequence reached 1 and completed successfully.\n",
+      "\n",
+      "**Greeter Sub-agent Result:**\n",
+      "- Name obtained: Andrei\n",
+      "- Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"\n",
+      "\n",
+      "Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a friendly greeting.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llm_agents_from_scratch.tools.default import SharedConsoleHumanInputTool\n",
+    "\n",
+    "# both subagents here do simple, tightly-scoped work, so a small\n",
+    "# local model is plenty\n",
+    "slm = OllamaLLM(model=\"qwen3:8b\", think=False)\n",
+    "\n",
+    "# two subagents, each with its own SharedConsoleHumanInputTool instance\n",
+    "# -- but the lock is a CLASS-level asyncio.Lock, so both instances\n",
+    "# share it. Dispatched concurrently, their prompts serialize instead\n",
+    "# of racing for stdin.\n",
+    "hailstone_input_tool = SharedConsoleHumanInputTool(agent_name=\"hailstone\")\n",
+    "hailstone_spec = SubAgentSpec(\n",
+    "    name=\"hailstone\",\n",
+    "    description=(\n",
+    "        \"Asks the human operator for a starting number, then computes \"\n",
+    "        \"its Hailstone sequence.\"\n",
+    "    ),\n",
+    "    builder=LLMAgentBuilder(\n",
+    "        llm=slm,\n",
+    "        tools=[next_number_tool, hailstone_input_tool],\n",
+    "    ),\n",
+    "    max_steps=20,\n",
+    ")\n",
+    "\n",
+    "greeter_input_tool = SharedConsoleHumanInputTool(agent_name=\"greeter\")\n",
+    "greeter_spec = SubAgentSpec(\n",
+    "    name=\"greeter\",\n",
+    "    description=\"Asks the human operator for their name, then greets them.\",\n",
+    "    builder=LLMAgentBuilder(llm=slm, tools=[greeter_input_tool]),\n",
+    "    max_steps=5,\n",
+    ")\n",
+    "\n",
+    "hitl_coordinator = await (\n",
+    "    LLMAgentBuilder()\n",
+    "    .with_llm(llm)\n",
+    "    .with_subagents([hailstone_spec, greeter_spec])\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "task_hitl = Task(\n",
+    "    instruction=(\n",
+    "        \"Dispatch both the hailstone and greeter subagents in the same \"\n",
+    "        \"response so they run concurrently. hailstone should ask the \"\n",
+    "        \"human for a starting number, then compute its Hailstone \"\n",
+    "        \"sequence. greeter should ask the human for their name, then \"\n",
+    "        \"return a friendly greeting. Report both results.\"\n",
+    "    ),\n",
+    ")\n",
+    "# with_approval=True -- the same end-of-loop gate from Chapter 8, now\n",
+    "# reviewing a coordinator's result instead of a single agent's. Watch\n",
+    "# the console: the two prompts complete one at a time, never\n",
+    "# interleaved, thanks to SharedConsoleHumanInputTool's shared lock.\n",
+    "result_hitl = await hitl_coordinator.run(task_hitl, with_approval=True)\n",
+    "print(result_hitl.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1b2c3d4-0009-0000-0000-000000000011",
    "metadata": {},
-   "source": "### Example 3: Router/Triage"
+   "source": [
+    "### Example 4: Router/Triage"
+   ]
   },
   {
    "cell_type": "code",
@@ -2119,10 +2419,9 @@
     "from llm_agents_from_scratch.data_structures import Task\n",
     "from llm_agents_from_scratch.subagents.recipes import explore_subagent, general_subagent\n",
     "\n",
-    "# explore only does lookups, so a small local model is plenty; general\n",
-    "# does open-ended computation, so it shares the coordinator's own model\n",
-    "slm = OllamaLLM(model=\"qwen3:8b\", think=False)\n",
-    "\n",
+    "# explore only does lookups, so the small model from Example 3 is\n",
+    "# plenty; general does open-ended computation, so it shares the\n",
+    "# coordinator's own model\n",
     "coordinator = await (\n",
     "    LLMAgentBuilder()\n",
     "    .with_llm(llm)  # the bigger model from Example 1\n",
@@ -2148,7 +2447,7 @@
    "id": "a1b2c3d4-0009-0000-0000-000000000014",
    "metadata": {},
    "source": [
-    "### Example 4: Parallel Fan-Out"
+    "### Example 5: Parallel Fan-Out"
    ]
   },
   {
@@ -2260,298 +2559,6 @@
     "# raised. Cloud models parallelize for free.\n",
     "result_fanout = await coordinator.run(task_fanout)\n",
     "print(result_fanout.content)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4-0009-0000-0000-000000000016",
-   "metadata": {},
-   "source": [
-    "### Example 5: HITL on the Coordinator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "a1b2c3d4-0009-0000-0000-000000000017",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n",
-      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for their name, then return a friendly greeting.\n",
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for their name, then return a friendly greeting.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭──────────────────────────────────────────── Human Input — hailstone ────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide a starting number for the Hailstone sequence:                                                    <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m Human Input — hailstone \u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m Please provide a starting number for the Hailstone sequence:                                                    \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt; <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[1/2/3/4/5/6/7/8/9/10]</span>: </pre>\n"
-      ],
-      "text/plain": [
-       "> \u001b[1;35m[1/2/3/4/5/6/7/8/9/10]\u001b[0m: "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " 4\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭───────────────────────────────────────────── Human Input — greeter ─────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m Human Input — greeter \u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m What is your name?                                                                                              \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">&gt;: </pre>\n"
-      ],
-      "text/plain": [
-       ">: "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The starting number is 4. Now, I will compute its Hailstone sequence by repeatedly applying the next_number tool until the value 1 is r...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " Andrei\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Andrei\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 2. I will continue applying the next_number tool to 2 until the sequence reaches 1. Let's proceed.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complete. ...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complet...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is c...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
-      "\n",
-      "**Hailstone Sub-agent Result:**\n",
-      "- Starting number:...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents have completed their tasks successfully. Let me report the results:                             <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Hailstone Sub-agent Result:**                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Starting number: 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Hailstone sequence: 4, 2, 1                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - The sequence reached 1 and completed successfully.                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Greeter Sub-agent Result:**                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Name obtained: Andrei                                                                                         <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> friendly greeting.                                                                                              <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Both sub-agents have completed their tasks successfully. Let me report the results:                             \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Hailstone Sub-agent Result:**                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Starting number: 4                                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Hailstone sequence: 4, 2, 1                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - The sequence reached 1 and completed successfully.                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Greeter Sub-agent Result:**                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Name obtained: Andrei                                                                                         \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m friendly greeting.                                                                                              \u001b[36m│\u001b[0m\n",
-       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Approve this result? <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">[y/n]</span>: </pre>\n"
-      ],
-      "text/plain": [
-       "Approve this result? \u001b[1;35m[y/n]\u001b[0m: "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " y\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
-      "\n",
-      "**Hailstone Sub-agent Result:**\n",
-      "- Starting numb...[TRUNCATED]\n",
-      "Both sub-agents have completed their tasks successfully. Let me report the results:\n",
-      "\n",
-      "**Hailstone Sub-agent Result:**\n",
-      "- Starting number: 4\n",
-      "- Hailstone sequence: 4, 2, 1\n",
-      "- The sequence reached 1 and completed successfully.\n",
-      "\n",
-      "**Greeter Sub-agent Result:**\n",
-      "- Name obtained: Andrei\n",
-      "- Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"\n",
-      "\n",
-      "Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a friendly greeting.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from llm_agents_from_scratch.tools.default import SharedConsoleHumanInputTool\n",
-    "\n",
-    "# two subagents, each with its own SharedConsoleHumanInputTool instance\n",
-    "# -- but the lock is a CLASS-level asyncio.Lock, so both instances\n",
-    "# share it. Dispatched concurrently, their prompts serialize instead\n",
-    "# of racing for stdin.\n",
-    "hailstone_input_tool = SharedConsoleHumanInputTool(agent_name=\"hailstone\")\n",
-    "hailstone_spec = SubAgentSpec(\n",
-    "    name=\"hailstone\",\n",
-    "    description=(\n",
-    "        \"Asks the human operator for a starting number, then computes \"\n",
-    "        \"its Hailstone sequence.\"\n",
-    "    ),\n",
-    "    builder=LLMAgentBuilder(\n",
-    "        llm=slm,\n",
-    "        tools=[next_number_tool, hailstone_input_tool],\n",
-    "    ),\n",
-    "    max_steps=20,\n",
-    ")\n",
-    "\n",
-    "greeter_input_tool = SharedConsoleHumanInputTool(agent_name=\"greeter\")\n",
-    "greeter_spec = SubAgentSpec(\n",
-    "    name=\"greeter\",\n",
-    "    description=\"Asks the human operator for their name, then greets them.\",\n",
-    "    builder=LLMAgentBuilder(llm=slm, tools=[greeter_input_tool]),\n",
-    "    max_steps=5,\n",
-    ")\n",
-    "\n",
-    "hitl_coordinator = await (\n",
-    "    LLMAgentBuilder()\n",
-    "    .with_llm(llm)\n",
-    "    .with_subagents([hailstone_spec, greeter_spec])\n",
-    "    .build()\n",
-    ")\n",
-    "\n",
-    "task_hitl = Task(\n",
-    "    instruction=(\n",
-    "        \"Dispatch both the hailstone and greeter subagents in the same \"\n",
-    "        \"response so they run concurrently. hailstone should ask the \"\n",
-    "        \"human for a starting number, then compute its Hailstone \"\n",
-    "        \"sequence. greeter should ask the human for their name, then \"\n",
-    "        \"return a friendly greeting. Report both results.\"\n",
-    "    ),\n",
-    ")\n",
-    "# with_approval=True -- the same end-of-loop gate from Chapter 8, now\n",
-    "# reviewing a coordinator's result instead of a single agent's. Watch\n",
-    "# the console: the two prompts complete one at a time, never\n",
-    "# interleaved, thanks to SharedConsoleHumanInputTool's shared lock.\n",
-    "result_hitl = await hitl_coordinator.run(task_hitl, with_approval=True)\n",
-    "print(result_hitl.content)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Reorders `examples/ch09.ipynb` per #887:

| before | after |
|---|---|
| Example 3: Router/Triage | Example 4 |
| Example 4: Parallel Fan-Out | Example 5 |
| Example 5: HITL on the Coordinator | **Example 3** |

Examples 1 and 2 are unchanged. Cells are physically moved, not just renumbered, so execution order matches the new numbering.

## The dependency this required resolving

The ticket flagged this and it was real: the old Example 3 cell defined both `coordinator` **and** `slm`, and the HITL example uses `slm` for its `hailstone_spec`/`greeter_spec` builders. Moving HITL ahead of it would leave `slm` undefined on a clean top-to-bottom run.

Fix: the `slm` construction moves into the new Example 3 (where it's first needed), and Router/Triage now uses it from there — its comment updated accordingly, since the "small model for explore, big model for general" rationale still applies but no longer introduces the variable.

## Verification

- **AST check for forward references.** Walked every code cell, collecting `Name` loads vs. stores (plus imports, defs, comprehension targets), accumulating definitions cell by cell in order. Result: no name is loaded before it's stored. This is what actually proves the reorder is safe, rather than eyeballing it.
- `make lint` passes.

## Outputs and execution counts — deliberately untouched

Neither source edit changes what its cell prints (both are setup lines producing no output), so the existing outputs remain accurate. The HITL cell's output is a genuine recorded interactive session (operator typing a number, a name, and approving the result) that can't be reproduced headlessly, so regenerating it isn't an option without a manual run.

Execution counts are left alone for the same reason. They were already non-monotonic on `main` (`1, 2, 4, 5, 5, 6` — two cells sharing `5`, a gap at `3`), and now read `1, 2, 4, 6, 5, 5`. Renumbering them would fabricate a clean-run provenance that didn't happen. Happy to do a full interactive re-run instead if you'd prefer coherent counts.

## Drive-by

Normalizes the two markdown cells whose `source` was a bare string rather than a list of lines — same inconsistency Copilot flagged on ch10 in #886, pre-existing here from earlier edits. One was already being rewritten by this change; the other is a one-line fix in the same file.

Closes #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)