### PR TITLE
feat(ch09): add Example 6 — Sequence

### DIFF
--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -5,7 +5,7 @@
    "id": "a1b2c3d4-0009-0000-0000-000000000001",
    "metadata": {},
    "source": [
-    "# Chapter 9 — Assembling MAS with Subagents"
+    "# Chapter 9 \u2014 Assembling MAS with Subagents"
    ]
   },
   {
@@ -55,7 +55,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Using Ollama Cloud\n"
+      "\u2713 Using Ollama Cloud\n"
      ]
     }
    ],
@@ -74,7 +74,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"✓ Ollama already running at {host}\")\n",
+    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -103,14 +103,14 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"✓ Ollama up and running at {host}\")\n",
+    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
     "\n",
     "\n",
     "use_cloud = \"OLLAMA_API_KEY\" in os.environ\n",
-    "ensure_ollama() if not use_cloud else print(\"✓ Using Ollama Cloud\")"
+    "ensure_ollama() if not use_cloud else print(\"\u2713 Using Ollama Cloud\")"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "source": [
     "### Example 1: Manual Dispatch with UseSubAgentTool\n",
     "\n",
-    "Console logging is enabled below so you can watch the dispatched sub-agent run — its log lines are tagged `[hailstone]`, distinguishing them from the coordinator's own logs in later examples."
+    "Console logging is enabled below so you can watch the dispatched sub-agent run \u2014 its log lines are tagged `[hailstone]`, distinguishing them from the coordinator's own logs in later examples."
    ]
   },
   {
@@ -141,64 +141,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"a5734e2c-a51c-48ea-bea0-47825f4a3cc2\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"5ecae314-a295-417e-96b7-17642a49be41\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"f5f729cc-2326-423d-b755-95722484298a\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"1fdc5c6d-66c8-4559-bb83-23f730f40e83\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full sequen...[TRUNCATED]\n",
       "[hailstone] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full seq...[TRUNCATED]\n",
       "The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full sequence:\n",
       "- Start: 5\n",
-      "- Step 1: 5 → 16 (odd, so 3*5+1=16)\n",
-      "- Step 2: 16 → 8 (even, so 16/2=8)\n",
-      "- Step 3: 8 → 4 (even, so 8/2=4)\n",
-      "- Step 4: 4 → 2 (even, so 4/2=2)\n",
-      "- Step 5: 2 → 1 (even, so 2/2=1)\n",
+      "- Step 1: 5 \u2192 16 (odd, so 3*5+1=16)\n",
+      "- Step 2: 16 \u2192 8 (even, so 16/2=8)\n",
+      "- Step 3: 8 \u2192 4 (even, so 8/2=4)\n",
+      "- Step 4: 4 \u2192 2 (even, so 4/2=2)\n",
+      "- Step 5: 2 \u2192 1 (even, so 2/2=1)\n",
       "\n",
-      "The full Hailstone sequence for 5 is: 5 → 16 → 8 → 4 → 2 → 1\n",
+      "The full Hailstone sequence for 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
       "\n",
       "It took **5 steps** to reach 1 from the starting number 5.\n"
      ]
