### PR TITLE
docs(ch09): construct Example 4's coordinator directly, drop registry print

### DIFF
--- a/examples/ch09.ipynb
+++ b/examples/ch09.ipynb
@@ -5,7 +5,7 @@
    "id": "a1b2c3d4-0009-0000-0000-000000000001",
    "metadata": {},
    "source": [
-    "# Chapter 9 \u2014 Assembling MAS with Subagents"
+    "# Chapter 9 — Assembling MAS with Subagents"
    ]
   },
   {
@@ -55,7 +55,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2713 Using Ollama Cloud\n"
+      "✓ Using Ollama Cloud\n"
      ]
     }
    ],
@@ -74,7 +74,7 @@
     "            return False\n",
     "\n",
     "    if _up():\n",
-    "        return print(f\"\u2713 Ollama already running at {host}\")\n",
+    "        return print(f\"✓ Ollama already running at {host}\")\n",
     "\n",
     "    # Lightning persistent path first, then standard locations\n",
     "    ollama_path = shutil.which(\"ollama\")\n",
@@ -103,14 +103,14 @@
     "    deadline = time.time() + timeout\n",
     "    while time.time() < deadline:\n",
     "        if _up():\n",
-    "            return print(f\"\u2713 Ollama up and running at {host}\")\n",
+    "            return print(f\"✓ Ollama up and running at {host}\")\n",
     "        time.sleep(0.5)\n",
     "\n",
     "    raise RuntimeError(f\"Ollama did not start within {timeout}s\")\n",
     "\n",
     "\n",
     "use_cloud = \"OLLAMA_API_KEY\" in os.environ\n",
-    "ensure_ollama() if not use_cloud else print(\"\u2713 Using Ollama Cloud\")"
+    "ensure_ollama() if not use_cloud else print(\"✓ Using Ollama Cloud\")"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "source": [
     "### Example 1: Manual Dispatch with UseSubAgentTool\n",
     "\n",
-    "Console logging is enabled below so you can watch the dispatched sub-agent run \u2014 its log lines are tagged `[hailstone]`, distinguishing them from the coordinator's own logs in later examples."
+    "Console logging is enabled below so you can watch the dispatched sub-agent run — its log lines are tagged `[hailstone]`, distinguishing them from the coordinator's own logs in later examples."
    ]
   },
   {
@@ -141,64 +141,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence for 5 step by step using next_number, until you reach 1. Report how many steps it took.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"a5734e2c-a51c-48ea-bea0-47825f4a3cc2\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id 'a5734e2c-a51c-48ea-bea0-47825f4a3cc2' using the next_number tool with argument x=16.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"5ecae314-a295-417e-96b7-17642a49be41\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '5ecae314-a295-417e-96b7-17642a49be41' using the next_number tool with argument x=8.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"f5f729cc-2326-423d-b755-95722484298a\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id 'f5f729cc-2326-423d-b755-95722484298a' using the next_number tool with argument x=4.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"1fdc5c6d-66c8-4559-bb83-23f730f40e83\",\n",
       "    \"tool_name\": \"next_number\",\n",
       "    \"argu...[TRUNCATED]\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n",
-      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call with id '1fdc5c6d-66c8-4559-bb83-23f730f40e83' using the next_number tool with argument x=2.\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n",
+      "[hailstone] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full sequen...[TRUNCATED]\n",
       "[hailstone] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
+      "[hailstone] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full seq...[TRUNCATED]\n",
       "The next number after 2 is 1. I've now reached 1, which means the Hailstone sequence is complete.\n",
       "\n",
       "Let me trace through the full sequence:\n",
       "- Start: 5\n",
-      "- Step 1: 5 \u2192 16 (odd, so 3*5+1=16)\n",
-      "- Step 2: 16 \u2192 8 (even, so 16/2=8)\n",
-      "- Step 3: 8 \u2192 4 (even, so 8/2=4)\n",
-      "- Step 4: 4 \u2192 2 (even, so 4/2=2)\n",
-      "- Step 5: 2 \u2192 1 (even, so 2/2=1)\n",
+      "- Step 1: 5 → 16 (odd, so 3*5+1=16)\n",
+      "- Step 2: 16 → 8 (even, so 16/2=8)\n",
+      "- Step 3: 8 → 4 (even, so 8/2=4)\n",
+      "- Step 4: 4 → 2 (even, so 4/2=2)\n",
+      "- Step 5: 2 → 1 (even, so 2/2=1)\n",
       "\n",
-      "The full Hailstone sequence for 5 is: 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
+      "The full Hailstone sequence for 5 is: 5 → 16 → 8 → 4 → 2 → 1\n",
       "\n",
       "It took **5 steps** to reach 1 from the starting number 5.\n"
      ]
