### PR TITLE
test(ch09): assert SharedConsoleHumanInputTool actually holds its lock

### DIFF
--- a/tests/tools/test_default.py
+++ b/tests/tools/test_default.py
@@ -1,6 +1,8 @@
 """Unit tests for default tools."""
 
 import asyncio
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -621,3 +623,55 @@ async def test_shared_console_human_input_tool_keyboard_interrupt() -> None:
 
     assert result.error is True
     assert "declined" in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_shared_console_human_input_tool_serializes_prompts() -> None:
+    """Tests _console_lock serializes concurrent prompts to one console.
+
+    The lock is the only reason this class exists separately from
+    HumanInputTool, so assert the behaviour and not just that the
+    attribute is shared: without it both calls sit inside _prompt_human
+    at once, interleaving their panels and racing for a single stdin.
+
+    _prompt_human runs via asyncio.to_thread, so the two calls land on
+    different worker threads and the counter needs its own threading
+    lock.
+    """
+    active = 0
+    peak = 0
+    guard = threading.Lock()
+
+    def fake_prompt(
+        prompt: str,
+        choices: list[str] | None,
+        agent_name: str | None = None,
+    ) -> str:
+        nonlocal active, peak
+        with guard:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.05)  # hold the console, as a real operator would
+        with guard:
+            active -= 1
+        return f"reply-{agent_name}"
+
+    def make_tool_call() -> ToolCall:
+        return ToolCall(
+            tool_name="from_scratch__human_input",
+            arguments={"prompt": "Enter value:"},
+        )
+
+    first = SharedConsoleHumanInputTool(agent_name="first")
+    second = SharedConsoleHumanInputTool(agent_name="second")
+    with patch(
+        "llm_agents_from_scratch.tools.default.human_input._prompt_human",
+        side_effect=fake_prompt,
+    ):
+        results = await asyncio.gather(
+            first(tool_call=make_tool_call()),
+            second(tool_call=make_tool_call()),
+        )
+
+    assert peak == 1, f"two prompts overlapped (peak={peak}); lock not held"
+    assert {r.content for r in results} == {"reply-first", "reply-second"}


### PR DESCRIPTION
Adds the one unit test issue #748 listed for #747 that was never written: *"Lock serializes concurrent callers (mock `to_thread` to verify ordering)"*.

## The gap

`_console_lock` is the only reason `SharedConsoleHumanInputTool` exists separately from `HumanInputTool`, and Chapter 9's prose motivates it. Nothing tested the behaviour. The closest existing test checks object identity:

```python
assert a._console_lock is b._console_lock
```

That passes even if `__call__` never acquires the lock.

Verified the gap rather than assuming it — replacing the `async with` in `__call__` with `if True:`:

| | lock present | lock replaced with `if True:` |
|---|---|---|
| existing suite | 537 passed | **537 passed** ← the gap |
| new test | passed | **failed:** `assert 2 == 1` |

So the lock could be deleted today and CI would stay green.

## The test

Dispatches two instances through `asyncio.gather` with `_prompt_human` patched to a stub that tracks peak concurrency, then asserts the peak is 1:

```python
assert peak == 1, f"two prompts overlapped (peak={peak}); lock not held"
```

The counter takes a `threading.Lock` because `_prompt_human` runs via `asyncio.to_thread` — the two calls genuinely land on different worker threads, which is precisely why the peak reaches 2 without serialization.

Reuses the existing `reset_console_lock` autouse fixture for 3.10/3.11 loop-binding isolation. Runs in ~0.1s.

## Checks

- `make lint` clean
- `make test` — 538 passed (537 + 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)