@@ -277,7 +277,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -291,7 +291,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -305,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -319,7 +319,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -333,7 +333,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -347,7 +347,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -375,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -403,7 +403,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -431,7 +431,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -459,7 +459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -487,7 +487,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -515,7 +515,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: \n"
      ]
     },
     {
@@ -543,7 +543,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -571,7 +571,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -599,7 +599,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n"
      ]
     },
     {
@@ -627,7 +627,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
@@ -659,7 +659,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -687,7 +687,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -715,7 +715,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -743,7 +743,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -771,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n"
      ]
     },
     {
@@ -799,7 +799,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 5 is 16. I will now continue the process to generate the full Hailstone sequence for the number 5...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 5 is 16. I will now continue the process to generate the full Hailstone sequence for the number 5...[TRUNCATED]\n"
      ]
     },
     {
@@ -827,7 +827,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -855,7 +855,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -883,7 +883,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -911,7 +911,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -939,7 +939,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -967,7 +967,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -995,7 +995,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n"
      ]
     },
     {
@@ -1023,7 +1023,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 16 is 8. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 16 is 8. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1051,7 +1051,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 8.\n"
      ]
     },
     {
@@ -1079,7 +1079,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 8.\n"
      ]
     },
     {
@@ -1107,7 +1107,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1135,7 +1135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
      ]
     },
     {
@@ -1163,7 +1163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 8 is 4. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 8 is 4. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1191,7 +1191,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1219,7 +1219,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1247,7 +1247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"e57e3a6f-815d-4a6f-8a6d-51f35c6b5d0f\",\n",
@@ -1280,7 +1280,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1308,7 +1308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1336,7 +1336,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1364,7 +1364,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n"
      ]
     },
     {
@@ -1392,7 +1392,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 4 is 2. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 4 is 2. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1420,7 +1420,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 2.\n"
      ]
     },
     {
@@ -1448,7 +1448,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 2.\n"
      ]
     },
     {
@@ -1476,7 +1476,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1504,7 +1504,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n"
      ]
     },
     {
@@ -1532,9 +1532,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 → 16 → 8 → 4...[TRUNCATED]\n"
+      "5 \u2192 16 \u2192 8 \u2192 4...[TRUNCATED]\n"
      ]
     },
     {
@@ -1590,9 +1590,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 → 16 → 8 ...[TRUNCATED]\n"
+      "5 \u2192 16 \u2192 8 ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1606,9 +1606,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 → 1...[TRUNCATED]\n"
+      "5 \u2192 1...[TRUNCATED]\n"
      ]
     },
     {
@@ -1622,9 +1622,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  ...[TRUNCATED]\n"
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1652,9 +1652,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → ...[TRUNCATED]\n"
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1663,7 +1663,7 @@
      "text": [
       "The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
+      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  \n",
       "**Starting number:** 5  \n",
       "**Total steps taken:** 5  \n",
       "**Maximum value reached:** 16  \n",
@@ -1714,29 +1714,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n",
-      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for their name, then return a friendly greeting.\n",
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for their name, then return a friendly greeting.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n",
+      "[greeter] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask the human for their name, then return a friendly greeting.\n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human for their name, then return a friendly greeting.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭──────────────────────────────────────────── Human Input — hailstone ────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide a starting number for the Hailstone sequence:                                                    <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2014 hailstone \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> Please provide a starting number for the Hailstone sequence:                                                    <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m Human Input — hailstone \u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m Please provide a starting number for the Hailstone sequence:                                                    \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u2014 hailstone \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
+       "\u001b[33m\u2502\u001b[0m Please provide a starting number for the Hailstone sequence:                                                    \u001b[33m\u2502\u001b[0m\n",
+       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -1758,7 +1758,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {
@@ -1772,21 +1772,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭───────────────────────────────────────────── Human Input — greeter ─────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2014 greeter \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m╭─\u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m Human Input — greeter \u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
-       "\u001b[33m│\u001b[0m What is your name?                                                                                              \u001b[33m│\u001b[0m\n",
-       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u2014 greeter \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
+       "\u001b[33m\u2502\u001b[0m What is your name?                                                                                              \u001b[33m\u2502\u001b[0m\n",
+       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -1808,9 +1808,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The starting number is 4. Now, I will compute its Hailstone sequence by repeatedly applying the next_number tool until the value 1 is r...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The starting number is 4. Now, I will compute its Hailstone sequence by repeatedly applying the next_number tool until the value 1 is r...[TRUNCATED]\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
      ]
     },
     {
@@ -1824,26 +1824,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Andrei\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n",
-      "[greeter] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Andrei\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: \n",
+      "[greeter] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the Hailstone sequence for the starting number 4 by repeatedly applying the next_number tool until the value 1 is reached.\n",
       "[greeter] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[greeter] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Hello, Andrei! Welcome. How can I assist you today?\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 2. I will continue applying the next_number tool to 2 until the sequence reaches 1. Let's proceed.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complete. ...[TRUNCATED]\n",
+      "[greeter] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Hello, Andrei! Welcome. How can I assist you today?\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence is 2. I will continue applying the next_number tool to 2 until the sequence reaches 1. Let's proceed.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complete. ...[TRUNCATED]\n",
       "[hailstone] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complet...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is c...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is complet...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The next number in the sequence is 1. Since we have reached the value 1, the Hailstone sequence for the starting number 4 is c...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
       "\n",
       "**Hailstone Sub-agent Result:**\n",
       "- Starting number:...[TRUNCATED]\n",
@@ -1853,41 +1853,41 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">╭───────────────────────────────────────────── Proposed Task Result ──────────────────────────────────────────────╮</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents have completed their tasks successfully. Let me report the results:                             <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Hailstone Sub-agent Result:**                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Starting number: 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Hailstone sequence: 4, 2, 1                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - The sequence reached 1 and completed successfully.                                                            <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> **Greeter Sub-agent Result:**                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Name obtained: Andrei                                                                                         <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">│</span> friendly greeting.                                                                                              <span style=\"color: #008080; text-decoration-color: #008080\">│</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Proposed Task Result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> Both sub-agents have completed their tasks successfully. Let me report the results:                             <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Hailstone Sub-agent Result:**                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - Starting number: 4                                                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - Hailstone sequence: 4, 2, 1                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - The sequence reached 1 and completed successfully.                                                            <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> **Greeter Sub-agent Result:**                                                                                   <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - Name obtained: Andrei                                                                                         <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>                                                                                                                 <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span> friendly greeting.                                                                                              <span style=\"color: #008080; text-decoration-color: #008080\">\u2502</span>\n",
+       "<span style=\"color: #008080; text-decoration-color: #008080\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[36m╭─\u001b[0m\u001b[36m────────────────────────────────────────────\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m─────────────────────────────────────────────\u001b[0m\u001b[36m─╮\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Both sub-agents have completed their tasks successfully. Let me report the results:                             \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Hailstone Sub-agent Result:**                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Starting number: 4                                                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Hailstone sequence: 4, 2, 1                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - The sequence reached 1 and completed successfully.                                                            \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m **Greeter Sub-agent Result:**                                                                                   \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Name obtained: Andrei                                                                                         \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m                                                                                                                 \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     \u001b[36m│\u001b[0m\n",
-       "\u001b[36m│\u001b[0m friendly greeting.                                                                                              \u001b[36m│\u001b[0m\n",
-       "\u001b[36m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
+       "\u001b[36m\u256d\u2500\u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m Proposed Task Result \u001b[0m\u001b[36m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[36m\u2500\u256e\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m Both sub-agents have completed their tasks successfully. Let me report the results:                             \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Hailstone Sub-agent Result:**                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - Starting number: 4                                                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - Hailstone sequence: 4, 2, 1                                                                                   \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - The sequence reached 1 and completed successfully.                                                            \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m **Greeter Sub-agent Result:**                                                                                   \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - Name obtained: Andrei                                                                                         \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m - Greeting returned: \"Hello, Andrei! Welcome. How can I assist you today?\"                                      \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m                                                                                                                 \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m Both sub-agents ran concurrently and completed their respective tasks - the hailstone agent computed the        \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m Hailstone sequence for the number 4, and the greeter agent obtained the user's name (Andrei) and provided a     \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2502\u001b[0m friendly greeting.                                                                                              \u001b[36m\u2502\u001b[0m\n",
+       "\u001b[36m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -1916,7 +1916,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Both sub-agents have completed their tasks successfully. Let me report the results:\n",
       "\n",
       "**Hailstone Sub-agent Result:**\n",
       "- Starting numb...[TRUNCATED]\n",
@@ -2031,7 +2031,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
      ]
     },
     {
@@ -2045,7 +2045,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
      ]
     },
     {
@@ -2059,7 +2059,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
      ]
     },
     {
@@ -2073,7 +2073,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
      ]
     },
     {
@@ -2087,7 +2087,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
      ]
     },
     {
@@ -2101,7 +2101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences....[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences....[TRUNCATED]\n"
      ]
     },
     {
@@ -2115,7 +2115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
      ]
     },
     {
@@ -2129,7 +2129,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json ...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json ...[TRUNCATED]\n"
      ]
     },
     {
@@ -2143,7 +2143,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -2171,7 +2171,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
      ]
     },
     {
@@ -2199,7 +2199,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
      ]
     },
     {
@@ -2227,7 +2227,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n"
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n"
      ]
     },
     {
@@ -2255,7 +2255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
       "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
       "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n"
      ]