@@ -277,7 +277,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -291,7 +291,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -305,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -319,7 +319,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -333,7 +333,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch the task to the hailstone subagent with the instruction to determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -347,7 +347,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -375,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -403,7 +403,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Determine the Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Determine the Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -431,7 +431,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -459,7 +459,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -487,7 +487,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -515,7 +515,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: \n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: \n"
      ]
     },
     {
@@ -543,7 +543,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -571,7 +571,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the stop-at-one skill with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the stop-at-one skill with the starting number 5.\n"
      ]
     },
     {
@@ -599,7 +599,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n"
      ]
     },
     {
@@ -627,7 +627,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
@@ -659,7 +659,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -687,7 +687,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -715,7 +715,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the starting number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the starting number 5.\n"
      ]
     },
     {
@@ -743,7 +743,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -771,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n"
      ]
     },
     {
@@ -799,7 +799,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 5 is 16. I will now continue the process to generate the full Hailstone sequence for the number 5...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 5 is 16. I will now continue the process to generate the full Hailstone sequence for the number 5...[TRUNCATED]\n"
      ]
     },
     {
@@ -827,7 +827,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -855,7 +855,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Continue generating the Hailstone sequence by calling the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -883,7 +883,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -911,7 +911,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -939,7 +939,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: I need to call the next_number tool with the current number 16.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the next_number tool with the current number 16.\n"
      ]
     },
     {
@@ -967,7 +967,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -995,7 +995,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n"
      ]
     },
     {
@@ -1023,7 +1023,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 16 is 8. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 16 is 8. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1051,7 +1051,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 8.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 8.\n"
      ]
     },
     {
@@ -1079,7 +1079,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 8.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 8.\n"
      ]
     },
     {
@@ -1107,7 +1107,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1135,7 +1135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
      ]
     },
     {
@@ -1163,7 +1163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 8 is 4. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 8 is 4. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1191,7 +1191,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1219,7 +1219,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1247,7 +1247,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool call(s):\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"e57e3a6f-815d-4a6f-8a6d-51f35c6b5d0f\",\n",
@@ -1280,7 +1280,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1308,7 +1308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 4.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 4.\n"
      ]
     },
     {
@@ -1336,7 +1336,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1364,7 +1364,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n"
      ]
     },
     {
@@ -1392,7 +1392,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 4 is 2. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 4 is 2. I will continue the process to generate the full Hailstone sequence for the number 5.\n"
      ]
     },
     {
@@ -1420,7 +1420,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the next_number tool with the current number 2.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Call the next_number tool with the current number 2.\n"
      ]
     },
     {
@@ -1448,7 +1448,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the next_number tool with the current number 2.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Call the next_number tool with the current number 2.\n"
      ]
     },
     {
@@ -1476,7 +1476,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -1504,7 +1504,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n"
      ]
     },
     {
@@ -1532,9 +1532,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 \u2192 16 \u2192 8 \u2192 4...[TRUNCATED]\n"
+      "5 → 16 → 8 → 4...[TRUNCATED]\n"
      ]
     },
     {
@@ -1590,9 +1590,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 \u2192 16 \u2192 8 ...[TRUNCATED]\n"
+      "5 → 16 → 8 ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1606,9 +1606,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The next number in the sequence after 2 is 1. The Hailstone sequence for the number 5 is now complete. The sequence is:\n",
       "\n",
-      "5 \u2192 1...[TRUNCATED]\n"
+      "5 → 1...[TRUNCATED]\n"
      ]
     },
     {
@@ -1622,9 +1622,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  ...[TRUNCATED]\n"
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1652,9 +1652,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 ...[TRUNCATED]\n"
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → ...[TRUNCATED]\n"
      ]
     },
     {
@@ -1663,7 +1663,7 @@
      "text": [
       "The Hailstone sequence for the number 5 has been successfully determined. Here is the sequence:\n",
       "\n",
-      "**Sequence:** 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1  \n",
+      "**Sequence:** 5 → 16 → 8 → 4 → 2 → 1  \n",
       "**Starting number:** 5  \n",
       "**Total steps taken:** 5  \n",
       "**Maximum value reached:** 16  \n",
@@ -1721,7 +1721,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human for a...[TRUNCATED]\n"
      ]
     },
     {
@@ -1735,7 +1735,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch both the hailstone and greeter subagents in the same response so they run concurrently. hailstone should ask the human fo...[TRUNCATED]\n"
      ]
     },
     {
@@ -1749,7 +1749,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -1763,7 +1763,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -1791,7 +1791,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for a starting number, then compute its Hailstone sequence.\n"
      ]
     },
     {
@@ -1819,7 +1819,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for a starting number, then compute its Hailstone sequence.\n"
      ]
     },
     {
@@ -1847,7 +1847,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask the human for their name, then return a friendly greeting.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask the human for their name, then return a friendly greeting.\n"
      ]
     },
     {
@@ -1875,7 +1875,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask the human for their name, then return a friendly greeting.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask the human for their name, then return a friendly greeting.\n"
      ]
     },
     {
@@ -1903,7 +1903,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -1931,21 +1931,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2014 greeter \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭───────────────────────────────────────────── Human Input — greeter ─────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> What is your name?                                                                                              <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u2014 greeter \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
-       "\u001b[33m\u2502\u001b[0m What is your name?                                                                                              \u001b[33m\u2502\u001b[0m\n",
-       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
+       "\u001b[33m╭─\u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m Human Input — greeter \u001b[0m\u001b[33m────────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m What is your name?                                                                                              \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -1988,7 +1988,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Andrei\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Andrei\n"
      ]
     },
     {
@@ -2016,7 +2016,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2044,7 +2044,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2072,7 +2072,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
      ]
     },
     {
@@ -2100,7 +2100,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2156,7 +2156,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
      ]
     },
     {
@@ -2170,7 +2170,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: I now know the human's name is Andrei. I will return a friendly greeting using that information.\n"
      ]
     },
     {
@@ -2198,7 +2198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2226,7 +2226,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2254,7 +2254,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2282,7 +2282,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2310,7 +2310,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2338,7 +2338,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2366,7 +2366,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2394,7 +2394,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2422,7 +2422,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2450,7 +2450,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2478,7 +2478,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2506,7 +2506,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2534,7 +2534,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2562,7 +2562,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2590,7 +2590,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2618,7 +2618,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2646,7 +2646,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2674,7 +2674,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2702,7 +2702,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2730,7 +2730,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -2758,7 +2758,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to call the from_scratch__human_input tool to ask the human for a starting number. Once I have that, I can use the stop-at-one s...[TRUNCATED]\n"
      ]
     },
     {
@@ -2786,7 +2786,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: I need to call the from_scratch__human_input tool to ask the human for a starting number.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: I need to call the from_scratch__human_input tool to ask the human for a starting number.\n"
      ]
     },
     {
@@ -2814,7 +2814,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: I need to call the from_scratch__human_input tool to ask the human for a starting number.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: I need to call the from_scratch__human_input tool to ask the human for a starting number.\n"
      ]
     },
     {
@@ -2842,21 +2842,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__human_input\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__human_input\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 Human Input \u2014 hailstone \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span> Please provide a starting number for the Hailstone sequence.                                                    <span style=\"color: #808000; text-decoration-color: #808000\">\u2502</span>\n",
-       "<span style=\"color: #808000; text-decoration-color: #808000\">\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">╭──────────────────────────────────────────── Human Input — hailstone ────────────────────────────────────────────╮</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">│</span> Please provide a starting number for the Hailstone sequence.                                                    <span style=\"color: #808000; text-decoration-color: #808000\">│</span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[33m\u256d\u2500\u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m Human Input \u2014 hailstone \u001b[0m\u001b[33m\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u001b[0m\u001b[33m\u2500\u256e\u001b[0m\n",
-       "\u001b[33m\u2502\u001b[0m Please provide a starting number for the Hailstone sequence.                                                    \u001b[33m\u2502\u001b[0m\n",
-       "\u001b[33m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m\n"
+       "\u001b[33m╭─\u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m Human Input — hailstone \u001b[0m\u001b[33m───────────────────────────────────────────\u001b[0m\u001b[33m─╮\u001b[0m\n",
+       "\u001b[33m│\u001b[0m Please provide a starting number for the Hailstone sequence.                                                    \u001b[33m│\u001b[0m\n",
+       "\u001b[33m╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -2899,7 +2899,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
      ]
     },
     {
@@ -2927,7 +2927,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The human provided the starting number as 4. Now I will use the `stop-at-one` skill to compute the Hailstone sequence for this number. ...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The human provided the starting number as 4. Now I will use the `stop-at-one` skill to compute the Hailstone sequence for this number. ...[TRUNCATED]\n"
      ]
     },
     {
@@ -2955,7 +2955,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -2983,7 +2983,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -3011,7 +3011,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n"
      ]
     },
     {
@@ -3039,7 +3039,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
@@ -3071,7 +3071,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The `stop-at-one` skill has been successfully activated. Now, I will use it to compute the Hailstone sequence for the starting number *...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The `stop-at-one` skill has been successfully activated. Now, I will use it to compute the Hailstone sequence for the starting number *...[TRUNCATED]\n"
      ]
     },
     {
@@ -3099,7 +3099,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -3127,7 +3127,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -3155,7 +3155,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -3183,7 +3183,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n"
      ]
     },
     {
@@ -3211,7 +3211,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The result of the first tool call is **2**. I will now append this value to the sequence and continue the computation by calling the `n...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The result of the first tool call is **2**. I will now append this value to the sequence and continue the computation by calling the `n...[TRUNCATED]\n"
      ]
     },
     {
@@ -3239,7 +3239,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: \n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: \n"
      ]
     },
     {
@@ -3267,7 +3267,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: \n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: \n"
      ]
     },
     {
@@ -3295,7 +3295,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -3323,7 +3323,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n"
      ]
     },
     {
@@ -3351,7 +3351,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is now compl...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is now compl...[TRUNCATED]\n"
      ]
     },
     {
@@ -3407,7 +3407,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is now co...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is now co...[TRUNCATED]\n"
      ]
     },
     {
@@ -3421,7 +3421,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is ...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The result of the second tool call is **1**. Since the value has reached **1**, the computation for the Hailstone sequence is ...[TRUNCATED]\n"
      ]
     },
     {
@@ -3435,7 +3435,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Both subagents have completed their tasks. Let me summarize the results:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: Both subagents have completed their tasks. Let me summarize the results:\n",
       "\n",
       "**Hailstone Subagent Results:**\n",
       "- Starting number: 4\n",
@@ -3467,7 +3467,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Both subagents have completed their tasks. Let me summarize the results:\n",
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: Both subagents have completed their tasks. Let me summarize the results:\n",
       "\n",
       "**Hailstone Subagent Results:**\n",
       "- Starting number: 4\n",
@@ -3482,7 +3482,7 @@
       "\n",
       "**Hailstone Subagent Results:**\n",
       "- Starting number: 4\n",
-      "- Hailstone sequence: 4 \u2192 2 \u2192 1\n",
+      "- Hailstone sequence: 4 → 2 → 1\n",
       "- Total steps: 2\n",
       "- Maximum value reached: 4\n",
       "\n",
@@ -3577,14 +3577,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'general': SubAgentSpec(name='general', description='General-purpose subagent for open-ended research, multi-step tasks, or work that benefits from an isolated context. Equipped with file reading and Python execution.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7073fe482780>, max_steps=20, skills_scopes=None, explicit_only_skills=None), 'explore': SubAgentSpec(name='explore', description='Read-only subagent for quickly finding and reading files. Use for lookups and fact-finding, not multi-step work.', builder=<llm_agents_from_scratch.agent.builder.LLMAgentBuilder object at 0x7073fe482b10>, max_steps=10, skills_scopes=None, explicit_only_skills=None)}"
+      "INFO"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
      ]
     },
     {
@@ -3598,7 +3598,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
      ]
     },
     {
@@ -3612,105 +3612,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json and report it.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Use the explore subagent to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences....[TRUNCATED]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json file.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Call the explore subagent with the task instruction to look up the Hailstone sequence for 6 in the hailstone_known_sequences.json ...[TRUNCATED]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -3738,7 +3640,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Find and read the file hailstone_known_sequences.json, then report the Hailstone sequence for the number 6.\n"
      ]
     },
     {
@@ -3766,7 +3668,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for 6 in hailstone_known_sequences.json\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Find and read the file hailstone_known_sequences.json, then report the Hailstone sequence for the number 6.\n"
      ]
     },
     {
@@ -3794,7 +3696,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n"
      ]
     },
     {
@@ -3822,7 +3724,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
       "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
       "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n"
      ]
@@ -3852,7 +3754,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the number 6 is: [6, 3, 10, 5, 16, 8, 4, 2, 1]. It takes 8 steps to reach the number 1.\n"
      ]
     },
     {
@@ -3908,7 +3810,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the number 6 is: [6, 3, 10, 5, 16, 8, 4, 2, 1]. It takes 8 steps to reach the number 1.\n"
      ]
     },
     {
@@ -3922,7 +3824,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1.\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for the number 6 is: [6, 3, 10, 5, 16, 8, 4, 2, 1]. It takes 8 steps to reach the number 1.\n"
      ]
     },
     {
@@ -3936,7 +3838,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assis...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
+      "\n",
+      "It takes 8 steps to reach the number 1.\n"
      ]
     },
     {
@@ -3964,14 +3868,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further as...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
+      "\n",
+      "It takes 8 steps to reach the number 1.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Hailstone sequence for 6 is `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, and it takes 8 steps to reach 1. Let me know if you need further assistance!"
+      "The Hailstone sequence for 6 is: **[6, 3, 10, 5, 16, 8, 4, 2, 1]**\n",
+      "\n",
+      "It takes 8 steps to reach the number 1."
      ]
     },
     {
@@ -3983,22 +3891,19 @@
     }
    ],
    "source": [
+    "from llm_agents_from_scratch import LLMAgent\n",
     "from llm_agents_from_scratch.data_structures import Task\n",
     "from llm_agents_from_scratch.subagents.recipes import explore_subagent, general_subagent\n",
     "\n",
     "# explore only does lookups, so the small model from Example 3 is\n",
     "# plenty; general does open-ended computation, so it shares the\n",
     "# coordinator's own model\n",
-    "coordinator = await (\n",
-    "    LLMAgentBuilder()\n",
-    "    .with_llm(llm)  # the bigger model from Example 1\n",
-    "    .with_subagents([general_subagent(llm), explore_subagent(slm)])\n",
-    "    .build()\n",
+    "coordinator = LLMAgent(\n",
+    "    llm=llm,  # the bigger model from Example 1\n",
+    "    subagents=[general_subagent(llm), explore_subagent(slm)],\n",
     ")\n",
     "\n",
-    "print(coordinator.subagents_registry)\n",
-    "\n",
-    "# a lookup task \u2014 should route to explore (reads hailstone_known_sequences.json)\n",
+    "# a lookup task — should route to explore (reads hailstone_known_sequences.json)\n",
     "task_lookup = Task(\n",
     "    instruction=(\n",
     "        \"Look up the Hailstone sequence for 6 in \"\n",
@@ -4027,72 +3932,72 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4, us...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4,...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the nu...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4, us...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Dispatch three sub-agent calls in the same response so they run concurrently: use general to compute the Hailstone sequence for 4,...[TRUNCATED]\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
+      "INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for starting number 4. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if the...[TRUNCATED]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the Hailstone sequence for starting number 8. The Hailstone sequence (also known as Collatz sequence) is generated by: if ...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.LLMAgent) :      🚀 Starting task: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the nu...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Look up the Hailstone sequence for starting number 12 in the file hailstone_known_sequences.json. Report the full sequence and the...[TRUNCATED]\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
       "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
       "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the number is eve...[TRUNCATED]\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__python_interpreter\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Sequence: [4, 2, 1]\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__python_interpreter\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Sequence: [4, 2, 1]\n",
       "Number of steps: 2\n",
       "\n",
       "[general] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the number is ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: I need to compute the Hailstone sequence starting from 8. Let me work through this step by step.\n",
       "\n",
       "The rules are:\n",
       "- If the numb...[TRUNCATED]\n",
-      "[explore] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The Hailstone sequence for the starting number 12 is:\n",
+      "[explore] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps taken:** 9\n",
-      "[general] INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Perfect! The Python code confirms my manual calculation.\n",
+      "[general] INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequence:** 4...[TRUNCATED]\n",
       "[explore] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[explore] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The Hailstone sequence for the starting number 12 is:\n",
+      "[explore] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps taken:** ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The Hailstone sequence for the starting number 12 is:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The Hailstone sequence for the starting number 12 is:\n",
       "\n",
       "**Sequence:** [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]  \n",
       "**Number of steps tak...[TRUNCATED]\n",
       "[general] INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "[general] INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Perfect! The Python code confirms my manual calculation.\n",
+      "[general] INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequence:*...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: Perfect! The Python code confirms my manual calculation.\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: Perfect! The Python code confirms my manual calculation.\n",
       "\n",
       "**Results for the Hailstone sequence starting at 4:**\n",
       "\n",
       "- **Full sequ...[TRUNCATED]\n",
-      "INFO (llm_agents_fs.TaskHandler) :      \u2705 Step Result: All three sub-agent calls completed successfully. Let me analyze the results:\n",
+      "INFO (llm_agents_fs.TaskHandler) :      ✅ Step Result: All three sub-agent calls completed successfully. Let me analyze the results:\n",
       "\n",
       "1. **Starting number 4**: Sequence [4, 2, 1], **2 steps*...[TRUNCATED]\n",
       "INFO (llm_agents_fs.TaskHandler) :      No new step required.\n",
-      "INFO (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: All three sub-agent calls completed successfully. Let me analyze the results:\n",
+      "INFO (llm_agents_fs.LLMAgent) :      🏁 Task completed: All three sub-agent calls completed successfully. Let me analyze the results:\n",
       "\n",
       "1. **Starting number 4**: Sequence [4, 2, 1], **2 ste...[TRUNCATED]\n",
       "All three sub-agent calls completed successfully. Let me analyze the results:\n",
@@ -4153,7 +4058,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the st...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the st...[TRUNCATED]\n"
      ]
     },
     {
@@ -4167,7 +4072,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the...[TRUNCATED]\n"
      ]
     },
     {
@@ -4181,7 +4086,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -4209,7 +4114,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Read hailstone_known_sequences.json and report its contents.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Read hailstone_known_sequences.json and report its contents.\n"
      ]
     },
     {
@@ -4237,7 +4142,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Read hailstone_known_sequences.json and report its contents.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Read hailstone_known_sequences.json and report its contents.\n"
      ]
     },
     {
@@ -4265,7 +4170,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__read_file\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__read_file\n"
      ]
     },
     {
@@ -4293,7 +4198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: {\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: {\n",
       "  \"6\": {\"sequence\": [6, 3, 10, 5, 16, 8, 4, 2, 1], \"steps\": 8},\n",
       "  \"12\": {\"sequence\": [12, 6, 3, 10, 5, 16, 8, 4, 2, 1], \"ste...[TRUNCATED]\n"
      ]
@@ -4323,7 +4228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting nu...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting nu...[TRUNCATED]\n"
      ]
     },
     {
@@ -4379,7 +4284,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting...[TRUNCATED]\n"
      ]
     },
     {
@@ -4393,7 +4298,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two st...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two st...[TRUNCATED]\n"
      ]
     },
     {
@@ -4407,7 +4312,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"cc562948-d3af-4bd8-b6b9-3b9671d62c62\",\n",
       "    \"tool_name\": \"from_scratch__use_subag...[TRUNCATED]\n"
@@ -4424,7 +4329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complet...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complet...[TRUNCATED]\n"
      ]
     },
     {
@@ -4438,7 +4343,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the...[TRUNCATED]\n"
      ]
     },
     {
@@ -4452,7 +4357,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_subagent\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_subagent\n"
      ]
     },
     {
@@ -4480,7 +4385,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83d\ude80 Starting task: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach 1.\n"
+      " (llm_agents_fs.LLMAgent) :      🚀 Starting task: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach 1.\n"
      ]
     },
     {
@@ -4508,7 +4413,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Compute the full Hailstone sequence for starting number 24. Report the complete sequence and the number of steps it takes to reach...[TRUNCATED]\n"
      ]
     },
     {
@@ -4536,7 +4441,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: from_scratch__use_skill\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: from_scratch__use_skill\n"
      ]
     },
     {
@@ -4564,7 +4469,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: <skill_content name=\"stop-at-one\">\n",
       "# Stop At One\n",
       "\n",
       "Compute a full sequence from a starting number down to 1\n",
@@ -4596,7 +4501,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"ac223eb9-b179-4710-b9c2-67b02030c843\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -4628,7 +4533,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
      ]
     },
     {
@@ -4656,7 +4561,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=24.\n"
      ]
     },
     {
@@ -4684,7 +4589,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -4712,7 +4617,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 12\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 12\n"
      ]
     },
     {
@@ -4740,7 +4645,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"4cc5e987-243a-4bda-be73-ba760caefc51\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -4772,7 +4677,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
      ]
     },
     {
@@ -4800,7 +4705,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=12.\n"
      ]
     },
     {
@@ -4828,7 +4733,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -4856,7 +4761,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 6\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 6\n"
      ]
     },
     {
@@ -4884,7 +4789,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"eee48e40-2b4e-43e5-9a22-99b51ae75830\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -4916,7 +4821,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
      ]
     },
     {
@@ -4944,7 +4849,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=6.\n"
      ]
     },
     {
@@ -4972,7 +4877,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5000,7 +4905,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 3\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 3\n"
      ]
     },
     {
@@ -5028,7 +4933,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"f6fc88cb-9070-4df9-9c3c-df6f639627f8\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5060,7 +4965,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
      ]
     },
     {
@@ -5088,7 +4993,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=3.\n"
      ]
     },
     {
@@ -5116,7 +5021,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5144,7 +5049,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 10\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 10\n"
      ]
     },
     {
@@ -5172,7 +5077,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"322777c1-0f79-4d0d-af3c-c4a9ed20a561\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5204,7 +5109,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
      ]
     },
     {
@@ -5232,7 +5137,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=10.\n"
      ]
     },
     {
@@ -5260,7 +5165,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5288,7 +5193,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 5\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 5\n"
      ]
     },
     {
@@ -5316,7 +5221,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"cfc726dc-1ba1-4c58-b56d-42c636039f49\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5348,7 +5253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
      ]
     },
     {
@@ -5376,7 +5281,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=5.\n"
      ]
     },
     {
@@ -5404,7 +5309,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5432,7 +5337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 16\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 16\n"
      ]
     },
     {
@@ -5460,7 +5365,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"0e72a2f0-b4ad-4a9f-b944-515043509be7\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5492,7 +5397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
      ]
     },
     {
@@ -5520,7 +5425,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=16.\n"
      ]
     },
     {
@@ -5548,7 +5453,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5576,7 +5481,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 8\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 8\n"
      ]
     },
     {
@@ -5604,7 +5509,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"12393215-b46c-40cf-8276-f5ad63dcfce0\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5636,7 +5541,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
      ]
     },
     {
@@ -5664,7 +5569,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=8.\n"
      ]
     },
     {
@@ -5692,7 +5597,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5720,7 +5625,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 4\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 4\n"
      ]
     },
     {
@@ -5748,7 +5653,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"48e95194-6647-4015-84b3-2147de5a8704\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5780,7 +5685,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
      ]
     },
     {
@@ -5808,7 +5713,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=4.\n"
      ]
     },
     {
@@ -5836,7 +5741,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -5864,7 +5769,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 2\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 2\n"
      ]
     },
     {
@@ -5892,7 +5797,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: I need to make the following tool-calls:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: I need to make the following tool-calls:\n",
       "{\n",
       "    \"id_\": \"8d097dbb-619e-4538-8970-b55b5a76fb62\",\n",
       "    \"tool_name\": \"next_number\",\n",
@@ -5924,7 +5829,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83e\udde0 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
+      " (llm_agents_fs.TaskHandler) :      🧠 New Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
      ]
     },
     {
@@ -5952,7 +5857,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2699\ufe0f Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
+      " (llm_agents_fs.TaskHandler) :      ⚙️ Processing Step: Execute the tool call to compute the next number in the Hailstone sequence for x=2.\n"
      ]
     },
     {
@@ -5980,7 +5885,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \ud83d\udee0\ufe0f Executing Tool Call: next_number\n"
+      " (llm_agents_fs.TaskHandler) :      🛠️ Executing Tool Call: next_number\n"
      ]
     },
     {
@@ -6008,7 +5913,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: 1\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: 1\n"
      ]
     },
     {
@@ -6036,7 +5941,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for sta...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for sta...[TRUNCATED]\n"
      ]
     },
     {
@@ -6092,7 +5997,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for ...[TRUNCATED]\n"
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for ...[TRUNCATED]\n"
      ]
     },
     {
@@ -6106,7 +6011,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Successful Tool Call: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequenc...[TRUNCATED]\n"
+      " (llm_agents_fs.TaskHandler) :      ✅ Successful Tool Call: The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequenc...[TRUNCATED]\n"
      ]
     },
     {
@@ -6120,7 +6025,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.TaskHandler) :      \u2705 Step Result: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      " (llm_agents_fs.TaskHandler) :      ✅ Step Result: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
       "\n",
       "**From hailstone_known_sequences.json:**\n",
       "- Sta...[TRUNCATED]\n"