@@ -2285,7 +2285,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
      ]
     },
     {
@@ -2341,7 +2341,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
      ]
     },
     {
@@ -2355,7 +2355,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
      ]
     },
     {
@@ -2369,7 +2369,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assis...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assis...[TRUNCATED]\n"
      ]
     },
     {
@@ -2397,7 +2397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further as...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further as...[TRUNCATED]\n"
      ]
     },
     {
@@ -2431,7 +2431,7 @@
     "\n",
     "print(coordinator.subagents_registry)\n",
     "\n",
-    "# a lookup task — should route to explore (reads hailstone_known_sequences.json)\n",
+    "# a lookup task \u2014 should route to explore (reads hailstone_known_sequences.json)\n",
     "task_lookup = Task(\n",
     "    instruction=(\n",
     "        \"Look up the Hailstone sequence for 6 in \"\n",
@@ -2460,72 +2460,72 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4, us...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4,...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the nu...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4, us...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4,...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the nu...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
       "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
       "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the number is eve...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__python_interpreter\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Sequence: [4, 2, 1]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__python_interpreter\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Sequence: [4, 2, 1]\n",
       "Number of steps: 2\n",
       "\n",
       "[general] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the number is ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the numb...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the starting number 12 is:\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps taken:** 9\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Perfect! The Python code confirms my manual calculation.\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequence:** 4...[TRUNCATED]\n",
       "[explore] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the starting number 12 is:\n",
+      "[explore] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps taken:** ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for the starting number 12 is:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps tak...[TRUNCATED]\n",
       "[general] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Perfect! The Python code confirms my manual calculation.\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequence:*...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Perfect! The Python code confirms my manual calculation.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: All three sub-agent calls completed successfully. Let me analyze the results:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: All three sub-agent calls completed successfully. Let me analyze the results:\n",
       "\n",
       "1. **Starting number 4**: Sequence [4, 2, 1], **2 steps*...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: All three sub-agent calls completed successfully. Let me analyze the results:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: All three sub-agent calls completed successfully. Let me analyze the results:\n",
       "\n",
       "1. **Starting number 4**: Sequence [4, 2, 1], **2 ste...[TRUNCATED]\n",
       "All three sub-agent calls completed successfully. Let me analyze the results:\n",
@@ -2559,6 +2559,2225 @@
     "# raised. Cloud models parallelize for free.\n",
     "result_fanout = await coordinator.run(task_fanout)\n",
     "print(result_fanout.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0009-0000-0000-000000000018",
+   "metadata": {},
+   "source": [
+    "### Example 6: Sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a1b2c3d4-0009-0000-0000-000000000019",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the st...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Read hailstone_known_sequences.json and report its contents.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Read hailstone_known_sequences.json and report its contents.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
+      "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
+      "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting nu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[explore]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two st...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"cc562948-d3af-4bd8-b6b9-3b9671d62c62\",\n",
+      "    \"tool_name\": \"from_scratch__use_subag...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complet...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach 1.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      "# Stop At One\n",
+      "\n",
+      "Compute a full sequence from a starting number down to 1\n",
+      "using the `next_num...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"ac223eb9-b179-4710-b9c2-67b02030c843\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 12\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"4cc5e987-243a-4bda-be73-ba760caefc51\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"eee48e40-2b4e-43e5-9a22-99b51ae75830\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"f6fc88cb-9070-4df9-9c3c-df6f639627f8\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 10\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"322777c1-0f79-4d0d-af3c-c4a9ed20a561\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"cfc726dc-1ba1-4c58-b56d-42c636039f49\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"0e72a2f0-b4ad-4a9f-b944-515043509be7\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"12393215-b46c-40cf-8276-f5ad63dcfce0\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"48e95194-6647-4015-84b3-2147de5a8704\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "{\n",
+      "    \"id_\": \"8d097dbb-619e-4538-8970-b55b5a76fb62\",\n",
+      "    \"tool_name\": \"next_number\",\n",
+      "    \"argu...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for sta...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[hailstone]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequenc...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      "\n",
+      "**From hailstone_known_sequences.json:**\n",
+      "- Sta...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.TaskHandler) :      No new step required.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      "\n",
+      "**From hailstone_known_sequences.json:**\n",
+      "- ...[TRUNCATED]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      "\n",
+      "**From hailstone_known_sequences.json:**\n",
+      "- Starting number 6: 8 steps\n",
+      "- Starting number 12: 9 steps\n",
+      "\n",
+      "The starting number with the most steps is **12** with **9 steps**.\n",
+      "\n",
+      "**Double that number:** 12 \u00d7 2 = **24**\n",
+      "\n",
+      "**Hailstone sequence for 24:**\n",
+      "- Sequence: 24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
+      "- Steps: **10 steps**\n",
+      "\n",
+      "**Comparison:**\n",
+      "- Recorded entry for 12: 9 steps\n",
+      "- Computed sequence for 24: 10 steps\n",
+      "\n",
+      "**Answer:** Yes, the Hailstone sequence for 24 took **more steps** (10 steps) than the recorded entry for 12 (9 steps). It took 1 additional step."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A chain assembled entirely out of specs we already have. `explore`\n",
+    "# (Example 4) is given ReadFileTool and no next_number, so it can read\n",
+    "# the file but has no way to compute a sequence; `spec` (Example 1's\n",
+    "# hailstone) is given next_number_tool and no ReadFileTool, so it can\n",
+    "# compute but has no way to read the file. Neither can answer alone.\n",
+    "#\n",
+    "# The Task instruction below is of course written up front. What cannot\n",
+    "# be written up front is the *dispatch* the coordinator sends to\n",
+    "# hailstone: the starting number inside it does not exist until explore\n",
+    "# has answered and the coordinator has done arithmetic on that answer.\n",
+    "# That is what makes this a sequence rather than the fan-out above,\n",
+    "# where all three dispatches were fully determined before any of them\n",
+    "# ran.\n",
+    "#\n",
+    "# Note that `explore` gets the coordinator's own model here, not the\n",
+    "# small one it was given in Example 4. The difference is what the lookup\n",
+    "# feeds. There, a garbled read just produces a bad answer the reader can\n",
+    "# see. Here the value read out of the file gets doubled and written into\n",
+    "# a second dispatch, so an unreliable lookup silently corrupts every\n",
+    "# step downstream of it. In a chain, the first link has to be trustworthy.\n",
+    "sequence_coordinator = await (\n",
+    "    LLMAgentBuilder()\n",
+    "    .with_llm(llm)\n",
+    "    .with_subagents([spec, explore_subagent(llm)])\n",
+    "    .build()\n",
+    ")\n",
+    "\n",
+    "# `explore` is asked only to read and report, never to compare. Picking\n",
+    "# the largest step count and doubling it are both left to the\n",
+    "# coordinator, matching what explore_subagent() is built for: \"lookups\n",
+    "# and fact-finding, not multi-step work\".\n",
+    "task_sequence = Task(\n",
+    "    instruction=(\n",
+    "        \"Ask explore to read hailstone_known_sequences.json and report \"\n",
+    "        \"its contents. Compare the recorded step counts yourself and \"\n",
+    "        \"take the starting number with the most steps. Then ask \"\n",
+    "        \"hailstone to compute the full Hailstone sequence for double \"\n",
+    "        \"that number. Report the sequence and whether it took more \"\n",
+    "        \"steps than the recorded entry.\"\n",
+    "    ),\n",
+    ")\n",
+    "sequence_handler = sequence_coordinator.run(task_sequence, max_steps=10)\n",
+    "result_sequence = await sequence_handler\n",
+    "print(result_sequence.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0009-0000-0000-000000000020",
+   "metadata": {},
+   "source": [
+    "`sequence_handler.rollout` is what shows this really was a chain. `explore` reports what the file contains, then the coordinator picks the entry with the most steps, doubles it, and writes the result into `hailstone`'s dispatch instruction. That second dispatch could not have been issued until the first one answered, and the number in it appears nowhere in the original task. The coordinator does not just relay a value here, it transforms one.\n",
+    "\n",
+    "The doubling also gives us a free correctness check. Any even number `2n` steps straight down to `n`, so a doubled starting number always takes exactly one more step than the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1b2c3d4-0009-0000-0000-000000000021",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Task Step Start ===\n",
+      "\n",
+      "\ud83d\udcac assistant: My current instruction is 'Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the starting number with the most steps. Then ask hailstone to compute the full Hailstone sequence for double that number. Report the sequence and whether it took more steps than the recorded entry.'\n",
+      "\n",
+      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"8b27f37e-f35b-4236-a34d-8dd23d6eebc8\",\n",
+      "    \"tool_name\": \"from_scratch__use_subagent\",\n",
+      "    \"arguments\": {\n",
+      "        \"name\": \"explore\",\n",
+      "        \"task\": \"Read hailstone_known_sequences.json and report its contents.\"\n",
+      "    }\n",
+      "}.\n",
+      "\n",
+      "\ud83d\udd27 tool: {\n",
+      "    \"tool_call_id\": \"8b27f37e-f35b-4236-a34d-8dd23d6eebc8\",\n",
+      "    \"content\": \"The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting numbers:\\n\\n**Contents:**\\n\\n1. **Starting number 6:**\\n   - Sequence: [6, 3, 10, 5, 16, 8, 4, 2, 1]\\n   - Steps: 8 (number of steps to reach 1)\\n\\n2. **Starting number 12:**\\n   - Sequence: [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]\\n   - Steps: 9 (number of steps to reach 1)\\n\\nThe file is in JSON format and stores pre-computed hailstone sequences. Each entry has the starting number as a key, with values containing the full sequence and the number of steps it took to reach 1.\",\n",
+      "    \"error\": false\n",
+      "}\n",
+      "\n",
+      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"cc562948-d3af-4bd8-b6b9-3b9671d62c62\",\n",
+      "    \"tool_name\": \"from_scratch__use_subagent\",\n",
+      "    \"arguments\": {\n",
+      "        \"name\": \"hailstone\",\n",
+      "        \"task\": \"Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach 1.\"\n",
+      "    }\n",
+      "}.\n",
+      "\n",
+      "=== Task Step End ===\n",
+      "\n",
+      "=== Task Step Start ===\n",
+      "\n",
+      "\ud83d\udcac assistant: My current instruction is 'Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complete sequence and the number of steps it takes to reach 1.'\n",
+      "\n",
+      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "\n",
+      "{\n",
+      "    \"id_\": \"45231c4d-14f9-4145-8da3-48b101c3f89c\",\n",
+      "    \"tool_name\": \"from_scratch__use_subagent\",\n",
+      "    \"arguments\": {\n",
+      "        \"name\": \"hailstone\",\n",
+      "        \"task\": \"Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach 1.\"\n",
+      "    }\n",
+      "}.\n",
+      "\n",
+      "\ud83d\udd27 tool: {\n",
+      "    \"tool_call_id\": \"45231c4d-14f9-4145-8da3-48b101c3f89c\",\n",
+      "    \"content\": \"The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for starting number 24:\\n\\nStarting from 24, the sequence was:\\n- 24 \u2192 12 (step 1)\\n- 12 \u2192 6 (step 2)\\n- 6 \u2192 3 (step 3)\\n- 3 \u2192 10 (step 4)\\n- 10 \u2192 5 (step 5)\\n- 5 \u2192 16 (step 6)\\n- 16 \u2192 8 (step 7)\\n- 8 \u2192 4 (step 8)\\n- 4 \u2192 2 (step 9)\\n- 2 \u2192 1 (step 10)\\n\\n**Complete Hailstone Sequence for starting number 24:**\\n24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\\n\\n**Summary:**\\n- **Starting number:** 24\\n- **Total steps taken:** 10 (number of tool calls made to reach 1)\\n- **Maximum value reached:** 24 (the starting number was the highest; though 16 appeared later, 24 > 16)\",\n",
+      "    \"error\": false\n",
+      "}\n",
+      "\n",
+      "\ud83d\udcac assistant: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      "\n",
+      "**From hailstone_known_sequences.json:**\n",
+      "- Starting number 6: 8 steps\n",
+      "- Starting number 12: 9 steps\n",
+      "\n",
+      "The starting number with the most steps is **12** with **9 steps**.\n",
+      "\n",
+      "**Double that number:** 12 \u00d7 2 = **24**\n",
+      "\n",
+      "**Hailstone sequence for 24:**\n",
+      "- Sequence: 24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
+      "- Steps: **10 steps**\n",
+      "\n",
+      "**Comparison:**\n",
+      "- Recorded entry for 12: 9 steps\n",
+      "- Computed sequence for 24: 10 steps\n",
+      "\n",
+      "**Answer:** Yes, the Hailstone sequence for 24 took **more steps** (10 steps) than the recorded entry for 12 (9 steps). It took 1 additional step.\n",
+      "\n",
+      "=== Task Step End ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sequence_handler.rollout)"
    ]
   }
  ],