@@ -6151,7 +6056,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " (llm_agents_fs.LLMAgent) :      \ud83c\udfc1 Task completed: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      " (llm_agents_fs.LLMAgent) :      🏁 Task completed: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
       "\n",
       "**From hailstone_known_sequences.json:**\n",
       "- ...[TRUNCATED]\n"
@@ -6169,10 +6074,10 @@
       "\n",
       "The starting number with the most steps is **12** with **9 steps**.\n",
       "\n",
-      "**Double that number:** 12 \u00d7 2 = **24**\n",
+      "**Double that number:** 12 × 2 = **24**\n",
       "\n",
       "**Hailstone sequence for 24:**\n",
-      "- Sequence: 24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
+      "- Sequence: 24 → 12 → 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "- Steps: **10 steps**\n",
       "\n",
       "**Comparison:**\n",
@@ -6259,9 +6164,9 @@
      "text": [
       "=== Task Step Start ===\n",
       "\n",
-      "\ud83d\udcac assistant: My current instruction is 'Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the starting number with the most steps. Then ask hailstone to compute the full Hailstone sequence for double that number. Report the sequence and whether it took more steps than the recorded entry.'\n",
+      "💬 assistant: My current instruction is 'Ask explore to read hailstone_known_sequences.json and report its contents. Compare the recorded step counts yourself and take the starting number with the most steps. Then ask hailstone to compute the full Hailstone sequence for double that number. Report the sequence and whether it took more steps than the recorded entry.'\n",
       "\n",
-      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"8b27f37e-f35b-4236-a34d-8dd23d6eebc8\",\n",
@@ -6272,13 +6177,13 @@
       "    }\n",
       "}.\n",
       "\n",
-      "\ud83d\udd27 tool: {\n",
+      "🔧 tool: {\n",
       "    \"tool_call_id\": \"8b27f37e-f35b-4236-a34d-8dd23d6eebc8\",\n",
       "    \"content\": \"The file `hailstone_known_sequences.json` contains data about hailstone sequences (also known as Collatz sequences) for two starting numbers:\\n\\n**Contents:**\\n\\n1. **Starting number 6:**\\n   - Sequence: [6, 3, 10, 5, 16, 8, 4, 2, 1]\\n   - Steps: 8 (number of steps to reach 1)\\n\\n2. **Starting number 12:**\\n   - Sequence: [12, 6, 3, 10, 5, 16, 8, 4, 2, 1]\\n   - Steps: 9 (number of steps to reach 1)\\n\\nThe file is in JSON format and stores pre-computed hailstone sequences. Each entry has the starting number as a key, with values containing the full sequence and the number of steps it took to reach 1.\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"cc562948-d3af-4bd8-b6b9-3b9671d62c62\",\n",
@@ -6293,9 +6198,9 @@
       "\n",
       "=== Task Step Start ===\n",
       "\n",
-      "\ud83d\udcac assistant: My current instruction is 'Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complete sequence and the number of steps it takes to reach 1.'\n",
+      "💬 assistant: My current instruction is 'Execute the tool call to ask the 'hailstone' subagent to compute the full Hailstone sequence for starting number 24 and report the complete sequence and the number of steps it takes to reach 1.'\n",
       "\n",
-      "\ud83d\udcac assistant: I need to make the following tool call(s):\n",
+      "💬 assistant: I need to make the following tool call(s):\n",
       "\n",
       "{\n",
       "    \"id_\": \"45231c4d-14f9-4145-8da3-48b101c3f89c\",\n",
@@ -6306,13 +6211,13 @@
       "    }\n",
       "}.\n",
       "\n",
-      "\ud83d\udd27 tool: {\n",
+      "🔧 tool: {\n",
       "    \"tool_call_id\": \"45231c4d-14f9-4145-8da3-48b101c3f89c\",\n",
-      "    \"content\": \"The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for starting number 24:\\n\\nStarting from 24, the sequence was:\\n- 24 \u2192 12 (step 1)\\n- 12 \u2192 6 (step 2)\\n- 6 \u2192 3 (step 3)\\n- 3 \u2192 10 (step 4)\\n- 10 \u2192 5 (step 5)\\n- 5 \u2192 16 (step 6)\\n- 16 \u2192 8 (step 7)\\n- 8 \u2192 4 (step 8)\\n- 4 \u2192 2 (step 9)\\n- 2 \u2192 1 (step 10)\\n\\n**Complete Hailstone Sequence for starting number 24:**\\n24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\\n\\n**Summary:**\\n- **Starting number:** 24\\n- **Total steps taken:** 10 (number of tool calls made to reach 1)\\n- **Maximum value reached:** 24 (the starting number was the highest; though 16 appeared later, 24 > 16)\",\n",
+      "    \"content\": \"The tool returned 1, which means the sequence has reached its termination point. Let me compile the complete Hailstone sequence for starting number 24:\\n\\nStarting from 24, the sequence was:\\n- 24 → 12 (step 1)\\n- 12 → 6 (step 2)\\n- 6 → 3 (step 3)\\n- 3 → 10 (step 4)\\n- 10 → 5 (step 5)\\n- 5 → 16 (step 6)\\n- 16 → 8 (step 7)\\n- 8 → 4 (step 8)\\n- 4 → 2 (step 9)\\n- 2 → 1 (step 10)\\n\\n**Complete Hailstone Sequence for starting number 24:**\\n24 → 12 → 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\\n\\n**Summary:**\\n- **Starting number:** 24\\n- **Total steps taken:** 10 (number of tool calls made to reach 1)\\n- **Maximum value reached:** 24 (the starting number was the highest; though 16 appeared later, 24 > 16)\",\n",
       "    \"error\": false\n",
       "}\n",
       "\n",
-      "\ud83d\udcac assistant: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
+      "💬 assistant: Now I have all the information needed to complete the task. Let me analyze and compare:\n",
       "\n",
       "**From hailstone_known_sequences.json:**\n",
       "- Starting number 6: 8 steps\n",
@@ -6320,10 +6225,10 @@
       "\n",
       "The starting number with the most steps is **12** with **9 steps**.\n",
       "\n",
-      "**Double that number:** 12 \u00d7 2 = **24**\n",
+      "**Double that number:** 12 × 2 = **24**\n",
       "\n",
       "**Hailstone sequence for 24:**\n",
-      "- Sequence: 24 \u2192 12 \u2192 6 \u2192 3 \u2192 10 \u2192 5 \u2192 16 \u2192 8 \u2192 4 \u2192 2 \u2192 1\n",
+      "- Sequence: 24 → 12 → 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1\n",
       "- Steps: **10 steps**\n",
       "\n",
       "**Comparison:**\n",


### PR DESCRIPTION
Follows #893's change to Example 3, applied to Example 4.

## Direct construction

```python
coordinator = LLMAgent(
    llm=llm,  # the bigger model from Example 1
    subagents=[general_subagent(llm), explore_subagent(slm)],
)
```

`LLMAgentBuilder.build()`'s only async work is discovering tools from MCP providers. This coordinator registers none, so the `await` and the fluent chain were forwarding `llm` and `subagents` to the constructor and nothing else.

`LLMAgent` is added to this cell's own imports rather than relying on Example 3's, matching how the cell already re-imports `Task` for self-containment.

## Dropped `print(coordinator.subagents_registry)`

Nothing in the notebook's prose referred to it, and the routing it hinted at is already visible in the run itself — the logger tags the dispatched subagent, so a reader sees `[explore]` directly in the output.

## Example 5 deliberately untouched

It reuses `coordinator`, but its source is unchanged and both constructions produce the same object. Re-recording it would risk replacing a good concurrent fan-out with a sequential one, since that dispatch is nondeterministic — measured on Example 3 in #893 at 2/3 vs 4/4 depending on wording.

## Verification

Re-recorded Example 4 only, pinned to `execution_count: 5` so #893's `1..8` narrative ordering survives.

Routing confirmed unchanged, which is the one thing a re-record could plausibly break:

| check | result |
|---|---|
| `use_subagent` dispatches | 1 |
| mentions of `general` | 0 |
| subagent log tags | `['explore']` |
| result | `[6, 3, 10, 5, 16, 8, 4, 2, 1]`, 8 steps |
| errors | none |

- `make lint` clean
- Cell-by-cell diff against `main`: only `0012` differs; execution counts still monotonic `1..8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)