### PR DESCRIPTION
Closes #888.

Adds **Example 6: Sequence** to `examples/ch09.ipynb` — a chain where one subagent's result determines the *next* dispatch's instruction.

## Shape

Built from specs the notebook already has, so the example adds no new `SubAgentSpec`:

- **`explore`** (Example 4) — `ReadFileTool`, no `next_number`: can read the file, cannot compute
- **`hailstone`** (`spec`, Example 1) — `next_number_tool`, no `ReadFileTool`: can compute, cannot read the file

The partition is a property of the tool sets, not of prose in a description, so the chain cannot collapse into a single dispatch.

## Why not Ch10's relay shape

Ch10's Example 5 is *"compute N steps, hand the last number forward, continue to 1."* Repeating that here would teach the same topology through a near-identical task. This runs the dependency the other direction, **file → computation**:

`explore` reports what `hailstone_known_sequences.json` contains → the coordinator picks the entry with the most steps (`12`, at 9) and **doubles** it → dispatches `hailstone` for `24`.

The coordinator *transforms* the value instead of relaying it, which makes the rollout evidence stronger than a passthrough: `24` appears in the dispatch and nowhere in the task instruction.

Doubling also gives a free correctness check — any even `2n` steps straight down to `n`, so a doubled start always takes exactly one more step:

```
24 → 12 → 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1   (10 steps vs the recorded 9)
```

## Why `explore` uses the coordinator's model here

Both the backing model and the instruction shape turned out to be load-bearing. Asking the small model to *enumerate and compare* entries sent it hunting: it hallucinated an `.agents/` path, replied in Russian, misread a sequence's largest element (`16`) as a step count, and burned `EXPLORE_MAX_STEPS` three times.

Measured across variants (same task, cloud coordinator):

| variant | task steps | `MaxStepsReachedError` | rollout chars | wall time |
|---|---|---|---|---|
| enumerate + compare, small model | 7 | 3 | 9794 | ~11.8 min |
| simple read, small model | 3 | 1 | 4632 | ~4.6 min |
| **simple read, coordinator's model** | **2** | **0** | **3572** | **~1.4 min** |

Example 4 still carries the "a small model is plenty for lookups" lesson. The difference is what the lookup feeds: there a garbled read yields a visibly bad answer, here it silently corrupts the number handed to the second dispatch.

## Verification

- **Cloud `qwen3.5:397b`** — 110s, 2 task steps, 0 errors. Committed outputs are from this run, matching the setup cell's recorded `✓ Using Ollama Cloud`.
- **Local `qwen3:14b`** — same correct sequence, but ~20 min with one recovered `MaxStepsReachedError`. Cloud is the comfortable path for this example.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)